### PR TITLE
feat: worker↔lieutenant comms plumbing — worker send + worker-said notify (papercuts #1, #7)

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -524,6 +524,11 @@ async function cmdStart() {
       '  --resume reincarnates the card\'s recorded (dead) worker in the same worktree.\n' +
       '  --model overrides the spawned worker\'s model (e.g. claude-fable-5); ignored with --resume.');
   }
+  if (opts.resume && opts.briefFile) {
+    die('--resume does not deliver briefs: the reincarnated worker keeps its own context and the\n' +
+      'brief would be silently dropped. To hand a live worker new instructions:\n' +
+      '  bc-axi worker send ' + id + ' --text-file <f|->');
+  }
   const body = { actor: opts.actor || 'agent' };
   if (opts.briefFile) body.brief = readInput(opts.briefFile);
   if (opts.resume) body.resume = true;
@@ -560,6 +565,23 @@ async function cmdWorkerDone() {
     { outcome, actor: opts.actor || 'worker' });
   const prs = (r.card.attributes && r.card.attributes.prs) || [];
   console.log('done -> ' + id + ' (owner notified' + (prs.length ? '; prs: ' + prs.map((p) => p.url).join(' ') : '') + ')');
+}
+
+// worker.send — the lieutenant side: hand a LIVE worker new instructions,
+// delivered into its session by the server through the harness typer
+// (verified submission — the same send half captain-feedback delivery uses).
+async function cmdWorkerSend() {
+  const id = positional[0];
+  const text = opts.textFile ? readInput(opts.textFile).trim() : positional.slice(1).join(' ').trim();
+  if (!id || !text) {
+    die('usage: bc-axi worker send <card-id> "<instructions>" [--text-file f|-]\n' +
+      '  Deliver text into the card\'s live worker session (typed + verified submission).\n' +
+      '  Errors when no live worker is bound — resume one first: card start <card-id> --resume.');
+  }
+  // The server types into a real pane with submit verification/retries — allow it time.
+  const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/worker/send',
+    { text, actor: opts.actor || 'agent' }, 60000);
+  console.log('sent -> worker ' + r.session + ' (card ' + id + ')');
 }
 
 // ---------- projects (F6) ----------
