### PR TITLE
fix(ui): reliable chat delivery + SSE staleness recovery (papercuts #9, #10)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -543,8 +543,12 @@ function publicCard(card, user) {
 }
 // The served board carries the EFFECTIVE kinds map (built-ins merged under the
 // registered entries); the stored board keeps only the registered map.
+// `boot` identifies this server instance: a client seeing it change knows the
+// server restarted and any SSE events in between are gone — refetch, don't trust
+// the old stream.
+const BOOT_ID = process.pid + '-' + Date.now();
 function publicBoard(user) {
-  return Object.assign({}, board, { kinds: effectiveKinds(), cards: board.cards.map((c) => publicCard(c, user)) });
+  return Object.assign({}, board, { boot: BOOT_ID, kinds: effectiveKinds(), cards: board.cards.map((c) => publicCard(c, user)) });
 }
 
 // status.set — the ONLY writer of card.status.worker.
@@ -575,7 +579,9 @@ function broadcast() {
   const payload = 'event: board\ndata: ' + JSON.stringify(publicBoard('user')) + '\n\n';
   for (const res of sseClients) res.write(payload);
 }
-setInterval(() => { for (const res of sseClients) res.write(': ping\n\n'); }, 25000).unref();
+// Named ping (not an SSE comment): comments are invisible to EventSource, so
+// the client's staleness watchdog couldn't see the stream is alive.
+setInterval(() => { for (const res of sseClients) res.write('event: ping\ndata: {}\n\n'); }, 25000).unref();
 
 // ---------- helpers ----------
 function sendJson(res, code, obj) {

--- a/test/sse.test.js
+++ b/test/sse.test.js
@@ -1,0 +1,73 @@
+'use strict';
+// SSE staleness recovery (papercut #9): the board payload carries a `boot` id
+// naming the server instance, so a client can detect a restart (and refetch)
+// even when EventSource auto-retry reconnects too fast for onerror to matter.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { startServer, freePort } = require('./helper');
+
+// Read the first SSE event from /api/events (the server pushes the full board
+// on connect) and return { event, data }.
+async function firstSseEvent(base) {
+  const res = await fetch(base + '/api/events');
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type'), /text\/event-stream/);
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) throw new Error('stream ended before first event');
+    buf += dec.decode(value, { stream: true });
+    const end = buf.indexOf('\n\n');
+    if (end === -1) continue;
+    reader.cancel().catch(() => {});
+    const frame = buf.slice(0, end);
+    const event = (/^event: (.*)$/m.exec(frame) || [])[1];
+    const data = (/^data: (.*)$/m.exec(frame) || [])[1];
+    return { event, data: data ? JSON.parse(data) : null };
+  }
+}
+
+test('board payload carries a stable per-instance boot id', async () => {
+  const s = await startServer();
+  try {
+    const r1 = await s.api('GET', '/api/board');
+    assert.equal(r1.status, 200);
+    assert.equal(typeof r1.body.boot, 'string');
+    assert.ok(r1.body.boot.length > 0);
+
+    // stable across requests within one server life
+    const r2 = await s.api('GET', '/api/board');
+    assert.equal(r2.body.boot, r1.body.boot);
+
+    // the SSE hello (event: board) carries the same id
+    const ev = await firstSseEvent(s.base);
+    assert.equal(ev.event, 'board');
+    assert.equal(ev.data.boot, r1.body.boot);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('boot id changes across a server restart on the same workspace+port', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-boot-'));
+  const port = await freePort();
+  try {
+    const s1 = await startServer({ dir, port });
+    const boot1 = (await s1.api('GET', '/api/board')).body.boot;
+    await s1.stop();
+
+    const s2 = await startServer({ dir, port });
+    const boot2 = (await s2.api('GET', '/api/board')).body.boot;
+    await s2.stop();
+
+    assert.ok(boot1 && boot2);
+    assert.notEqual(boot2, boot1);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -171,6 +171,13 @@ body.resizing { user-select: none; cursor: col-resize; }
   font-size: 14px; display: flex; align-items: center; justify-content: center; transition: background .15s;
 }
 .composer button:hover { background: var(--accent); color: #06222f; }
+.composer button:disabled { pointer-events: none; }
+.composer button.sending { animation: send-pulse 1s ease-in-out infinite; }
+@keyframes send-pulse { 50% { opacity: .35; } }
+.composer textarea.send-fail { border-color: var(--danger); }
+#chat-send-err {
+  flex: none; padding: 6px 12px 0; font-size: 12px; color: var(--danger);
+}
 
 /* ---------- lieutenant lane (above the columns) ---------- */
 #lane {

--- a/ui/index.html
+++ b/ui/index.html
@@ -73,6 +73,7 @@
       <button id="chat-card-open" title="open card" hidden>open card</button>
     </div>
     <div id="chat-feed"></div>
+    <div id="chat-send-err" hidden></div>
     <form id="chat-form" class="composer">
       <textarea id="chat-input" rows="1" placeholder="message your lieutenant…" autocomplete="off"></textarea>
       <button type="submit" title="send">➤</button>

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -30,5 +30,6 @@ export const api = {
   markThreadRead: (target) => j('POST', '/api/read', { user: 'user', target }),
   labels: (body) => j('POST', '/api/labels', body),
   artifact: (uri) => j('GET', '/api/artifact?uri=' + encodeURIComponent(uri)),
+  board: () => j('GET', '/api/board'),
   config: () => j('GET', '/api/config'),
 };

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -6,7 +6,7 @@ import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, card
 import { api } from './api.js';
 import { esc, hhmm, dayLabel, cardEmoji } from './util.js';
 import { md } from './md.js';
-import { speakMessage } from './voice.js';
+import { speakMessage, trackMessages } from './voice.js';
 
 const feedEl = document.getElementById('chat-feed');
 const titleEl = document.getElementById('chat-title');
@@ -233,17 +233,69 @@ function maybeMarkRead(c, target) {
 }
 
 // ---------- composer ----------
+// The input clears ONLY once the message is confirmed delivered AND visible in
+// the chat timeline; until then the text is the captain's only copy. On failure
+// it stays in the composer with an error indication — never silently eaten.
+const sendBtn = document.querySelector('#chat-form button[type=submit]');
+const sendErrEl = document.getElementById('chat-send-err');
+
 function autoGrow(t) { t.style.height = 'auto'; t.style.height = Math.min(t.scrollHeight, 132) + 'px'; }
+
+// The POST already triggered a broadcast, so the echo normally arrives over SSE
+// within a beat; poll the local state for it, with one direct refetch as a
+// fallback (e.g. the SSE stream is stale and hasn't been reaped yet).
+function threadMsgs(target) {
+  const m = /^card:(.+)$/.exec(target);
+  if (m) { const c = card(m[1]); return (c && c.thread) || []; }
+  const l = lieutenant(target.replace(/^lieutenant:/, ''));
+  return (l && l.chat) || [];
+}
+async function waitForEcho(target, text) {
+  const seen = () => threadMsgs(target).some((m) => m.author === USER && m.text === text);
+  for (let i = 0; i < 20; i++) {
+    if (seen()) return true;
+    if (i === 10) api.board().then((doc) => { S.doc = doc; trackMessages(doc); render(); }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 150));
+  }
+  return seen();
+}
+function setSendError(msg) {
+  inputEl.classList.add('send-fail');
+  sendErrEl.textContent = '⚠ not delivered — ' + msg + '. Your message is still below; try again.';
+  sendErrEl.hidden = false;
+}
+function clearSendError() {
+  inputEl.classList.remove('send-fail');
+  sendErrEl.hidden = true;
+}
+
+let sending = false;
 async function send() {
+  if (sending) return;
   const target = currentTarget();
   if (!target) return;
   const text = inputEl.value.trim();
   if (!text) return;
-  inputEl.value = '';
-  autoGrow(inputEl);
-  try { await api.feedback(target, text); } catch (e) { alert(e.message); }
+  sending = true;
+  clearSendError();
+  sendBtn.disabled = true;
+  sendBtn.classList.add('sending');
+  inputEl.readOnly = true; // the pending text must stay exactly what was sent
+  try {
+    await api.feedback(target, text);
+    if (!(await waitForEcho(target, text))) throw new Error('sent, but no echo from the server');
+    inputEl.value = '';
+  } catch (e) {
+    setSendError(e.message);
+  } finally {
+    sending = false;
+    sendBtn.disabled = false;
+    sendBtn.classList.remove('sending');
+    inputEl.readOnly = false;
+    autoGrow(inputEl);
+  }
 }
-inputEl.oninput = () => autoGrow(inputEl);
+inputEl.oninput = () => { autoGrow(inputEl); clearSendError(); };
 // Enter inserts a newline; Cmd+Enter (mac) or Ctrl+Enter sends.
 inputEl.onkeydown = (e) => {
   if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); }

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -1,5 +1,6 @@
 // boot: SSE, header controls, mobile tabs, render orchestration
 import { S, onRender, render, cards, lieutenants, cardUnread, lieutenantUnread, notifUnreadCount, owedTargets, clearFilters, filtersActive } from './state.js';
+import { api } from './api.js';
 import { trackMessages } from './voice.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
@@ -125,16 +126,54 @@ onRender(() => {
 });
 
 // ---------- SSE ----------
+// A half-open connection after a server restart can sit silent forever without
+// ever firing onerror, leaving a zombie tab. Two defenses:
+//  - staleness watchdog: the server emits a named `ping` every 25s, so >STALE_MS
+//    of total silence means the stream is dead — tear it down and reconnect;
+//  - boot-id: the board payload carries the server instance id, so a restart is
+//    detected even on a fast auto-retry reconnect.
+// Every (re)open also refetches the full board: events missed while stale are
+// gone for good, and the refetch is what heals the tab.
+const STALE_MS = 40000;
+let es = null;
+let lastEventAt = Date.now();
+let serverBoot = null;
+
+function applyBoard(doc) {
+  serverBoot = doc.boot || serverBoot;
+  S.doc = doc;
+  trackMessages(S.doc);
+  render();
+}
+function refetchBoard() {
+  api.board().then(applyBoard).catch(() => {}); // still down — the watchdog retries
+}
 function connect() {
-  const es = new EventSource('/api/events');
+  if (es) es.close();
+  es = new EventSource('/api/events');
   es.addEventListener('board', (e) => {
-    S.doc = JSON.parse(e.data);
-    trackMessages(S.doc);
-    render();
+    lastEventAt = Date.now();
+    const doc = JSON.parse(e.data);
+    const restarted = serverBoot && doc.boot && doc.boot !== serverBoot;
+    applyBoard(doc);
+    if (restarted) refetchBoard(); // new server instance — make sure we hold its current state
   });
-  es.onopen = () => { S.connected = true; renderStatusDot(); };
+  es.addEventListener('ping', () => { lastEventAt = Date.now(); });
+  es.onopen = () => {
+    lastEventAt = Date.now();
+    S.connected = true;
+    renderStatusDot();
+    refetchBoard(); // anything pushed while we were away is unrecoverable — resync
+  };
   es.onerror = () => { S.connected = false; renderStatusDot(); };
 }
 connect();
+setInterval(() => {
+  if (Date.now() - lastEventAt <= STALE_MS) return;
+  lastEventAt = Date.now(); // one reconnect per stale window
+  S.connected = false;
+  renderStatusDot();
+  connect();
+}, 5000);
 renderStatusDot();
 setInterval(render, 60000); // refresh "ago" labels


### PR DESCRIPTION
## What / why

Fixes two coupled UI failures around a server restart (papercuts #9 + #10): the captain's chat messages could silently vanish, and a stale tab never healed itself.

**The failure story:** server restarts → the tab's SSE connection goes half-open and sits silent forever (EventSource never fires `onerror` on a half-open TCP connection) → captain sends a message → the composer cleared the input *before* the POST → the POST fails or the echo never arrives → the message "disappears".

## #10 — composer eats the message (`ui/js/chat.js`)

`send()` cleared the input optimistically before the POST. Now:

- send button gets a **sending** state (disabled + pulse) and the textarea goes read-only for the flight, so the pending text stays exactly what was sent;
- the input clears **only after** the POST succeeds **and** the message is visible in the chat timeline — the POST triggers a broadcast, so the echo normally lands over SSE within a beat; `waitForEcho` polls local state for it (~3s) with one direct `GET /api/board` refetch as fallback;
- on failure the text **stays in the composer** with a red border and an inline "⚠ not delivered" line (cleared on next input/attempt). No more `alert()`.

## #9 — zombie SSE after server restart (`ui/js/main.js` + `server/server.js`)

- **Staleness watchdog:** the client tracks last-received-anything; >40s of total silence → tear the stream down, reconnect, refetch. For the watchdog to see liveness, the server's 25s ping is now a **named `ping` event** instead of an SSE comment (`: ping` is invisible to EventSource — a comment ping can't feed a client-side watchdog).
- **Boot id:** the served board now carries `boot`, a per-instance id (`pid-timestamp` minted at startup). A client seeing it change knows the server restarted and forces a refetch even on a fast auto-retry reconnect.
- **`onopen` always refetches** the full board: events missed while stale/disconnected are gone for good; the refetch is what heals the tab.

Server change is additive and backward-safe: one extra field on the served board payload, ping comment → named event. No shape restructuring.

## Test evidence

- Full suite green: **122/122** (`node --test test/*.test.js`), including 2 new tests in `test/sse.test.js`:
  - board payload (`GET /api/board` **and** the SSE `board` hello) carries a stable `boot` id;
  - `boot` changes across a server restart on the same workspace+port.

## Manual verification (throwaway server on :4899, real Chrome tab)

1. **Happy path:** send a message → button pulses, message appears in the timeline, composer clears.
2. **Send while server dead** (`kill -9`): button re-enables, red border + "⚠ not delivered — Failed to fetch. Your message is still below; try again.", text intact in the composer.
3. **Restart the server** on the same port: tab reconnects and re-renders the persisted board with no manual refresh; the composer still held the undelivered text + error.
4. **Retry after restart:** message delivers, appears in the timeline, composer clears.
5. **True zombie** (`kill -STOP` the server — TCP stays open, stream silent, `onerror` never fires, the exact papercut-#9 condition): within the watchdog window the status dot flipped to "disconnected — reconnecting…". After `kill -CONT` + posting a fresh lieutenant message via the API, the tab healed itself: dot green, new message rendered, no refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
