### PR TITLE
fix: never block the server event loop on subprocesses

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -256,7 +256,7 @@ async function cmdInit() {
   // Harness state is workspace-scoped (never the harness's global last-resort
   // dir); BC_HARNESS_STATE stays an explicit override, matching the server.
   const harnessState = process.env.BC_HARNESS_STATE || path.join(STATE_DIR, 'harness');
-  installHooks(WORKSPACE, 'ws', harnessState, 'http://127.0.0.1:' + PORT + '/api/turn-end');
+  await installHooks(WORKSPACE, 'ws', harnessState, 'http://127.0.0.1:' + PORT + '/api/turn-end');
   console.log('turn-end hook installed (.claude/settings.local.json -> /api/turn-end)');
 
   // 5. shared memory scaffold (never overwrite what exists)

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -27,7 +27,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
-const { execFileSync } = require('node:child_process');
+const { execFile } = require('node:child_process');
 const t = require('./tmux.js');
 
 const HOOK_SCRIPT = path.join(__dirname, 'turnend-hook.js');
@@ -61,19 +61,19 @@ function paneTarget(session) {
   return `=${session}:`;
 }
 
-function paneCommand(session) {
-  const out = t.tryTmux('display-message', '-p', '-t', paneTarget(session), '#{pane_current_command}');
+async function paneCommand(session) {
+  const out = await t.tryTmux('display-message', '-p', '-t', paneTarget(session), '#{pane_current_command}');
   return out === null ? null : out.trim();
 }
 
-function hasSession(session) {
-  return t.tryTmux('has-session', '-t', paneTarget(session)) !== null;
+async function hasSession(session) {
+  return (await t.tryTmux('has-session', '-t', paneTarget(session))) !== null;
 }
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
 // Idempotent; preserves any existing settings/hooks. Also hides the file from
 // git (info/exclude) when cwd is a repo, so it never dirties a worktree.
-function installHooks(cwd, session, stateDir, callbackUrl) {
+async function installHooks(cwd, session, stateDir, callbackUrl) {
   const dir = path.join(cwd, '.claude');
   const file = path.join(dir, 'settings.local.json');
   fs.mkdirSync(dir, { recursive: true });
@@ -99,8 +99,10 @@ function installHooks(cwd, session, stateDir, callbackUrl) {
   }
   fs.writeFileSync(file, JSON.stringify(settings, null, 2) + '\n');
   try {
-    const gitDir = execFileSync('git', ['-C', cwd, 'rev-parse', '--git-path', 'info/exclude'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const gitDir = (await new Promise((resolve, reject) => {
+      execFile('git', ['-C', cwd, 'rev-parse', '--git-path', 'info/exclude'],
+        { encoding: 'utf8' }, (err, stdout) => (err ? reject(err) : resolve(stdout)));
+    })).trim();
     const excl = path.isAbsolute(gitDir) ? gitDir : path.join(cwd, gitDir);
     fs.mkdirSync(path.dirname(excl), { recursive: true });
     const cur = fs.existsSync(excl) ? fs.readFileSync(excl, 'utf8') : '';
@@ -121,25 +123,25 @@ function installHooks(cwd, session, stateDir, callbackUrl) {
 const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
 
 async function launchAndSettle(session, launchCmd) {
-  t.sendLiteral(paneTarget(session), launchCmd);
+  await t.sendLiteral(paneTarget(session), launchCmd);
   await t.sleep(300);
-  t.sendKey(paneTarget(session), 'Enter');
+  await t.sendKey(paneTarget(session), 'Enter');
 
   const deadline = Date.now() + 45000;
   while (Date.now() < deadline) {
     await t.sleep(500);
-    const cmd = paneCommand(session);
+    const cmd = await paneCommand(session);
     if (cmd === null) throw new Error(`tmux session ${session} vanished during launch`);
     if (SHELLS.has(cmd)) continue; // claude not up yet (or it already exited — captured by timeout)
-    const pane = t.capture(paneTarget(session), 40);
+    const pane = await t.capture(paneTarget(session), 40);
     if (TRUST_RE.test(pane)) {
-      t.sendKey(paneTarget(session), 'Enter');
+      await t.sendKey(paneTarget(session), 'Enter');
       await t.sleep(1000);
       continue;
     }
     if (UI_READY_RE.test(pane)) return;
   }
-  const tail = t.capture(paneTarget(session), 20);
+  const tail = await t.capture(paneTarget(session), 20);
   throw new Error(`claude did not start in session ${session} within 45s; pane tail:\n${tail}`);
 }
 
@@ -155,18 +157,18 @@ async function spawn(cwd, prompt, opts = {}) {
   if (!/^bc-[A-Za-z0-9_-]+$/.test(session)) {
     throw new Error(`invalid session name "${session}" (must match bc-<id>)`);
   }
-  if (hasSession(session)) throw new Error(`tmux session ${session} already exists`);
+  if (await hasSession(session)) throw new Error(`tmux session ${session} already exists`);
   const stateDir = stateDirOf(opts);
   const resumeId = crypto.randomUUID();
 
   if (opts.installHooks !== false) {
-    installHooks(cwdAbs, session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
+    await installHooks(cwdAbs, session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
   }
 
   const promptFile = path.join(stateDir, `${session}.prompt`);
   fs.writeFileSync(promptFile, prompt);
 
-  t.tmux('new-session', '-d', '-s', session, '-c', cwdAbs);
+  await t.tmux('new-session', '-d', '-s', session, '-c', cwdAbs);
   try {
     const extra = (opts.extraArgs || []).map(shellQuote).join(' ');
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
@@ -175,7 +177,7 @@ async function spawn(cwd, prompt, opts = {}) {
       + `"$(cat ${shellQuote(promptFile)})"`;
     await launchAndSettle(session, launchCmd);
   } catch (err) {
-    t.tryTmux('kill-session', '-t', paneTarget(session));
+    await t.tryTmux('kill-session', '-t', paneTarget(session));
     try { fs.unlinkSync(promptFile); } catch { /* best-effort */ }
     throw err;
   }
@@ -205,8 +207,8 @@ async function send(ref, text) {
 // alive(ref) — tmux session exists AND its pane is still running the agent
 // (a pane sitting back at a bare shell means claude exited).
 async function alive(ref) {
-  if (!hasSession(ref.session)) return false;
-  const cmd = paneCommand(ref.session);
+  if (!(await hasSession(ref.session))) return false;
+  const cmd = await paneCommand(ref.session);
   return cmd !== null && !SHELLS.has(cmd);
 }
 
@@ -237,19 +239,19 @@ async function resume(ref, opts = {}) {
   } catch {
     // no recorded id — fall back to the ref's
   }
-  if (hasSession(ref.session)) t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+  if (await hasSession(ref.session)) await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
 
   if (opts.installHooks !== false) {
-    installHooks(ref.cwd, ref.session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
+    await installHooks(ref.cwd, ref.session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
   }
-  t.tmux('new-session', '-d', '-s', ref.session, '-c', ref.cwd);
+  await t.tmux('new-session', '-d', '-s', ref.session, '-c', ref.cwd);
   try {
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + 'claude --dangerously-skip-permissions '
       + (resumeId ? `--resume ${resumeId}` : '');
     await launchAndSettle(ref.session, launchCmd.trim());
   } catch (err) {
-    t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+    await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
     throw err;
   }
   return { harness: 'claude', session: ref.session, cwd: ref.cwd, resumeId };
@@ -261,7 +263,7 @@ async function resume(ref, opts = {}) {
 // turn-end log are cheap, and a later resume(ref) can still reincarnate the
 // conversation if the kill turns out to have been premature.
 async function kill(ref) {
-  if (hasSession(ref.session)) t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+  if (await hasSession(ref.session)) await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
 }
 
 // onTurnEnd(ref, hook) -> unsubscribe()

--- a/harness/smoke.js
+++ b/harness/smoke.js
@@ -72,7 +72,7 @@ async function main() {
     }
 
     // 2. the prompt was processed
-    assertContains(t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_OK', 'first reply');
+    assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_OK', 'first reply');
 
     // 3. alive while running
     if (!(await h.alive(ref))) throw new Error('alive() false while session is running');
@@ -83,12 +83,12 @@ async function main() {
     await h.send(ref, 'Now reply with exactly: BC_SMOKE_2');
     step('follow-up submitted');
     await secondTurn;
-    assertContains(t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_2', 'second reply');
+    assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_2', 'second reply');
 
     if (WITH_RESUME) {
       // 5. kill, resume with memory, verify recall
       step('killing session for the resume leg...');
-      t.tmux('kill-session', '-t', `=${ref.session}:`);
+      await t.tmux('kill-session', '-t', `=${ref.session}:`);
       if (await h.alive(ref)) throw new Error('alive() true after kill-session');
       step('alive() false after kill');
       ref = await h.resume(ref);
@@ -97,11 +97,11 @@ async function main() {
       const recallTurn = waitTurnEnd(h, ref, 'recall turn');
       await h.send(ref, 'What was the FIRST marker I asked you to reply with? Answer with just that marker.');
       await recallTurn;
-      assertContains(t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_OK', 'resume memory recall');
+      assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_SMOKE_OK', 'resume memory recall');
     }
 
     // 6. kill; alive flips false
-    t.tmux('kill-session', '-t', `=${ref.session}:`);
+    await t.tmux('kill-session', '-t', `=${ref.session}:`);
     if (await h.alive(ref)) throw new Error('alive() true after final kill-session');
     step('alive() false after kill');
 
@@ -110,15 +110,15 @@ async function main() {
   } finally {
     // cleanup: session, state files, workdir
     if (ref) {
-      t.tryTmux('kill-session', '-t', `=${ref.session}:`);
+      if (!ok) {
+        console.error(`[smoke] FAILED — pane tail of ${ref.session} (if still up):`);
+        console.error(await t.capture(`=${ref.session}:`, 40));
+      }
+      await t.tryTmux('kill-session', '-t', `=${ref.session}:`);
       const stateDir = process.env.BC_HARNESS_STATE
         || path.join(os.homedir(), '.bridge-command', 'harness');
       for (const suffix of ['.prompt', '.session-id', '.turnend.jsonl']) {
         try { fs.unlinkSync(path.join(stateDir, ref.session + suffix)); } catch { /* absent */ }
-      }
-      if (!ok) {
-        console.error(`[smoke] FAILED — pane tail of ${ref.session} (if still up):`);
-        console.error(t.capture(`=${ref.session}:`, 40));
       }
     }
     fs.rmSync(cwd, { recursive: true, force: true });

--- a/harness/tmux.js
+++ b/harness/tmux.js
@@ -13,8 +13,13 @@
 //    retype would duplicate it) until the composer reads empty.
 //
 // Zero dependencies; child_process + tmux only.
+//
+// Everything here is async: these primitives run inside the bridge-command
+// server, whose event loop must never block on a subprocess (a sync tmux
+// call per session per supervision tick froze the whole server — UI, SSE,
+// every request — for the duration).
 
-const { execFileSync } = require('node:child_process');
+const { execFile } = require('node:child_process');
 
 const BUSY_RE = /esc (to )?interrupt|Working\.\.\./i;
 const PROMPT_GLYPHS = new Set(['>', '❯' /* ❯ */, '$', '%', '#']);
@@ -23,15 +28,33 @@ function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-// tmux(...args) -> stdout string; throws on tmux error.
-function tmux(...args) {
-  return execFileSync('tmux', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+// tmuxRun(args, input?) -> Promise<stdout>; rejects on tmux error. input, when
+// given, is piped to stdin (load-buffer); otherwise stdin is closed immediately.
+function tmuxRun(args, input) {
+  return new Promise((resolve, reject) => {
+    const child = execFile('tmux', args, { encoding: 'utf8' }, (err, stdout, stderr) => {
+      if (err) {
+        err.stderr = stderr;
+        reject(err);
+      } else {
+        resolve(stdout);
+      }
+    });
+    child.stdin.on('error', () => {}); // EPIPE when tmux exits before reading
+    if (input === undefined) child.stdin.end();
+    else child.stdin.end(input);
+  });
 }
 
-// tryTmux(...args) -> stdout string or null on error.
-function tryTmux(...args) {
+// tmux(...args) -> Promise<stdout string>; rejects on tmux error.
+function tmux(...args) {
+  return tmuxRun(args);
+}
+
+// tryTmux(...args) -> Promise<stdout string or null on error>.
+async function tryTmux(...args) {
   try {
-    return tmux(...args);
+    return await tmuxRun(args);
   } catch {
     return null;
   }
@@ -91,11 +114,11 @@ function stripGhost(line) {
 //             ghost text). Safe to inject; also the positive ack that a submit landed.
 //   pending — real unsubmitted text on the cursor line.
 //   unknown — the pane could not be read.
-function composerState(target) {
-  const cy = tryTmux('display-message', '-p', '-t', target, '#{cursor_y}');
+async function composerState(target) {
+  const cy = await tryTmux('display-message', '-p', '-t', target, '#{cursor_y}');
   if (cy === null || !/^\d+$/.test(cy.trim())) return 'unknown';
   const row = cy.trim();
-  const raw = tryTmux('capture-pane', '-e', '-p', '-t', target, '-S', row, '-E', row);
+  const raw = await tryTmux('capture-pane', '-e', '-p', '-t', target, '-S', row, '-E', row);
   if (raw === null) return 'unknown';
   let s = stripGhost(raw.replace(/\n$/, ''));
   // Strip composer box borders (claude/codex draw "│ … │"; some TUIs use ┃ or |).
@@ -108,16 +131,16 @@ function composerState(target) {
 
 // paneIsBusy(target) — do the last few non-blank lines of the pane show a
 // busy footer (agent mid-turn)?
-function paneIsBusy(target) {
-  const tail = tryTmux('capture-pane', '-p', '-t', target, '-S', '-40');
+async function paneIsBusy(target) {
+  const tail = await tryTmux('capture-pane', '-p', '-t', target, '-S', '-40');
   if (tail === null) return false;
   const lines = tail.split('\n').filter((l) => l.trim() !== '').slice(-6);
   return BUSY_RE.test(lines.join('\n'));
 }
 
 // capture(target, lines) — bounded plain-text pane capture (default 60 lines).
-function capture(target, lines = 60) {
-  const out = tryTmux('capture-pane', '-p', '-t', target, '-S', `-${lines}`);
+async function capture(target, lines = 60) {
+  const out = await tryTmux('capture-pane', '-p', '-t', target, '-S', `-${lines}`);
   return out === null ? '' : out;
 }
 
@@ -125,21 +148,18 @@ function capture(target, lines = 60) {
 // Single-line text goes via `send-keys -l`. Multi-line text goes via a tmux
 // buffer paste in bracketed-paste mode (-p) so embedded newlines land as part
 // of the paste instead of acting as Enter presses that submit mid-text.
-function sendLiteral(target, text) {
+async function sendLiteral(target, text) {
   if (text.includes('\n')) {
-    execFileSync('tmux', ['load-buffer', '-b', 'bc-harness', '-'], {
-      input: text,
-      stdio: ['pipe', 'ignore', 'pipe'],
-    });
-    tmux('paste-buffer', '-p', '-d', '-b', 'bc-harness', '-t', target);
+    await tmuxRun(['load-buffer', '-b', 'bc-harness', '-'], text);
+    await tmux('paste-buffer', '-p', '-d', '-b', 'bc-harness', '-t', target);
   } else {
-    tmux('send-keys', '-t', target, '-l', text);
+    await tmux('send-keys', '-t', target, '-l', text);
   }
 }
 
 // sendKey(target, key) — one named tmux key ('Enter', 'Escape', 'C-c', ...).
 function sendKey(target, key) {
-  tmux('send-keys', '-t', target, key);
+  return tmux('send-keys', '-t', target, key);
 }
 
 // submit(target, text, opts) — type text once, then Enter with verification.
@@ -154,19 +174,19 @@ async function submit(target, text, opts = {}) {
   const enterSleep = opts.enterSleep ?? 400;
   const settle = opts.settle ?? (text.startsWith('/') ? 1200 : 300);
   try {
-    sendLiteral(target, text);
+    await sendLiteral(target, text);
   } catch {
     return 'send-failed';
   }
   await sleep(settle);
   for (let i = 0; i < retries; i++) {
     try {
-      sendKey(target, 'Enter');
+      await sendKey(target, 'Enter');
     } catch {
       // fall through to state check
     }
     await sleep(enterSleep);
-    const state = composerState(target);
+    const state = await composerState(target);
     if (state !== 'pending') return state; // 'empty' (landed) or 'unknown' (inconclusive)
   }
   return 'pending';

--- a/server/server.js
+++ b/server/server.js
@@ -57,7 +57,7 @@ const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '.
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
 const { workerBrief, PROJECT_MODES } = require(path.join(__dirname, 'brief.js'));
 const names = require(path.join(__dirname, 'names.js'));
-const { execFile, execFileSync } = require('child_process');
+const { execFile } = require('child_process');
 
 // ---------- args ----------
 function parseArgs(argv) {
@@ -898,7 +898,8 @@ function restoreCard(id, body) {
 // record {name, path, mode}. A card's `repo` attribute must name a registered
 // project for card.start to provision its worker a worktree.
 function findProject(name) { return board.projects.find((p) => p.name === name); }
-function addProject(body) {
+const addingProjects = new Set(); // names with a clone in flight (async clone opens racing duplicate adds)
+async function addProject(body) {
   const source = String((body && body.source) || '').trim();
   if (!source) return { error: 'source required (git URL or local path)' };
   const mode = String((body && body.mode) || 'no-mistakes');
@@ -906,15 +907,21 @@ function addProject(body) {
   const name = String((body && body.name) || path.basename(source.replace(/\/+$/, '')).replace(/\.git$/, '')).trim();
   if (!/^[\w][\w.-]*$/.test(name)) return { error: 'bad project name: ' + name + ' (use [A-Za-z0-9_.-], or pass --name)' };
   if (findProject(name)) return { error: 'project exists: ' + name, code: 409 };
+  if (addingProjects.has(name)) return { error: 'project add already in progress: ' + name, code: 409 };
   const dest = path.join(WORKSPACE, 'projects', name);
   if (fs.existsSync(dest)) return { error: 'destination already exists: ' + dest, code: 409 };
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   const src = fs.existsSync(source) ? path.resolve(source) : source;
+  addingProjects.add(name);
   try {
-    execFileSync('git', ['clone', src, dest],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 300000 });
+    await new Promise((resolve, reject) => {
+      execFile('git', ['clone', src, dest], { encoding: 'utf8', timeout: 300000 },
+        (err, stdout, stderr) => (err ? reject(Object.assign(err, { stderr })) : resolve()));
+    });
   } catch (e) {
     return { error: 'clone failed: ' + String((e && e.stderr) || (e && e.message) || e).trim(), code: 502 };
+  } finally {
+    addingProjects.delete(name);
   }
   const project = { name, path: dest, mode, source: src, added: now() };
   board.projects.push(project);
@@ -950,7 +957,27 @@ function enterWorking(card, text) {
 // whose hook a per-spawn install would clobber), bind {session, worktree,
 // branch} into the card + the worker registry, move the card → Working.
 // body.resume reincarnates a recorded (dead) worker in the same worktree instead.
+//
+// Provisioning + spawn are long async waits (a worktree add on a multi-GB
+// repo, a real agent launch): the per-card in-flight guard keeps a second
+// start of the SAME card from racing the first (different cards interleave
+// freely — that's the point of going async), and the card is re-checked
+// against the board after the spawn so a mid-start archive never leaves an
+// orphan session behind. The response still reports the REAL spawn outcome —
+// the await keeps startCard's success/failure contract synchronous-looking.
+const startingCards = new Set(); // card ids with a start/resume in flight
 async function startCard(card, body) {
+  if (startingCards.has(card.id)) {
+    return { error: 'card start already in progress: ' + card.id, code: 409 };
+  }
+  startingCards.add(card.id);
+  try {
+    return await doStartCard(card, body);
+  } finally {
+    startingCards.delete(card.id);
+  }
+}
+async function doStartCard(card, body) {
   if (card.type === 'plan') return { error: 'plan cards never start (no worker is spawned for a plan)' };
 
   const existing = findWorker(card.id);
@@ -961,6 +988,10 @@ async function startCard(card, body) {
       ref = await harnessFor(existing.ref).resume(existing.ref, { stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL });
     } catch (e) {
       return { error: 'worker resume failed: ' + String((e && e.message) || e), code: 502 };
+    }
+    if (!findCard(card.id)) { // archived while the resume was in flight
+      Promise.resolve().then(() => harnessFor(ref).kill(ref)).catch(() => {});
+      return { error: 'card left the board during resume: ' + card.id, code: 409 };
     }
     existing.ref = ref;
     existing.done = false;
@@ -995,15 +1026,16 @@ async function startCard(card, body) {
       return { error: 'previous worker session ' + existing.ref.session + ' is still alive — resume it (card start --resume) or steer it instead of spawning over it', code: 409 };
     }
     const prevProject = findProject(existing.project) || project;
-    const rel = releaseWorktree(existing.worktree, prevProject.path);
+    const rel = await releaseWorktree(existing.worktree, prevProject.path);
     if (!rel.released) {
       return { error: 'previous worker worktree not releasable (' + rel.reason + '): ' + existing.worktree.path, code: 409 };
     }
-    board.workers.splice(board.workers.indexOf(existing), 1);
+    const idx = board.workers.indexOf(existing);
+    if (idx !== -1) board.workers.splice(idx, 1);
   }
 
   let wt;
-  try { wt = createWorktree(project.path, card.id, WORKSPACE); }
+  try { wt = await createWorktree(project.path, card.id, WORKSPACE); }
   catch (e) { return { error: 'worktree provisioning failed: ' + String((e && e.message) || e), code: 502 }; }
 
   const session = workerSession(card.id);
@@ -1019,8 +1051,13 @@ async function startCard(card, body) {
   try {
     ref = await impl.spawn(wt.path, prompt, spawnOpts);
   } catch (e) {
-    releaseWorktree(wt, project.path); // best-effort: no spawnless lease left behind
+    await releaseWorktree(wt, project.path).catch(() => {}); // best-effort: no spawnless lease left behind
     return { error: 'worker spawn failed: ' + String((e && e.message) || e), code: 502 };
+  }
+  if (!findCard(card.id)) { // archived while provisioning/spawn were in flight
+    Promise.resolve().then(() => impl.kill(ref)).catch(() => {});
+    await releaseWorktree(wt, project.path).catch(() => {});
+    return { error: 'card left the board during start: ' + card.id, code: 409 };
   }
 
   card.attributes.session = session;
@@ -1228,7 +1265,7 @@ async function prWatchTick() {
           : (card.attributes && card.attributes.worktree ? { path: card.attributes.worktree, tool: 'git' } : null);
         let note = merged.url;
         if (wtRec && project) {
-          const rel = releaseWorktree(wtRec, project.path);
+          const rel = await releaseWorktree(wtRec, project.path);
           if (!rel.released) {
             note += ' (worktree NOT released: ' + rel.reason + ')';
             console.error(now() + ' worktree not released for ' + card.id + ': ' + rel.reason);
@@ -1498,7 +1535,7 @@ const server = http.createServer(async (req, res) => {
     // ----- projects (F6) -----
     if (route === 'GET /api/projects') return sendJson(res, 200, { projects: board.projects });
     if (route === 'POST /api/projects') {
-      const r = addProject(JSON.parse(await readBody(req) || '{}'));
+      const r = await addProject(JSON.parse(await readBody(req) || '{}'));
       if (r.error) return sendJson(res, r.code || 400, { error: r.error });
       saveBoard(); broadcast();
       return sendJson(res, 200, { ok: true, project: r.project });

--- a/server/worktrees.js
+++ b/server/worktrees.js
@@ -13,34 +13,66 @@
 // plain `git worktree add -d` under <workspace>/.bridge-command/worktrees/.
 // BC_WORKTREE_TOOL=git|treehouse forces the choice (tests pin `git` for
 // hermetic cleanup).
+//
+// All subprocess work is async (the server's event loop must never block on
+// a multi-GB worktree add), and provision/release are serialized per project
+// clone: concurrent `git worktree add/remove` on one repo race its worktree
+// locks, so operations on the same clone queue behind each other.
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { execFileSync } = require('node:child_process');
+const { execFile } = require('node:child_process');
 
 function run(cmd, args, opts = {}) {
-  return execFileSync(cmd, args, Object.assign(
-    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 120000 }, opts)).trim();
+  return new Promise((resolve, reject) => {
+    const child = execFile(cmd, args, Object.assign({ encoding: 'utf8', timeout: 120000 }, opts),
+      (err, stdout, stderr) => {
+        if (err) {
+          const detail = String(stderr || '').trim();
+          if (detail && !String(err.message || '').includes(detail)) {
+            err.message = err.message + ': ' + detail;
+          }
+          reject(err);
+        } else {
+          resolve(String(stdout).trim());
+        }
+      });
+    child.stdin.on('error', () => {});
+    child.stdin.end(); // never interactive (execFileSync ran with stdin ignored)
+  });
 }
 function git(dir, ...args) { return run('git', ['-C', dir, ...args]); }
 
-function treehouseAvailable() {
+// Per-clone operation queue: worktree add/remove mutate the clone's shared
+// git dir, so two in-flight operations on the same clone are never allowed.
+const projectQueues = new Map(); // realpath(project) -> tail promise
+function withProjectLock(key, fn) {
+  const tail = projectQueues.get(key) || Promise.resolve();
+  const next = tail.catch(() => {}).then(fn);
+  projectQueues.set(key, next);
+  next.catch(() => {}).then(() => {
+    if (projectQueues.get(key) === next) projectQueues.delete(key);
+  });
+  return next;
+}
+
+async function treehouseAvailable() {
   if (process.env.BC_WORKTREE_TOOL === 'git') return false;
   if (process.env.BC_WORKTREE_TOOL === 'treehouse') return true;
-  try { run('treehouse', ['--version']); return true; } catch (e) { return false; }
+  try { await run('treehouse', ['--version']); return true; } catch (e) { return false; }
 }
 
 // assertIsolated — the worktree is a genuine, distinct linked worktree:
 // not the clone itself, a real worktree root, and not sharing the clone's
 // primary git dir. Throws with a precise reason otherwise.
-function assertIsolated(wt, projectPath) {
+async function assertIsolated(wt, projectPath) {
   const w = fs.realpathSync(wt);
   const p = fs.realpathSync(projectPath);
   if (w === p) throw new Error('worktree resolves to the project clone itself: ' + w);
-  const top = fs.realpathSync(git(w, 'rev-parse', '--show-toplevel'));
+  const top = fs.realpathSync(await git(w, 'rev-parse', '--show-toplevel'));
   if (top !== w) throw new Error('not a worktree root: ' + wt + ' (toplevel is ' + top + ')');
-  const wGit = git(w, 'rev-parse', '--absolute-git-dir');
-  const pGit = git(p, 'rev-parse', '--absolute-git-dir');
+  const wGit = await git(w, 'rev-parse', '--absolute-git-dir');
+  const pGit = await git(p, 'rev-parse', '--absolute-git-dir');
   if (wGit === pGit) throw new Error('worktree shares the clone\'s git dir (not isolated): ' + wt);
 }
 
@@ -48,26 +80,28 @@ function assertIsolated(wt, projectPath) {
 // Always returns an asserted-isolated worktree or throws.
 function createWorktree(projectPath, cardId, workspace) {
   const proj = fs.realpathSync(projectPath);
-  let wt = null;
-  let tool = 'git';
-  if (treehouseAvailable()) {
-    try {
-      const out = run('treehouse', ['get', '--lease', '--lease-holder', 'bc-w-' + cardId], { cwd: proj });
-      const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);
-      const cand = lines[lines.length - 1];
-      if (cand && fs.existsSync(cand)) { wt = cand; tool = 'treehouse'; }
-    } catch (e) { wt = null; /* fall back to git worktree */ }
-  }
-  if (!wt) {
-    tool = 'git';
-    const dir = path.join(workspace, '.bridge-command', 'worktrees');
-    fs.mkdirSync(dir, { recursive: true });
-    wt = path.join(dir, String(cardId).replace(/[^A-Za-z0-9_.-]/g, '-'));
-    if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);
-    git(proj, 'worktree', 'add', '-d', wt);
-  }
-  assertIsolated(wt, proj);
-  return { path: fs.realpathSync(wt), tool };
+  return withProjectLock(proj, async () => {
+    let wt = null;
+    let tool = 'git';
+    if (await treehouseAvailable()) {
+      try {
+        const out = await run('treehouse', ['get', '--lease', '--lease-holder', 'bc-w-' + cardId], { cwd: proj });
+        const lines = out.split('\n').map((l) => l.trim()).filter(Boolean);
+        const cand = lines[lines.length - 1];
+        if (cand && fs.existsSync(cand)) { wt = cand; tool = 'treehouse'; }
+      } catch (e) { wt = null; /* fall back to git worktree */ }
+    }
+    if (!wt) {
+      tool = 'git';
+      const dir = path.join(workspace, '.bridge-command', 'worktrees');
+      fs.mkdirSync(dir, { recursive: true });
+      wt = path.join(dir, String(cardId).replace(/[^A-Za-z0-9_.-]/g, '-'));
+      if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);
+      await git(proj, 'worktree', 'add', '-d', wt);
+    }
+    await assertIsolated(wt, proj);
+    return { path: fs.realpathSync(wt), tool };
+  });
 }
 
 // releaseWorktree({ path, tool }, projectPath) -> { released, reason? }
@@ -75,18 +109,23 @@ function createWorktree(projectPath, cardId, workspace) {
 // a dirty or unreadable worktree is left in place with the reason reported.
 function releaseWorktree(rec, projectPath) {
   const wt = rec && rec.path;
-  if (!wt || !fs.existsSync(wt)) return { released: true, reason: 'already gone' };
-  let dirty;
-  try { dirty = git(wt, 'status', '--porcelain'); }
-  catch (e) { return { released: false, reason: 'unreadable: ' + String(e.message || e) }; }
-  if (dirty) return { released: false, reason: 'worktree has uncommitted changes' };
-  try {
-    if (rec.tool === 'treehouse') run('treehouse', ['return', wt], { cwd: projectPath });
-    else git(projectPath, 'worktree', 'remove', wt);
-    return { released: true };
-  } catch (e) {
-    return { released: false, reason: String(e.message || e) };
-  }
+  if (!wt || !fs.existsSync(wt)) return Promise.resolve({ released: true, reason: 'already gone' });
+  let proj;
+  try { proj = fs.realpathSync(projectPath); }
+  catch (e) { return Promise.resolve({ released: false, reason: 'unreadable: ' + String(e.message || e) }); }
+  return withProjectLock(proj, async () => {
+    let dirty;
+    try { dirty = await git(wt, 'status', '--porcelain'); }
+    catch (e) { return { released: false, reason: 'unreadable: ' + String(e.message || e) }; }
+    if (dirty) return { released: false, reason: 'worktree has uncommitted changes' };
+    try {
+      if (rec.tool === 'treehouse') await run('treehouse', ['return', wt], { cwd: projectPath });
+      else await git(projectPath, 'worktree', 'remove', wt);
+      return { released: true };
+    } catch (e) {
+      return { released: false, reason: String(e.message || e) };
+    }
+  });
 }
 
 module.exports = { createWorktree, releaseWorktree, assertIsolated };

--- a/test/unblock.test.js
+++ b/test/unblock.test.js
@@ -1,0 +1,158 @@
+'use strict';
+// The server never blocks its event loop on subprocesses (papercuts #4/#6/#11).
+//
+// A `git` shim on PATH sleeps on the expensive subcommands (clone, worktree)
+// before delegating to the real git — the moral equivalent of a multi-GB repo.
+// While those crawl, the server must keep answering: on the old execFileSync
+// code every probe below stalled for the full sleep; now it answers in ms.
+// The async window the conversion opens is guarded: a second start of the
+// same card and a duplicate in-flight project add are refused, not raced.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { startServerWithLieutenant, withOwner, sleep } = require('./helper');
+
+const REAL_GIT = execFileSync('which', ['git'], { encoding: 'utf8' }).trim();
+
+function git(dir, ...args) {
+  return execFileSync(REAL_GIT, ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+function makeRepo(root, name = 'srcrepo') {
+  const repo = path.join(root, name);
+  fs.mkdirSync(repo, { recursive: true });
+  execFileSync(REAL_GIT, ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'hello\n');
+  git(repo, 'add', '.');
+  git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init');
+  return repo;
+}
+
+// A git shim that sleeps SLOW_GIT_MS before clone/worktree work, then execs
+// the real git. Fast plumbing (rev-parse, status) passes straight through.
+function makeSlowGit(root, sleepMs) {
+  const bin = path.join(root, 'slowbin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, 'git'),
+    '#!/bin/bash\n' +
+    'for a in "$@"; do\n' +
+    '  if [ "$a" = "clone" ] || [ "$a" = "worktree" ]; then\n' +
+    '    sleep ' + (sleepMs / 1000) + '\n' +
+    '    break\n' +
+    '  fi\n' +
+    'done\n' +
+    'exec ' + JSON.stringify(REAL_GIT) + ' "$@"\n');
+  fs.chmodSync(path.join(bin, 'git'), 0o755);
+  return bin;
+}
+
+async function boot(root, sleepMs) {
+  const bin = makeSlowGit(root, sleepMs);
+  return startServerWithLieutenant({
+    env: {
+      PATH: bin + path.delimiter + process.env.PATH,
+      BC_FAKE_STATE: path.join(root, 'fake'), BC_WORKTREE_TOOL: 'git',
+      BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
+    },
+  });
+}
+
+// Probe latency while `work` is in flight. Fails loudly if `work` finished
+// before the probe ran (the slow window never overlapped — a broken test).
+async function probeDuring(work, probe) {
+  let settled = false;
+  const guarded = work.then((r) => { settled = true; return r; });
+  await sleep(150); // let the slow subprocess start
+  assert.strictEqual(settled, false, 'slow operation finished before the probe — widen the sleep');
+  const t0 = Date.now();
+  const res = await probe();
+  const elapsed = Date.now() - t0;
+  return { result: await guarded, elapsed, probeRes: res };
+}
+
+test('project add (slow clone) does not block other requests', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-unblock-'));
+  const repo = makeRepo(root);
+  const s = await boot(root, 2000);
+  try {
+    const adding = s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+    const { result, elapsed, probeRes } = await probeDuring(adding, () => s.api('GET', '/api/status'));
+    assert.strictEqual(probeRes.status, 200);
+    assert.ok(elapsed < 1000, '/api/status answered in ' + elapsed + 'ms while a 2s clone was in flight');
+    assert.strictEqual(result.status, 200, JSON.stringify(result.body));
+    assert.ok(fs.existsSync(path.join(s.dir, 'projects', 'proj', 'README.md')), 'really cloned');
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('card start burst (slow worktree add) keeps the board answering; all starts land', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-unblock-'));
+  const repo = makeRepo(root);
+  const s = await boot(root, 2000);
+  try {
+    // registration pays the slow clone once, awaited up front
+    const reg = await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+    assert.strictEqual(reg.status, 200, JSON.stringify(reg.body));
+    for (const id of ['b1', 'b2', 'b3']) {
+      await s.api('POST', '/api/cards', withOwner({ title: id, id, attributes: { repo: 'proj' } }));
+    }
+    // 3 concurrent starts: worktree adds are serialized per clone (git lock
+    // safety), so the slow window is ~6s — the board must answer inside it.
+    const burst = Promise.all(['b1', 'b2', 'b3'].map((id) =>
+      s.api('POST', '/api/cards/' + id + '/start', { harness: 'fake' })));
+    const { result, elapsed, probeRes } = await probeDuring(burst, () => s.api('GET', '/api/board'));
+    assert.strictEqual(probeRes.status, 200);
+    assert.ok(elapsed < 1000, '/api/board answered in ' + elapsed + 'ms during a 3-way start burst');
+    for (const r of result) assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    // every card really landed in Working with its own isolated worktree
+    const worktrees = new Set();
+    for (const id of ['b1', 'b2', 'b3']) {
+      const card = (await s.api('GET', '/api/cards/' + id)).body;
+      assert.strictEqual(card.column, 'working');
+      worktrees.add(card.attributes.worktree);
+    }
+    assert.strictEqual(worktrees.size, 3, 'three distinct worktrees');
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('async window is guarded: same-card double start and duplicate in-flight project add refuse', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-unblock-'));
+  const repo = makeRepo(root);
+  const s = await boot(root, 1000);
+  try {
+    const reg = await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+    assert.strictEqual(reg.status, 200, JSON.stringify(reg.body));
+    await s.api('POST', '/api/cards', withOwner({ title: 'One', id: 'one', attributes: { repo: 'proj' } }));
+
+    // two concurrent starts of the SAME card: exactly one wins
+    const [a, b] = await Promise.all([
+      s.api('POST', '/api/cards/one/start', { harness: 'fake' }),
+      s.api('POST', '/api/cards/one/start', { harness: 'fake' }),
+    ]);
+    const statuses = [a.status, b.status].sort();
+    assert.deepStrictEqual(statuses, [200, 409], JSON.stringify([a.body, b.body]));
+    const loser = a.status === 409 ? a : b;
+    assert.match(loser.body.error, /already in progress|already Working/);
+    const disk = JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-command', 'board.json'), 'utf8'));
+    assert.strictEqual(disk.workers.filter((w) => w.card === 'one').length, 1, 'exactly one worker bound');
+
+    // two concurrent adds of the SAME project name: exactly one clone lands
+    const [c, d] = await Promise.all([
+      s.api('POST', '/api/projects', { source: repo, name: 'dup', mode: 'local-only' }),
+      s.api('POST', '/api/projects', { source: repo, name: 'dup', mode: 'local-only' }),
+    ]);
+    assert.deepStrictEqual([c.status, d.status].sort(), [200, 409], JSON.stringify([c.body, d.body]));
+    const projects = (await s.api('GET', '/api/projects')).body.projects;
+    assert.strictEqual(projects.filter((p) => p.name === 'dup').length, 1);
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What / why

The server is a single-threaded Node process that called `execFileSync` on the request path and in timers: `git clone` inline in project add, `git worktree add/remove` (+ treehouse) in provisioning, and tmux calls in the harness — including one per lieutenant+worker every 30s supervision tick. Any of these froze the ENTIRE server — UI, SSE, all requests — for the duration. Observed live: `bc-axi board` timing out during a 9-way `card start` burst; the UI freezing during a multi-GB `git clone`. (Papercuts #4/#6/#11, one root cause.)

## What was converted

- **`harness/tmux.js`** — `tmux()`/`tryTmux()` now wrap async `execFile`; everything above them (`composerState`, `paneIsBusy`, `capture`, `sendLiteral`, `sendKey`, `submit`) is async. The multi-line `load-buffer` stdin pipe rides the same helper.
- **`harness/claude-tmux.js`** — awaits the primitives throughout (`spawn`/`send`/`alive`/`resume`/`kill` were already async-shaped); `installHooks` goes async for its `git rev-parse`. The port contract already said all verbs may be async; every server call site already awaited them.
- **`server/worktrees.js`** — `createWorktree`/`releaseWorktree`/`assertIsolated` fully async.
- **`server/server.js`** — `addProject`'s inline `git clone` → awaited `execFile`; `startCard` and the PR watch await the worktree ops. `harness/smoke.js` and `bc-axi init` updated for the async helpers.

## Concurrency guards (sync code was implicitly serialized; async opens interleaving)

- `startCard`: per-card in-flight guard (second start of the same card → 409), and a post-spawn re-check against the board — a card archived mid-start gets its fresh session killed and worktree released instead of leaving an orphan. The response still reports the REAL spawn outcome (the await preserves startCard's success/failure contract). Also fixed a latent `splice(indexOf(...))` -1 hazard.
- `addProject`: in-flight name guard (concurrent duplicate add → 409, one clone lands).
- `worktrees.js`: add/remove serialized per project clone (concurrent `git worktree` ops race the clone's locks); different clones interleave freely.
- Supervision + PR-watch ticks already had non-overlap flags; they now yield at every subprocess.

## Test evidence

New `test/unblock.test.js` uses a `git` shim on PATH that sleeps on `clone`/`worktree` (the moral equivalent of a 4.4GB repo):

- `/api/status` answers in **~5ms** while a 2s clone is in flight — **fails on the old sync code** (probe stalls the full 2s).
- `/api/board` answers in ms during a 3-way concurrent `card start` burst; all three starts land in Working with three distinct isolated worktrees — **fails on the old sync code**.
- Same-card double start and duplicate in-flight project add: exactly one wins, exactly one worker/clone bound.

Full suite: **142/143 pass**. The one failure (`cards.test.js` "card owner is immutable") is pre-existing on `main` — stale test from the owner-reassignment feature in 52bdd3a, unrelated to this change (verified by running it on a clean checkout of main).

Verified manually: the Working⇔live-worker invariant paths (start refusals, resume, worker-died flagging) are covered by the existing `workers`/`supervise` suites, all green. Not restarted against the live server (a worker must not touch the server supervising it) — the lieutenant applies the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)