### PR TITLE
fix(ui): stop full-page re-render flicker (papercut #12)

### DIFF
--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -2,7 +2,7 @@
 // move menu, new-card / new-lieutenant modals.
 import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, lieutenantUnread, cardVisible, cardStatus, cardRecency, targetOwed, targetOwedStale, toggleFilter, filterSelected, render } from './state.js';
 import { api } from './api.js';
-import { esc, ago, cardEmoji, cardPrs, prChipHtml } from './util.js';
+import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, setHtmlIfChanged } from './util.js';
 import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
@@ -43,8 +43,9 @@ function ltCardHtml(l) {
 }
 
 function renderLane() {
-  laneEl.innerHTML = lieutenants().map(ltCardHtml).join('') +
+  const html = lieutenants().map(ltCardHtml).join('') +
     '<button class="lt-add" title="new lieutenant">＋ lieutenant</button>';
+  if (!setHtmlIfChanged(laneEl, html)) return; // unchanged — keep the DOM (and its handlers)
   laneEl.querySelectorAll('.lt-card').forEach((el) => {
     el.onclick = (e) => {
       if (e.target.closest('.lt-menu')) { e.stopPropagation(); openLtMenu(el.dataset.id, e.clientX, e.clientY); return; }
@@ -132,30 +133,33 @@ function tileHtml(c) {
     '<span class="grow"></span>' +
     (hasLink ? '<span class="t-ind" title="has link">📎</span>' : '') +
     (msgs ? '<span class="t-ind" title="' + msgs + ' messages">💬' + msgs + '</span>' : '') +
-    '<span class="t-ago">' + ago(cardRecency(c)) + '</span>' +
+    agoSpanHtml(cardRecency(c), 't-ago') +
     '</div></div>';
 }
 
 export function renderBoard() {
   renderLane();
+  const cols = columns();
+  const html = !cols.length
+    ? '<div class="empty">waiting for board…</div>'
+    : cols.map((col) => {
+      const list = cards().filter((c) => c.column === col.id && cardVisible(c)).sort(byRecency);
+      return '<div class="column" data-id="' + esc(col.id) + '"><h2><span>' + esc(col.title || col.id) + '</span>' +
+        '<span class="count">' + list.length + '</span>' +
+        '<button class="add-card" title="new card here">+</button></h2>' +
+        '<div class="cards">' + list.map(tileHtml).join('') + '</div></div>';
+    }).join('');
+  // unchanged markup = leave the DOM (and scroll/selection/handlers) alone;
+  // only a real change pays the rebuild + scroll save/restore
+  if (boardEl.__bcHtml === html) return;
+  boardEl.__bcHtml = html;
   const sx = boardEl.scrollLeft;
   const colScroll = {};
   boardEl.querySelectorAll('.column').forEach((col) => {
     colScroll[col.dataset.id] = col.querySelector('.cards').scrollTop;
   });
-
-  const cols = columns();
-  if (!cols.length) {
-    boardEl.innerHTML = '<div class="empty">waiting for board…</div>';
-    return;
-  }
-  boardEl.innerHTML = cols.map((col) => {
-    const list = cards().filter((c) => c.column === col.id && cardVisible(c)).sort(byRecency);
-    return '<div class="column" data-id="' + esc(col.id) + '"><h2><span>' + esc(col.title || col.id) + '</span>' +
-      '<span class="count">' + list.length + '</span>' +
-      '<button class="add-card" title="new card here">+</button></h2>' +
-      '<div class="cards">' + list.map(tileHtml).join('') + '</div></div>';
-  }).join('');
+  boardEl.innerHTML = html;
+  if (!cols.length) return;
   boardEl.scrollLeft = sx;
   boardEl.querySelectorAll('.column').forEach((col) => {
     if (colScroll[col.dataset.id] != null) col.querySelector('.cards').scrollTop = colScroll[col.dataset.id];

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -4,7 +4,7 @@
 // premium composer.
 import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, cardStatus, cardActivityTs, render, threadUnread, targetOwed, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
-import { esc, hhmm, dayLabel, cardEmoji } from './util.js';
+import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged } from './util.js';
 import { md } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
 
@@ -78,10 +78,6 @@ backBtn.onclick = backToMain;
 openBtn.onclick = () => { if (S.chatMode && S.chatMode.mode === 'card' && detailOpener) detailOpener(S.chatMode.id); };
 
 // ---------- feed rendering ----------
-// lieutenant messages rendered this pass, in DOM order, so a post-render pass can
-// wire each .msg.agent[data-speak] button to the right message's text without ever
-// interpolating message text into markup (XSS-safe).
-let speakMsgs = [];
 function msgHtml(m) {
   const mine = m.author === USER;
   const body = mine
@@ -91,7 +87,6 @@ function msgHtml(m) {
   // speak button only on lieutenant bubbles; 🔊 icon, no message text in markup
   const speakBtn = mine ? '' :
     '<button class="msg-speak" type="button" data-speak title="read this message aloud" aria-label="read this message aloud">🔊</button>';
-  if (!mine) speakMsgs.push(m);
   return '<div class="msg ' + (mine ? 'user' : 'agent') + '">' + body +
     '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
 }
@@ -117,9 +112,20 @@ function mainFeedMsgs() {
 }
 
 // a main chat collapses older history behind one expander; expansion is
-// client-side only and resets on page load
+// client-side only and resets on page load. The cutoff is ANCHORED when the
+// conversation is first shown (not "always the last 30"): new arrivals extend
+// the visible window downward without shifting it, which keeps the earlier
+// blocks' markup stable so the append fast-path below can run.
 const COLLAPSE_KEEP = 30;
 let mainExpanded = false;
+let collapsedHidden = -1; // -1 = recompute on next render (conversation switch)
+
+// What the feed currently shows: per-block html (a block = one message with
+// its day divider merged in, or the history expander) plus the trailing typing
+// indicator. Diffed on every render: identical = leave the DOM alone; new
+// blocks at the end only = append them without touching the earlier DOM (no
+// flicker, no scroll/selection reset); anything else = full rebuild.
+let feed = { key: null, blocks: [], tail: '' };
 
 // the conversation currently shown; a change means "jump to the newest message"
 let lastViewKey = null;
@@ -130,15 +136,35 @@ function scrollFeedToBottom() {
   requestAnimationFrame(() => { jump(); requestAnimationFrame(jump); });
 }
 
+// Wire the speak buttons of freshly (re)built blocks. Buttons not yet wired
+// appear in DOM order and map 1:1 to the given blocks' lieutenant messages, so
+// message text never needs to be interpolated into markup (XSS-safe).
+function wireSpeak(blocks, target) {
+  const msgs = blocks.filter((b) => b.msg).map((b) => b.msg);
+  const btns = feedEl.querySelectorAll('.msg.agent [data-speak]:not([data-wired])');
+  btns.forEach((btn, i) => {
+    const m = msgs[i];
+    if (!m) return;
+    btn.setAttribute('data-wired', '');
+    const key = target + '|' + m.ts + '|' + m.author; // stable per message, for toggle-off
+    btn.onclick = (e) => {
+      e.stopPropagation();
+      const spoke = speakMessage(m.text, key);
+      btn.classList.toggle('speaking', spoke);
+    };
+  });
+}
+
 export function renderChat() {
   const target = currentTarget();
   if (!target) {
     backBtn.hidden = true;
     openBtn.hidden = true;
-    titleEl.textContent = '💬 chat';
+    setHtmlIfChanged(titleEl, '💬 chat');
     inputEl.placeholder = 'create a lieutenant to start…';
     inputEl.disabled = true;
-    feedEl.innerHTML = '<div class="empty">no lieutenants yet — add one above the board to start commanding</div>';
+    if (feed.key !== '') feedEl.innerHTML = '<div class="empty">no lieutenants yet — add one above the board to start commanding</div>';
+    feed = { key: '', blocks: [], tail: '' };
     return;
   }
   inputEl.disabled = false;
@@ -149,11 +175,9 @@ export function renderChat() {
 
   backBtn.hidden = !isCard;
   openBtn.hidden = !isCard;
-  if (isCard) {
-    titleEl.textContent = cardEmoji(c) + ' ' + (c.title || c.id);
-  } else {
-    titleEl.innerHTML = '<span class="lt-dot" style="background:' + esc(lieutenantColor(lt.id)) + '"></span> ' + esc(ltName);
-  }
+  setHtmlIfChanged(titleEl, isCard
+    ? esc(cardEmoji(c) + ' ' + (c.title || c.id))
+    : '<span class="lt-dot" style="background:' + esc(lieutenantColor(lt.id)) + '"></span> ' + esc(ltName));
   inputEl.placeholder = isCard ? 'message ' + ltName + ' about this card…' : 'message ' + ltName + '…';
 
   // Land at the newest message when the visible conversation changes (first
@@ -161,54 +185,64 @@ export function renderChat() {
   // feed was already near the bottom; otherwise leave the reader's scroll be.
   const viewKey = target + '|' + (window.innerWidth <= 760 ? S.view : 'desktop');
   const switched = viewKey !== lastViewKey;
-  if (switched) mainExpanded = false; // each conversation starts collapsed
   lastViewKey = viewKey;
+  if (target !== feed.key) { mainExpanded = false; collapsedHidden = -1; } // each conversation starts collapsed
   const pinned = feedEl.scrollHeight - feedEl.scrollTop - feedEl.clientHeight < 48;
-  speakMsgs = [];
-  let html = '', lastDay = '';
-  const push = (ts, itemHtml) => {
-    const day = ts ? dayLabel(ts) : '';
-    if (day && day !== lastDay) { html += '<div class="feed-day">' + esc(day) + '</div>'; lastDay = day; }
-    html += itemHtml;
+
+  const blocks = []; // {html, msg?} — msg only on lieutenant bubbles, for speak wiring
+  let lastDay = '';
+  const push = (m) => {
+    const day = m.ts ? dayLabel(m.ts) : '';
+    let h = '';
+    if (day && day !== lastDay) { h += '<div class="feed-day">' + esc(day) + '</div>'; lastDay = day; }
+    blocks.push({ html: h + msgHtml(m), msg: m.author === USER ? null : m });
   };
   if (isCard) {
-    for (const m of c.thread || []) push(m.ts, msgHtml(m));
+    for (const m of c.thread || []) push(m);
   } else {
     // only the newest COLLAPSE_KEEP messages render by default; older history
-    // sits behind the expander. msgHtml runs only for visible messages so the
-    // speak-button ↔ speakMsgs DOM-order mapping stays 1:1.
+    // sits behind the expander (anchored cutoff — see collapsedHidden above)
     const msgs = mainFeedMsgs();
-    const hidden = mainExpanded ? 0 : Math.max(0, msgs.length - COLLAPSE_KEEP);
-    if (hidden) html += '<button class="feed-expand" type="button">show earlier messages (' + hidden + ')</button>';
-    for (const m of msgs.slice(hidden)) push(m.ts, msgHtml(m));
+    if (collapsedHidden < 0) collapsedHidden = Math.max(0, msgs.length - COLLAPSE_KEEP);
+    const hidden = mainExpanded ? 0 : Math.min(collapsedHidden, msgs.length);
+    if (hidden) blocks.push({ html: '<button class="feed-expand" type="button">show earlier messages (' + hidden + ')</button>' });
+    for (const m of msgs.slice(hidden)) push(m);
   }
-  if (targetOwed(target)) html += typingHtml(targetOwedStale(target), ltName);
-  feedEl.innerHTML = html || '<div class="empty">no messages yet</div>';
-  if (switched) scrollFeedToBottom(); // deferred: the feed may still be hidden this frame
-  else if (pinned) feedEl.scrollTop = feedEl.scrollHeight;
+  const tail = targetOwed(target) ? typingHtml(targetOwedStale(target), ltName) : '';
 
-  // expander: reveal the full history, keeping the reader's place (content is
-  // inserted above, so anchor scrollTop by the height delta)
-  const expandBtn = feedEl.querySelector('.feed-expand');
-  if (expandBtn) expandBtn.onclick = () => {
-    const prevH = feedEl.scrollHeight, prevTop = feedEl.scrollTop;
-    mainExpanded = true;
-    renderChat();
-    feedEl.scrollTop = prevTop + (feedEl.scrollHeight - prevH);
-  };
+  const prev = feed;
+  feed = { key: target, blocks, tail };
+  const prefixOk = target === prev.key && blocks.length >= prev.blocks.length &&
+    prev.blocks.every((b, i) => b.html === blocks[i].html);
+  if (prefixOk && blocks.length === prev.blocks.length && tail === prev.tail) {
+    // nothing visible changed — leave the DOM (and the reader) alone
+    if (switched) scrollFeedToBottom();
+  } else if (prefixOk && prev.blocks.length) {
+    // append-only delta: swap the typing indicator, add the new blocks at the
+    // end; the earlier DOM — scroll, selection, focus — is never touched
+    const typingEl = feedEl.querySelector('.msg.typing');
+    if (typingEl) typingEl.remove();
+    const fresh = blocks.slice(prev.blocks.length);
+    feedEl.insertAdjacentHTML('beforeend', fresh.map((b) => b.html).join('') + tail);
+    wireSpeak(fresh, target);
+    if (switched) scrollFeedToBottom();
+    else if (pinned) feedEl.scrollTop = feedEl.scrollHeight;
+  } else {
+    feedEl.innerHTML = blocks.map((b) => b.html).join('') + tail || '<div class="empty">no messages yet</div>';
+    wireSpeak(blocks, target);
+    if (switched) scrollFeedToBottom(); // deferred: the feed may still be hidden this frame
+    else if (pinned) feedEl.scrollTop = feedEl.scrollHeight;
 
-  // wire speak buttons: .msg.agent[data-speak] in DOM order maps 1:1 to speakMsgs
-  const speakBtns = feedEl.querySelectorAll('.msg.agent [data-speak]');
-  speakBtns.forEach((btn, i) => {
-    const m = speakMsgs[i];
-    if (!m) return;
-    const key = target + '|' + m.ts + '|' + m.author; // stable per message, for toggle-off
-    btn.onclick = (e) => {
-      e.stopPropagation();
-      const spoke = speakMessage(m.text, key);
-      btn.classList.toggle('speaking', spoke);
+    // expander: reveal the full history, keeping the reader's place (content is
+    // inserted above, so anchor scrollTop by the height delta)
+    const expandBtn = feedEl.querySelector('.feed-expand');
+    if (expandBtn) expandBtn.onclick = () => {
+      const prevH = feedEl.scrollHeight, prevTop = feedEl.scrollTop;
+      mainExpanded = true;
+      renderChat();
+      feedEl.scrollTop = prevTop + (feedEl.scrollHeight - prevH);
     };
-  });
+  }
 
   maybeMarkRead(isCard ? c : null, target);
 }

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -1,6 +1,6 @@
 // card detail: attributes header + markdown body + event timeline (chat lives in the chat panel)
 import { S, card, lieutenant, lieutenants, lieutenantColor, cardStatus, cardActivityTs, cardRecency, kindEmoji, render, toggleFilter, filterSelected } from './state.js';
-import { esc, hhmm, ago, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename } from './util.js';
+import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename, setHtmlIfChanged } from './util.js';
 import { md } from './md.js';
 import { api } from './api.js';
 import { labelChipHtml, openLabelPicker, saveCardLabels } from './labels.js';
@@ -233,17 +233,20 @@ export function renderDetail() {
   if (!c) { closeDetail(); return; }
   el.hidden = false;
 
-  document.getElementById('dt-emoji').textContent = cardEmoji(c);
-  if (!editingTitle) titleEl.textContent = c.title || c.id; // don't clobber an in-progress rename
+  const emojiEl = document.getElementById('dt-emoji');
+  const emoji = cardEmoji(c);
+  if (emojiEl.textContent !== emoji) emojiEl.textContent = emoji;
+  if (!editingTitle && titleEl.textContent !== (c.title || c.id)) titleEl.textContent = c.title || c.id; // don't clobber an in-progress rename
   // sub line: id + timestamps, plus a worker-id chip when a worker is attached.
   // Same whitelist as the tile stripe (board.js) — only known states render, so
   // no server value ever reaches the class name; the id itself is esc()'d.
   const WORKER_STATES = { working: 1, 'needs-you': 1, idle: 1 };
   const w = cardStatus(c).worker;
   const worker = w && w.id && WORKER_STATES[w.state] ? w : null;
-  document.getElementById('dt-sub').innerHTML =
-    esc(c.id + ' · ' + c.type + ' · created ' + ago(c.created) + ' ago · updated ' + ago(cardRecency(c)) + ' ago') +
-    (worker ? '<span class="dt-worker dt-worker-' + worker.state + '" title="worker: ' + esc(worker.state) + '">' + esc(worker.id) + '</span>' : '');
+  setHtmlIfChanged(document.getElementById('dt-sub'),
+    esc(c.id + ' · ' + c.type + ' · created ') + agoSpanHtml(c.created) +
+    esc(' ago · updated ') + agoSpanHtml(cardRecency(c)) + esc(' ago') +
+    (worker ? '<span class="dt-worker dt-worker-' + worker.state + '" title="worker: ' + esc(worker.state) + '">' + esc(worker.id) + '</span>' : ''));
 
   // attributes header. The owner (the owning lieutenant) leads, in the
   // lieutenant's color and clickable as a filter. prs and artifacts are
@@ -251,15 +254,17 @@ export function renderDetail() {
   // the generic key:value chips.
   const at = c.attributes || {};
   const attrsEl = document.getElementById('dt-attrs');
-  attrsEl.innerHTML =
-    '<span class="attr attr-owner" title="filter by lieutenant"><span class="k">lieutenant</span>' +
+  // data-card keys the markup to THIS card: the chip handlers below close over
+  // c, so a same-looking attrs row on another card must not skip the rebuild
+  const attrsChanged = setHtmlIfChanged(attrsEl,
+    '<span class="attr attr-owner" data-card="' + esc(c.id) + '" title="filter by lieutenant"><span class="k">lieutenant</span>' +
     '<span class="v" style="color:' + esc(lieutenantColor(c.owner)) + '">' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span></span>' +
     (c.pendingOrder ? '<span class="attr"><span class="k">pending</span><span class="v">⏳ ' + esc(c.pendingOrder.kind) + '</span></span>' : '') +
     Object.entries(at)
       .filter(([k]) => k !== 'emoji' && k !== 'prs' && k !== 'artifacts')
       .map(([k, v]) => attrHtml(k, v)).join('') +
-    cardPrs(c).map((pr) => prChipHtml(pr, true)).join('');
-  const ownerChip = attrsEl.querySelector('.attr-owner');
+    cardPrs(c).map((pr) => prChipHtml(pr, true)).join(''));
+  const ownerChip = attrsChanged && attrsEl.querySelector('.attr-owner');
   if (ownerChip) {
     ownerChip.style.cursor = 'pointer';
     ownerChip.onclick = () => toggleFilter('owner', c.owner);
@@ -279,37 +284,43 @@ export function renderDetail() {
     ownerChip.appendChild(edit);
   }
 
-  // labels (user-owned)
+  // labels (user-owned) — DOM-built, so guarded by a signature (card + each
+  // chip's rendered markup, covering name/color/filter state) instead of an
+  // innerHTML cache; the handlers close over c, hence c.id in the signature
   const labWrap = document.getElementById('dt-labels');
-  labWrap.textContent = '';
-  for (const name of c.labels || []) {
-    const chip = document.createElement('span');
-    chip.className = 'dlabel';
-    chip.innerHTML = labelChipHtml(name, filterSelected('label', name));
-    chip.querySelector('.label').onclick = () => toggleFilter('label', name);
-    const x = document.createElement('button');
-    x.type = 'button'; x.textContent = '✕'; x.title = 'remove label';
-    x.onclick = () => saveCardLabels(c.id, (c.labels || []).filter((v) => v !== name));
-    chip.appendChild(x);
-    labWrap.appendChild(chip);
+  const labSig = c.id + '|' + (c.labels || []).map((n) => labelChipHtml(n, filterSelected('label', n))).join('');
+  if (labWrap.__bcSig !== labSig) {
+    labWrap.__bcSig = labSig;
+    labWrap.textContent = '';
+    for (const name of c.labels || []) {
+      const chip = document.createElement('span');
+      chip.className = 'dlabel';
+      chip.innerHTML = labelChipHtml(name, filterSelected('label', name));
+      chip.querySelector('.label').onclick = () => toggleFilter('label', name);
+      const x = document.createElement('button');
+      x.type = 'button'; x.textContent = '✕'; x.title = 'remove label';
+      x.onclick = () => saveCardLabels(c.id, (c.labels || []).filter((v) => v !== name));
+      chip.appendChild(x);
+      labWrap.appendChild(chip);
+    }
+    const add = document.createElement('button');
+    add.type = 'button';
+    add.id = 'dt-label-add';
+    add.setAttribute('data-label-add', '');
+    add.textContent = '+ label';
+    add.onclick = () => openLabelPicker(c.id, add);
+    labWrap.appendChild(add);
   }
-  const add = document.createElement('button');
-  add.type = 'button';
-  add.id = 'dt-label-add';
-  add.setAttribute('data-label-add', '');
-  add.textContent = '+ label';
-  add.onclick = () => openLabelPicker(c.id, add);
-  labWrap.appendChild(add);
 
   // body (don't clobber an in-progress description edit)
-  if (!editingBody) bodyEl.innerHTML = md(c.body || '');
+  if (!editingBody) setHtmlIfChanged(bodyEl, md(c.body || ''));
 
   // artifacts: attributes.artifacts [{uri, label}] — shown by FILENAME, not the
   // raw uri. http(s) uris open normally; anything else (file:// / local paths)
   // opens in the artifact viewer popup, served by GET /api/artifact.
   const artEl = document.getElementById('dt-artifacts');
   const arts = cardArtifacts(c);
-  artEl.innerHTML = !arts.length ? '' :
+  const artsChanged = setHtmlIfChanged(artEl, !arts.length ? '' :
     '<div class="dt-arts-head">artifacts</div>' + arts.map((a) => {
       const name = uriBasename(a.uri) || a.uri;
       const label = '<span class="a-label">' + esc(a.label || name) + '</span>';
@@ -317,8 +328,8 @@ export function renderDetail() {
         ? '<a class="a-uri" href="' + esc(a.uri) + '" target="_blank" rel="noopener" title="' + esc(a.uri) + '">' + esc(name) + '</a>'
         : '<code class="a-uri" data-view="' + esc(a.uri) + '" title="' + esc(a.uri) + ' — click to view">' + esc(name) + '</code>';
       return '<div class="art">' + label + uri + '</div>';
-    }).join('');
-  artEl.querySelectorAll('.a-uri[data-view]').forEach((n) => {
+    }).join(''));
+  if (artsChanged) artEl.querySelectorAll('.a-uri[data-view]').forEach((n) => {
     n.onclick = () => openArtifact(n.dataset.view);
   });
 
@@ -326,11 +337,11 @@ export function renderDetail() {
   const evEl = document.getElementById('dt-events');
   const events = (c.events || []).slice().reverse();
   // kind emoji from the effective kinds map, for any level; unknown kind = no emoji
-  evEl.innerHTML = events.map((e) =>
+  setHtmlIfChanged(evEl, events.map((e) =>
     '<div class="ev lvl' + e.level + '"><span class="dot"></span><div class="bd">' +
     '<div class="tx">' + (kindEmoji(e.kind) ? esc(kindEmoji(e.kind)) + ' ' : '') + esc(e.text) + '</div>' +
-    '<div class="sub">' + esc(e.actor || '') + ' · ' + hhmm(e.ts) + ' · ' + ago(e.ts) + ' ago</div>' +
-    '</div></div>').join('') || '<div class="ev"><div class="bd"><div class="sub">no events yet</div></div></div>';
+    '<div class="sub">' + esc(e.actor || '') + ' · ' + hhmm(e.ts) + ' · ' + agoSpanHtml(e.ts) + ' ago</div>' +
+    '</div></div>').join('') || '<div class="ev"><div class="bd"><div class="sub">no events yet</div></div></div>');
 
   maybeMarkCardRead(c);
 }

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -1,6 +1,7 @@
 // boot: SSE, header controls, mobile tabs, render orchestration
 import { S, onRender, render, cards, lieutenants, cardUnread, lieutenantUnread, notifUnreadCount, owedTargets, clearFilters, filtersActive } from './state.js';
 import { api } from './api.js';
+import { refreshAgoLabels } from './util.js';
 import { trackMessages } from './voice.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
@@ -24,6 +25,11 @@ function syncFilterInputs() {
   if (filterInput.value !== S.filters.text) filterInput.value = S.filters.text;
   if (filterAge.value !== S.filters.age) filterAge.value = S.filters.age;
   filterClear.style.display = filtersActive() ? 'inline' : 'none';
+  // rebuild the chips only when the selection actually changed (the chip
+  // handlers close over the f objects, so identity is per-selection anyway)
+  const sig = S.filters.sel.map((f) => f.kind + ':' + f.value).join('|');
+  if (chipsEl.__bcSig === sig) return;
+  chipsEl.__bcSig = sig;
   chipsEl.textContent = '';
   for (const f of S.filters.sel) {
     const chip = document.createElement('span');
@@ -123,6 +129,9 @@ onRender(() => {
   renderTabs();
   if (pickerIsOpen()) renderPicker();
   if (!spEl.hidden) renderLabelManager();
+  // fill the [data-ago] spans the panels above left empty (see util.js: time
+  // text stays out of the compared markup so it never forces a rebuild)
+  refreshAgoLabels();
 });
 
 // ---------- SSE ----------
@@ -176,4 +185,8 @@ setInterval(() => {
   connect();
 }, 5000);
 renderStatusDot();
-setInterval(render, 60000); // refresh "ago" labels
+// the minute tick: one guarded render pass — the [data-ago] labels are updated
+// in place by the refreshAgoLabels post-pass, and time-derived STATE (the
+// stale-owed ⚠ flip) still surfaces; panels whose markup didn't change leave
+// their DOM untouched
+setInterval(render, 60000);

--- a/ui/js/notify.js
+++ b/ui/js/notify.js
@@ -2,7 +2,6 @@
 // expandable "· N events ·" dividers revealing the suppressed level-2 events.
 import { S, allEvents, notifItems, notifUnreadCount, card, kindEmoji, render } from './state.js';
 import { api } from './api.js';
-import { ago } from './util.js';
 
 const bellBtn = document.getElementById('bell');
 const bellN = document.getElementById('bell-n');
@@ -41,7 +40,12 @@ function itemNode(e, lvl2) {
   tx.textContent = e.text;
   const sub = document.createElement('div');
   sub.className = 'sub';
-  sub.textContent = [e.cardTitle || (e.card ? e.card : ''), e.actor, ago(e.ts) + ' ago'].filter(Boolean).join(' · ');
+  // the "ago" text lives in a [data-ago] span filled post-render (util.js), so
+  // the passage of time alone never changes the list's markup
+  sub.textContent = [e.cardTitle || (e.card ? e.card : ''), e.actor].filter(Boolean).map((p) => p + ' · ').join('');
+  const agoEl = document.createElement('span');
+  agoEl.dataset.ago = e.ts || '';
+  sub.append(agoEl, ' ago');
   bd.append(tx, sub);
   row.append(em, bd);
   if (!lvl2) {
@@ -65,6 +69,46 @@ function gapNode(count, seq) {
   return g;
 }
 
+// The list rows are DOM-built (per-row click handlers), so the list is
+// assembled DETACHED and swapped into the live panel only when its markup
+// actually differs from what was last swapped in — otherwise the visible rows
+// (and the reader's scroll position) are left alone. Compared against a cached
+// string, never the live DOM, which the post-render ago pass mutates.
+let lastListHtml = null;
+function buildList(into) {
+  const all = allEvents(); // ascending seq
+  if (S.notifShowAll) {
+    if (!all.length) { into.innerHTML = '<div class="np-empty">no events yet</div>'; return; }
+    const items = notifItems(); // for read flags on level-1
+    const readOf = new Map(items.map((i) => [i.seq, i.read]));
+    for (const e of all.slice().reverse()) {
+      const node = itemNode(Object.assign({}, e, { read: readOf.get(e.seq) !== false }), e.level === 2);
+      into.appendChild(node);
+    }
+    return;
+  }
+  const lvl1 = notifItems(); // newest first
+  if (!lvl1.length) { into.innerHTML = '<div class="np-empty">nothing yet — level-1 signals land here</div>'; return; }
+  // Between consecutive level-1 items sit suppressed level-2 events (by seq gap):
+  // collapsed to a "· N events ·" divider, expandable inline. Newer-than-newest
+  // level-2 events get a leading divider on top.
+  const top = all.filter((x) => x.level === 2 && x.seq > lvl1[0].seq).reverse();
+  if (top.length) {
+    if (S.notifExpanded.has('top')) for (const g of top) into.appendChild(itemNode(g, true));
+    else into.appendChild(gapNode(top.length, 'top'));
+  }
+  for (let i = 0; i < lvl1.length; i++) {
+    const e = lvl1[i];
+    into.appendChild(itemNode(e, false));
+    const lower = i + 1 < lvl1.length ? lvl1[i + 1].seq : 0;
+    const gap = all.filter((x) => x.level === 2 && x.seq > lower && x.seq < e.seq).reverse();
+    if (gap.length) {
+      if (S.notifExpanded.has(e.seq)) for (const g of gap) into.appendChild(itemNode(g, true));
+      else into.appendChild(gapNode(gap.length, e.seq));
+    }
+  }
+}
+
 export function renderNotifications() {
   const unread = notifUnreadCount();
   bellN.hidden = !unread;
@@ -75,36 +119,10 @@ export function renderNotifications() {
   if (!S.notifOpen) return;
   showAllCb.checked = S.notifShowAll;
 
+  const tmp = document.createElement('div');
+  buildList(tmp);
+  if (lastListHtml === tmp.innerHTML) return; // same markup — keep the live rows
+  lastListHtml = tmp.innerHTML;
   listEl.textContent = '';
-  const all = allEvents(); // ascending seq
-  if (S.notifShowAll) {
-    if (!all.length) { listEl.innerHTML = '<div class="np-empty">no events yet</div>'; return; }
-    const items = notifItems(); // for read flags on level-1
-    const readOf = new Map(items.map((i) => [i.seq, i.read]));
-    for (const e of all.slice().reverse()) {
-      const node = itemNode(Object.assign({}, e, { read: readOf.get(e.seq) !== false }), e.level === 2);
-      listEl.appendChild(node);
-    }
-    return;
-  }
-  const lvl1 = notifItems(); // newest first
-  if (!lvl1.length) { listEl.innerHTML = '<div class="np-empty">nothing yet — level-1 signals land here</div>'; return; }
-  // Between consecutive level-1 items sit suppressed level-2 events (by seq gap):
-  // collapsed to a "· N events ·" divider, expandable inline. Newer-than-newest
-  // level-2 events get a leading divider on top.
-  const top = all.filter((x) => x.level === 2 && x.seq > lvl1[0].seq).reverse();
-  if (top.length) {
-    if (S.notifExpanded.has('top')) for (const g of top) listEl.appendChild(itemNode(g, true));
-    else listEl.appendChild(gapNode(top.length, 'top'));
-  }
-  for (let i = 0; i < lvl1.length; i++) {
-    const e = lvl1[i];
-    listEl.appendChild(itemNode(e, false));
-    const lower = i + 1 < lvl1.length ? lvl1[i + 1].seq : 0;
-    const gap = all.filter((x) => x.level === 2 && x.seq > lower && x.seq < e.seq).reverse();
-    if (gap.length) {
-      if (S.notifExpanded.has(e.seq)) for (const g of gap) listEl.appendChild(itemNode(g, true));
-      else listEl.appendChild(gapNode(gap.length, e.seq));
-    }
-  }
+  while (tmp.firstChild) listEl.appendChild(tmp.firstChild);
 }

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -11,6 +11,30 @@ export function ago(iso) {
   if (s < 86400) return Math.floor(s / 3600) + 'h';
   return Math.floor(s / 86400) + 'd';
 }
+// "ago" labels are rendered as EMPTY spans carrying the timestamp, then filled
+// in by refreshAgoLabels after every render pass (and on the periodic tick).
+// Keeping the time-dependent text OUT of the markup keeps panel html strings
+// stable, so the skip-identical render guards don't rebuild the DOM just
+// because a minute passed.
+export function agoSpanHtml(iso, cls) {
+  return '<span' + (cls ? ' class="' + cls + '"' : '') + ' data-ago="' + esc(iso || '') + '"></span>';
+}
+export function refreshAgoLabels(root) {
+  for (const el of (root || document).querySelectorAll('[data-ago]')) {
+    const t = ago(el.dataset.ago);
+    if (el.textContent !== t) el.textContent = t;
+  }
+}
+// Assign innerHTML only when the markup actually changed since the LAST
+// assignment through this helper (cached on the element — never read back from
+// the live DOM, which post-passes like refreshAgoLabels mutate). Returns true
+// when the DOM was rebuilt, so callers re-wire handlers only then.
+export function setHtmlIfChanged(el, html) {
+  if (el.__bcHtml === html) return false;
+  el.__bcHtml = html;
+  el.innerHTML = html;
+  return true;
+}
 export function hhmm(iso) {
   try { return new Date(iso).toTimeString().slice(0, 5); } catch (e) { return ''; }
 }


### PR DESCRIPTION
## What / why

Reading the board blinked (papercut #12): every SSE `board` event replaced `S.doc` wholesale and re-ran the whole render orchestration — `renderBoard() + renderChat() + renderDetail() + renderNotifications() + renderTabs()` — each rebuilding its panel via `innerHTML`, plus a blanket `setInterval(render, 60000)` for "ago" labels. Any activity anywhere (a worker event on another card, the minute tick) blew away and rebuilt the DOM under the reader: visible blink, scroll reset, selection/focus loss.

## What changed (incremental, no framework / no vdom)

1. **Skip identical re-renders per panel.** Each panel builds its markup string and assigns `innerHTML` only when it differs from the last assignment (`setHtmlIfChanged` in `util.js`; cached signatures for the DOM-built label chips / notification list, compared against cached strings, never the live DOM). Handlers are re-wired only on a real rebuild. The detail attrs markup is keyed by card id so a same-looking row on another card can't keep stale closures.
2. **Chat feed append path.** The feed diffs per-block html (block = message + merged day divider, or the history expander) against what it currently shows. Unchanged → DOM untouched. Previous blocks an unchanged prefix → new messages are appended with `insertAdjacentHTML` and the typing indicator swapped, never touching earlier DOM; stick-to-bottom only when the reader was already at the bottom. Anything else → full rebuild (conversation switch, expand, out-of-order edit). The main-chat collapse cutoff is anchored per conversation so new arrivals don't shift the window (keeps the prefix stable). The PR #2 composer delivery behavior (`waitForEcho`, sending state, clear-after-confirm) is untouched and was re-verified live.
3. **"ago" labels update in place.** Time text renders as empty `[data-ago]` spans filled by a `refreshAgoLabels` post-render pass, so the passage of time never invalidates the compared markup. The minute tick still runs one *guarded* render pass so time-derived state (the stale-owed ⚠ flip) surfaces — but panels whose markup didn't change leave their DOM alone.

## Live verification (real Chrome, throwaway server on :4899, temp workspace — never touched :4780)

Seeded 2 lieutenants + 2 cards, opened card A's thread with a `MutationObserver` on `#chat-feed` and `#detail`, a draft + selection in the composer:

- **Activity on OTHER cards** (3 thread messages + 3 events on card B): chat feed **0 mutations**, detail panel **0 mutations**, same DOM node identity, composer focus + draft text + selection range all preserved. Card B's tile updated (💬 count) as expected.
- **Message in the OPEN thread**: exactly **1 `msg agent` node appended, 0 removed** (mutation records captured). Captain message → message + typing indicator appended; lieutenant reply → typing indicator swapped for the reply.
- **Scroll**: scrolled up to `scrollTop=100`, posted a new message → scroll stayed at 100 while the message appended; scrolled to bottom, posted → feed followed.
- **Main-chat expander** (40 msgs): shows "show earlier messages (10)" + 30 visible; new arrival appends (label stays anchored at 10, same first DOM node); expanding reveals all 41.
- **Composer delivery (PR #2 behavior)**: sent via the real form — input `readOnly` during send, cleared only after the SSE echo, message visible, no error shown.
- **Bell panel open** during a level-1 event: new row appears, `[data-ago]` labels filled ("now").

`node --test test/*.test.js`: **125/125 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