@@ -641,6 +663,9 @@ async function cmdDrain() {
     } else if (it.kind === 'worker-signal') {
       head = 'worker milestone — ' + cardBit(it.card);
       hint = 'note it; act only if it changes your plan';
+    } else if (it.kind === 'worker-said') {
+      head = 'worker said — ' + cardBit(it.card);
+      hint = 'read the thread (bc-axi thread card:' + it.card + ') and act; steer the worker: bc-axi worker send ' + it.card + ' --text-file <f|->';
     } else if (it.kind === 'worker-done') {
       head = 'WORKER DONE — ' + cardBit(it.card);
       hint = 'verify the work in its worktree (read the diff/branch, not just the outcome text), rewrite the card body to current state (bc-axi card patch ' + it.card + ' --body-file <f|->), then hand off: bc-axi card move ' + it.card + ' review';
@@ -746,7 +771,7 @@ const commands = {
   'card create': cmdCreate, 'card move': cmdMove, 'card patch': cmdPatch,
   'card archive': cmdArchive, 'card restore': cmdRestore, 'card show': cmdShow,
   'card start': cmdStart,
-  'worker signal': cmdWorkerSignal, 'worker done': cmdWorkerDone,
+  'worker signal': cmdWorkerSignal, 'worker done': cmdWorkerDone, 'worker send': cmdWorkerSend,
   show: cmdShow, // alias for card show
   event: cmdEvent, notify: cmdNotify,
   say: cmdSay, drain: cmdDrain, ack: cmdAck,
@@ -807,7 +832,11 @@ if (!commands[cmd]) {
     '                                         worker session (brief as launch prompt), session/worktree/\n' +
     '                                         branch bound to the card, card -> Working. Refuses plan\n' +
     '                                         cards, Working cards, and unregistered repos. --resume\n' +
-    '                                         reincarnates the recorded worker (after worker-died)\n' +
+    '                                         reincarnates the recorded worker (after worker-died);\n' +
+    '                                         it never takes --brief-file (use worker send instead)\n' +
+    '  worker send <card-id> "<instructions>" [--text-file f|-]\n' +
+    '                                         hand a LIVE worker new instructions: typed into its\n' +
+    '                                         session with verified submission (run by the lieutenant)\n' +
     '\nworker (run by the worker itself, from its worktree):\n' +
     '  worker signal <card-id> "<milestone>" [--text-file f|-]\n' +
     '                                         real milestone -> level-2 card event + QueueItem to owner\n' +
@@ -821,7 +850,9 @@ if (!commands[cmd]) {
     '  notify [--kind K] [--text-file f|-]    board-level notification (no card)\n' +
     '  say <lieutenant:ID|card:ID> [--actor a] [--text-file f|-]\n' +
     '                                         post a chat message; a card thread\'s interlocutor is\n' +
-    '                                         the owning lieutenant (lieutenant-main says also notify)\n' +
+    '                                         the owning lieutenant (lieutenant-main says also notify).\n' +
+    '                                         A card-thread say by anyone but the owner (e.g. its\n' +
+    '                                         worker) also queues a worker-said item waking the owner\n' +
     '\ndelivery (at-least-once):\n' +
     '  drain [--lieutenant <id>] [--json]     print pending QueueItems with card context and a\n' +
     '    next-action hint per item (--json: raw JSON lines). Captain messages, start/rework\n' +

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -38,7 +38,7 @@ columns; each lieutenant has a color, and its cards carry that color stripe.
 | Worker | Implementation agent bound 1:1 to a Working card: tmux session + isolated worktree (+ delivery pipeline per project mode). Ephemeral — dies with the card's Working state |
 | Event | Card timeline entry: `text`, `level` (1 = bell, 2 = timeline only), `actor`, `kind` (open token; the board's kinds registry maps kind → emoji + default level) |
 | Message | Chat utterance. `target`: a lieutenant's main chat or a card thread. A card thread is a **context folder**: the interlocutor is always the owning lieutenant, never the worker |
-| QueueItem | One durable delivery to a lieutenant. Kinds: captain `message`, `start-order`, `rework-order`, `card-created` / `card-moved` (captain acts echoed to the owner), `worker-signal`, `worker-stopped`, `worker-died`, `worker done`, `pr-merged`, `pr-closed`. `seq`-ordered, at-least-once |
+| QueueItem | One durable delivery to a lieutenant. Kinds: captain `message`, `start-order`, `rework-order`, `card-created` / `card-moved` (captain acts echoed to the owner), `worker-signal`, `worker-said` (a non-owner posted on the card thread), `worker-stopped`, `worker-died`, `worker done`, `pr-merged`, `pr-closed`. `seq`-ordered, at-least-once |
 | Archive | Append-only frozen card snapshots with `reason`; `card.restore` resurrects with full state and a loud level-1 event (a snapshot frozen in Working restores to Backlog — only `card.start` may enter Working) |
 | Label | Board-level tag registry: name + color, palette auto-assigned; cards carry label names |
 
@@ -135,6 +135,8 @@ Harness working state (session ids, prompts, turn-end logs) lives in the workspa
 | captain creates / moves a card | `card-created` / `card-moved` QueueItem to the owner (awareness, not an order) |
 | `card.start` | worker spawned (worktree + session), card → Working, level-2 event |
 | `chat.say` by captain | QueueItem (write-ahead) + `harness.send` wake to the owning lieutenant |
+| `chat.say` on a card thread by anyone but the owning lieutenant (its worker, a peer, unidentified tooling) | `worker-said` QueueItem waking the owner — the thread alone notifies nobody |
+| `worker.send` by the lieutenant | text typed into the card's live worker session (harness `send`, verified submission) + level-2 event; loud error without a live worker. `card.start --resume` refuses a brief and points here |
 | worker signal | level-2 event on card + QueueItem to the owning lieutenant |
 | worker turn-end without `done` (card still Working) | `worker-stopped` QueueItem to the owner + level-2 event, immediately — a stopped worker is never invisible |
 | worker done + lieutenant review | lieutenant rewrites body, moves → Your review — the level-1 handoff |

--- a/server/server.js
+++ b/server/server.js
@@ -982,6 +982,11 @@ async function doStartCard(card, body) {
 
   const existing = findWorker(card.id);
   if (body && body.resume) {
+    if (body.brief) {
+      return { error: 'resume does not deliver briefs — the reincarnated worker keeps its own context '
+        + 'and the brief would be silently dropped. To hand a live worker new instructions: '
+        + 'bc-axi worker send ' + card.id + ' --text-file <f|->' };
+    }
     if (!existing) return { error: 'nothing to resume: card ' + card.id + ' has no recorded worker' };
     let ref;
     try {
@@ -1117,6 +1122,37 @@ function workerDone(card, body) {
   card.updated = now();
   queuePush(card.owner, { kind: 'worker-done', card: card.id, text: outcome.slice(0, 2000) });
   return { ok: true, event: ev };
+}
+
+// worker.send — lieutenant -> live worker: deliver text into the worker's
+// session through the harness typer (verified submission), the same send half
+// captain-feedback delivery uses for its wake. Workers have no queue, so the
+// pane IS the delivery — the send is awaited and its real outcome reported;
+// a level-2 card event records what was handed over.
+async function workerSend(card, body) {
+  const text = String((body && body.text) || '').trim();
+  if (!text) return { error: 'text required' };
+  const w = findWorker(card.id);
+  if (!w) {
+    return { error: 'no worker bound to card ' + card.id + ' — start one first (card start ' + card.id + ')', code: 404 };
+  }
+  if (w.done) {
+    return { error: 'worker for ' + card.id + ' already reported done — spawn a fresh one (card start ' + card.id + ') instead of sending into a finished session', code: 409 };
+  }
+  let up = false;
+  try { up = await harnessFor(w.ref).alive(w.ref); } catch (e) { up = false; }
+  if (!up) {
+    return { error: 'worker session ' + w.ref.session + ' is not alive — resume it first (card start ' + card.id + ' --resume), then send', code: 409 };
+  }
+  try {
+    await harnessFor(w.ref).send(w.ref, text);
+  } catch (e) {
+    return { error: 'delivery to ' + w.ref.session + ' failed: ' + String((e && e.message) || e), code: 502 };
+  }
+  const ev = mkEvent({ text: 'sent to worker: ' + text.slice(0, 1900), actor: (body && body.actor) || 'agent' }, { kind: 'worker-send' });
+  card.events.push(ev);
+  card.updated = now();
+  return { ok: true, event: ev, session: w.ref.session };
 }
 
 // ---------- supervision loop (invariant 8: supervision is infrastructure) ----------
@@ -1472,7 +1508,7 @@ const server = http.createServer(async (req, res) => {
       saveBoard(); broadcast();
       return sendJson(res, 200, { ok: true, card: publicCard(r.card, 'user'), event: r.event });
     }
-    const cardRoute = /^\/api\/cards\/([^/]+)(\/(move|events|archive|status|start|worker\/signal|worker\/done))?$/.exec(p);
+    const cardRoute = /^\/api\/cards\/([^/]+)(\/(move|events|archive|status|start|worker\/signal|worker\/done|worker\/send))?$/.exec(p);
     if (cardRoute) {
       const card = findCard(decodeURIComponent(cardRoute[1]));
       if (!card) return sendJson(res, 404, { error: 'unknown card: ' + decodeURIComponent(cardRoute[1]) });
@@ -1488,6 +1524,12 @@ const server = http.createServer(async (req, res) => {
         if (r.error) return sendJson(res, 400, { error: r.error });
         saveBoard(); broadcast();
         return sendJson(res, 200, { ok: true, event: r.event });
+      }
+      if (sub === 'worker/send' && req.method === 'POST') {
+        const r = await workerSend(card, JSON.parse(await readBody(req) || '{}'));
+        if (r.error) return sendJson(res, r.code || 400, { error: r.error });
+        saveBoard(); broadcast();
+        return sendJson(res, 200, { ok: true, event: r.event, session: r.session });
       }
       if (sub === 'worker/done' && req.method === 'POST') {
         const r = workerDone(card, JSON.parse(await readBody(req) || '{}'));
@@ -1604,7 +1646,19 @@ const server = http.createServer(async (req, res) => {
       const m = /^card:(.+)$/.exec(target);
       if (m) {
         const card = findCard(m[1]);
-        if (card) { card.updated = now(); if (!card.threadStart) card.threadStart = msg.ts; }
+        if (card) {
+          card.updated = now(); if (!card.threadStart) card.threadStart = msg.ts;
+          // A card-thread say from anyone but the owning lieutenant — its own
+          // worker (whose session resolves to no lieutenant), a peer, raw
+          // tooling — must WAKE the owner: the thread alone notifies nobody.
+          // Default-notify: only a session-identified owner is exempt (author
+          // names can't be trusted — an unidentified worker is stamped with
+          // the owner's name). Captain messages ride /api/feedback, never here.
+          const fromOwner = !!(caller && caller.id === card.owner);
+          if (!fromOwner && msg.author !== 'user') {
+            queuePush(card.owner, { kind: 'worker-said', card: card.id, target, author: msg.author, text: text.slice(0, 2000) });
+          }
+        }
       } else {
         // A free-form lieutenant message in its main chat is a level-1 notification.
         const ev = mkEvent({ text: text.slice(0, 200), actor: msg.author, level: body.level, kind: body.kind }, { level: 1 });

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -106,6 +106,47 @@ test('cli: say self-identifies by its tmux session', async () => {
   }
 });
 
+test('card-thread say by a non-owner queues a worker-said item waking the owner; the identified owner is exempt', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    // grace owns the card and HAS a session ref (so she can be identified as the owner)
+    await s.api('POST', '/api/lieutenants', { name: 'Grace', id: 'grace', ref: { harness: 'fake', session: 'bc-grace', cwd: '/tmp' } });
+    await s.api('POST', '/api/cards', { title: 'Watched', owner: 'grace' });
+
+    // an unidentified caller (a worker's tmux session resolves to no lieutenant)
+    // → durable worker-said item for the owner, on top of the thread message
+    let r = await s.api('POST', '/api/message', { target: 'card:watched', text: 'EMERGENCY: the PR looks spurious', session: 'bc-w-nobody' });
+    assert.strictEqual(r.status, 200);
+    let items = (await s.api('GET', '/api/feed?lieutenant=grace')).body.items;
+    assert.strictEqual(items.length, 1);
+    assert.strictEqual(items[0].kind, 'worker-said');
+    assert.strictEqual(items[0].card, 'watched');
+    assert.strictEqual(items[0].target, 'card:watched');
+    assert.strictEqual(items[0].text, 'EMERGENCY: the PR looks spurious');
+
+    // a peer lieutenant (identified, NOT the owner) also notifies, stamped as itself
+    await s.api('POST', '/api/message', { target: 'card:watched', text: 'peer heads-up', session: 'bc-' + LT });
+    await s.api('POST', '/api/lieutenants', { name: 'Hopper', id: 'hopper', ref: { harness: 'fake', session: 'bc-hopper', cwd: '/tmp' } });
+    await s.api('POST', '/api/message', { target: 'card:watched', text: 'from hopper', session: 'bc-hopper' });
+    items = (await s.api('GET', '/api/feed?lieutenant=grace')).body.items;
+    const hop = items.find((i) => i.text === 'from hopper');
+    assert.ok(hop, 'peer say queued');
+    assert.strictEqual(hop.kind, 'worker-said');
+    assert.strictEqual(hop.author, 'Hopper');
+
+    // the owner replying on her OWN card thread never self-notifies
+    const before = (await s.api('GET', '/api/feed?lieutenant=grace')).body.items.length;
+    await s.api('POST', '/api/message', { target: 'card:watched', text: 'on it', session: 'bc-grace' });
+    items = (await s.api('GET', '/api/feed?lieutenant=grace')).body.items;
+    assert.strictEqual(items.length, before, 'no worker-said for the owner\'s own reply');
+    // …but her reply DID land on the thread
+    const card = (await s.api('GET', '/api/cards/watched')).body;
+    assert.strictEqual(card.thread[card.thread.length - 1].text, 'on it');
+  } finally {
+    await s.stop();
+  }
+});
+
 test('captain feedback lands in the thread and queues a message item to the owner', async () => {
   const s = await startServerWithLieutenant();
   try {

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -95,11 +95,24 @@ test('cli card create / board / say / drain / ack round-trip against a test serv
     // lieutenant reply via say (interlocutor default: the owning lieutenant)
     const sayFile = path.join(s.dir, 'reply.md');
     fs.writeFileSync(sayFile, 'on it, captain');
-    r = await runCli(['say', 'card:cli-card', '--text-file', sayFile, ...args]);
+    r = await runCli(['say', 'card:cli-card', '--text-file', sayFile, ...args], { TMUX: '' });
     assert.strictEqual(r.code, 0, r.stderr);
     const card = (await s.api('GET', '/api/cards/cli-card')).body;
     assert.strictEqual(card.thread[1].author, 'Ada');
     assert.strictEqual(card.thread[1].text, 'on it, captain');
+
+    // an UNIDENTIFIED card-thread say default-notifies the owner (worker-said);
+    // only a session-identified owner is exempt (Ada here has no ref)
+    r = await runCli(['drain', '--lieutenant', LT, '--json', ...args]);
+    const said = r.stdout.trim().split('\n').map((l) => JSON.parse(l));
+    assert.strictEqual(said.length, 1);
+    assert.strictEqual(said[0].kind, 'worker-said');
+    assert.strictEqual(said[0].text, 'on it, captain');
+    r = await runCli(['drain', '--lieutenant', LT, ...args]);
+    assert.match(r.stdout, /worker said — card cli-card/);
+    assert.match(r.stdout, /bc-axi worker send cli-card/);
+    r = await runCli(['ack', String(said[0].seq), ...args]);
+    assert.strictEqual(r.code, 0, r.stderr);
 
     // lieutenant handoff via the CLI
     r = await runCli(['card', 'move', 'cli-card', 'review', ...args]);

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -371,3 +371,59 @@ test('fresh restart after done: refuses over a live session; releases the dead o
     fs.rmSync(root, { recursive: true, force: true });
   }
 });
+
+test('worker send: delivers into the live worker session + level-2 card event; loud errors when it cannot', async () => {
+  const { s, fdir, teardown } = await boot();
+  try {
+    const wsArgs = ['--workspace', s.dir, '--port', String(s.port)];
+
+    // no worker bound → clear error, API and CLI
+    await s.api('POST', '/api/cards', withOwner({ title: 'Steer', id: 'steer', attributes: { repo: 'proj' } }));
+    let r = await s.api('POST', '/api/cards/steer/worker/send', { text: 'too early' });
+    assert.strictEqual(r.status, 404);
+    assert.match(r.body.error, /no worker bound/);
+    let cli = await runCli(['worker', 'send', 'steer', 'too early', ...wsArgs]);
+    assert.strictEqual(cli.code, 1);
+    assert.match(cli.stderr, /no worker bound/);
+
+    // live worker → text typed into its session (the fake logs sends), event recorded
+    assert.strictEqual((await s.api('POST', '/api/cards/steer/start', { harness: 'fake' })).status, 200);
+    const sess = workerSession(s.dir, 'steer');
+    cli = await runCli(['worker', 'send', 'steer', 'also fix the flaky test', ...wsArgs]);
+    assert.strictEqual(cli.code, 0, cli.stderr);
+    assert.match(cli.stdout, /sent -> worker /);
+    const sends = fs.readFileSync(path.join(fdir, sess + '.sends.jsonl'), 'utf8')
+      .trim().split('\n').map((l) => JSON.parse(l));
+    assert.deepStrictEqual(sends.map((x) => x.text), ['also fix the flaky test']);
+    const card = (await s.api('GET', '/api/cards/steer')).body;
+    const ev = card.events[card.events.length - 1];
+    assert.strictEqual(ev.kind, 'worker-send');
+    assert.strictEqual(ev.level, 2);
+    assert.match(ev.text, /also fix the flaky test/);
+
+    // empty text rejected; a done worker refuses (spawn fresh instead)
+    assert.strictEqual((await s.api('POST', '/api/cards/steer/worker/send', { text: '  ' })).status, 400);
+    await s.api('POST', '/api/cards/steer/worker/done', { outcome: 'landed' });
+    r = await s.api('POST', '/api/cards/steer/worker/send', { text: 'one more thing' });
+    assert.strictEqual(r.status, 409);
+    assert.match(r.body.error, /already reported done/);
+  } finally { await teardown(); }
+});
+
+test('card start --resume refuses a brief and points at worker send (API + CLI)', async () => {
+  const { s, teardown } = await boot();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Rez', id: 'rez', attributes: { repo: 'proj' } }));
+    await s.api('POST', '/api/cards/rez/start', { harness: 'fake' });
+    const r = await s.api('POST', '/api/cards/rez/start', { resume: true, brief: 'new instructions' });
+    assert.strictEqual(r.status, 400);
+    assert.match(r.body.error, /worker send rez/);
+    // the CLI refuses loudly before even reaching the server
+    const bf = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(bf, 'new instructions');
+    const cli = await runCli(['card', 'start', 'rez', '--resume', '--brief-file', bf,
+      '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(cli.code, 1);
+    assert.match(cli.stderr, /worker send rez/);
+  } finally { await teardown(); }
+});


### PR DESCRIPTION
## What / why

Two comms gaps between a lieutenant and a live worker (papercuts #1 + #7), both in the same plumbing — getting words to/from a worker session:

1. **Lieutenant → worker had no verb.** `card start --resume` silently ignored `--brief-file`, and the only workaround was raw `tmux load-buffer`/`send-keys`.
2. **Worker → lieutenant `say` vanished.** A worker posting `bc-axi say card:<id>` landed on the thread + UI broadcast but created no QueueItem, so the owner was never woken. Real incident: an emergency report sat unseen.

## What changed

**CLI (`cli/bc-axi`)**
- New verb `bc-axi worker send <card-id> "<instructions>"` (or `--text-file f|-`): POSTs to the new route; 60s timeout since the server types into a real pane with submit verification.
- `card start --resume --brief-file` now dies loudly, pointing at `worker send` (server rejects it too, for API callers).
- `drain` renders the new `worker-said` kind with a read-the-thread / steer hint; usage text updated.

**Server (`server/server.js`)**
- `workerSend(card, body)` + route `POST /api/cards/:id/worker/send`: resolves the worker via `findWorker`, refuses when none is bound (404), when it already reported done (409), or when its session is dead (409 → "resume first"). Delivery reuses the existing harness `send()` (the verified-submission typer used by captain-feedback wakes — no second mechanism). Awaited, so the response reports the real outcome; a level-2 `worker-send` card event records what was handed over. Workers have no queue, so the pane IS the delivery.
- `POST /api/message` on a card thread: when the caller is not the session-identified owning lieutenant, also `queuePush(card.owner, { kind: 'worker-said', … })` — write-ahead + send-keys wake, exactly like `worker-signal`. Default-notify: author names can't be trusted (an unidentified worker is stamped with the owner's name — precisely the incident case), so only a session-identified owner is exempt. Captain messages ride `/api/feedback`, never this route.
- Payload/route shapes backward-safe: new route + new optional QueueItem fields (`author`, `target`) only.

**Docs** — `docs/api/overview.md` QueueItem kinds + side-effects table updated.

## Test evidence

`node --test test/*.test.js` → **123 pass, 0 fail** (was 121; +2 new test blocks, 1 extended).

- `workers.test.js`: `worker send` end-to-end against the file-backed fake harness — text observed in the fake's `sends.jsonl`, level-2 `worker-send` event on the card; clean errors for no-worker (API + CLI), empty text, done worker; `--resume` + brief refused by API and CLI.
- `chat.test.js`: non-owner card-thread say → durable `worker-said` item for the owner (unidentified caller and identified peer, author stamped); session-identified owner reply → no self-notification.
- `cli.test.js`: round-trip extended — unidentified CLI say now drains as `worker-said` and acks clean.

## Manual verification (real tmux pane)

The tmux typing path (`harness/claude-tmux.js send`) can't run in the test env (no real pane); it is the same code path already exercised in production by captain-feedback wakes. To verify live after deploy:

1. Start a worker on any card, let it go idle.
2. `bc-axi worker send <card-id> "please also update the README"` → text appears in the worker pane, submits (verified — Enter retried, never the text), worker acts on it; card timeline shows the `worker-send` event.
3. From the worker's worktree: `bc-axi say card:<card-id> --text-file <f>` → owning lieutenant's next drain shows a `worker-said` item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
