### PR TITLE
fix(ui): owner change via dropdown of lieutenants, not a prompt()

### DIFF
--- a/ui/app.css
+++ b/ui/app.css
@@ -502,19 +502,24 @@ a.a-uri { color: var(--accent); }
 .md th, .md td { border: 1px solid var(--line2); padding: 3px 8px; text-align: left; vertical-align: top; }
 .md th { background: var(--panel2); color: var(--dim); font-weight: 600; font-size: 12px; white-space: nowrap; }
 
-/* ---------- move menu ---------- */
-#move-menu {
+/* ---------- move menu (owner menu shares the look) ---------- */
+#move-menu, #owner-menu {
   position: fixed; z-index: 80; min-width: 190px; display: flex; flex-direction: column;
   background: var(--bg2); border: 1px solid var(--line2); border-radius: 10px; padding: 5px;
   box-shadow: var(--shadow); animation: pop-in .12s ease-out;
 }
-#move-menu .mm-head { color: var(--faint); font-size: 10px; text-transform: uppercase; letter-spacing: 1px; padding: 5px 10px 3px; }
-#move-menu button { text-align: left; font-size: 12.5px; padding: 7px 10px; border-radius: 7px; }
-#move-menu button:hover { background: var(--panel2); }
+#move-menu .mm-head, #owner-menu .mm-head { color: var(--faint); font-size: 10px; text-transform: uppercase; letter-spacing: 1px; padding: 5px 10px 3px; }
+#move-menu button, #owner-menu button { text-align: left; font-size: 12.5px; padding: 7px 10px; border-radius: 7px; }
+#move-menu button:hover, #owner-menu button:hover { background: var(--panel2); }
 #move-menu button.cur { color: var(--faint); cursor: default; }
 #move-menu button.danger { color: var(--danger); }
 #move-menu button.danger:hover { background: rgba(239, 100, 97, .1); }
 #move-menu .mm-sep { height: 1px; background: var(--line); margin: 4px 6px; }
+#owner-menu button { display: flex; align-items: center; gap: 7px; }
+#owner-menu button .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; }
+#owner-menu .mm-none { color: var(--faint); font-size: 12.5px; padding: 7px 10px; }
+.attr-owner .owner-edit { border: none; background: none; cursor: pointer; padding: 0 2px; font-size: 11px; opacity: .6; }
+.attr-owner .owner-edit:hover { opacity: 1; }
 
 /* ---------- new card modal ---------- */
 #nc-overlay {

--- a/ui/index.html
+++ b/ui/index.html
@@ -130,6 +130,9 @@
 <!-- move / actions menu (detail ⋯ and tile long-press) -->
 <div id="move-menu" hidden></div>
 
+<!-- owner menu (detail ✎ on the lieutenant chip — reassign the owning lieutenant) -->
+<div id="owner-menu" hidden></div>
+
 <!-- new card modal -->
 <div id="nc-overlay" hidden>
   <form id="nc-modal">

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -67,6 +67,7 @@ document.addEventListener('click', (e) => {
     t.closest('.lt-card') ||                  // a lane card — switches the chat, not a close
     t.closest('#lt-overlay') ||               // new-lieutenant modal
     t.closest('#move-menu') ||                // transient popovers dismiss on their own
+    t.closest('#owner-menu') ||
     t.closest('#notif-panel') ||
     t.closest('#settings-panel') ||
     t.closest('#label-picker') ||
@@ -203,6 +204,53 @@ export function artifactOpen() { return !avOverlay.hidden; }
 document.getElementById('av-close').onclick = closeArtifact;
 avOverlay.onclick = (e) => { if (e.target === avOverlay) closeArtifact(); };
 
+// ---------- owner menu (reassign the owning lieutenant) ----------
+// Popover twin of the board's move-menu (shares its look — see app.css): lists
+// the OTHER lieutenants by name with their color dot; picking one PATCHes
+// {owner} and the SSE board push repaints chip + tile live. Opened by the ✎ on
+// the owner chip, which only renders while no worker is bound (the server
+// refuses owner changes otherwise). Closes on select / outside click / Esc
+// (main.js).
+const omEl = document.getElementById('owner-menu');
+function openOwnerMenu(cardId, x, y) {
+  const c = card(cardId);
+  if (!c) return;
+  omEl.textContent = '';
+  const head = document.createElement('div');
+  head.className = 'mm-head';
+  head.textContent = 'hand card to';
+  omEl.appendChild(head);
+  const others = lieutenants().filter((l) => l.id !== c.owner);
+  if (!others.length) {
+    const none = document.createElement('div');
+    none.className = 'mm-none';
+    none.textContent = 'no other lieutenant';
+    omEl.appendChild(none);
+  }
+  for (const l of others) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    const dot = document.createElement('span');
+    dot.className = 'dot';
+    dot.style.background = lieutenantColor(l.id);
+    b.appendChild(dot);
+    b.appendChild(document.createTextNode(l.name || l.id));
+    b.onclick = async () => {
+      closeOwnerMenu();
+      try { await api.patchCard(cardId, { owner: l.id }); }
+      catch (e) { alert(e.message); }
+    };
+    omEl.appendChild(b);
+  }
+  omEl.hidden = false;
+  const r = omEl.getBoundingClientRect();
+  omEl.style.left = Math.max(8, Math.min(x, window.innerWidth - r.width - 8)) + 'px';
+  omEl.style.top = Math.max(8, Math.min(y, window.innerHeight - r.height - 8)) + 'px';
+}
+export function closeOwnerMenu() { omEl.hidden = true; }
+export function ownerMenuOpen() { return !omEl.hidden; }
+document.addEventListener('click', (e) => { if (!omEl.hidden && !omEl.contains(e.target)) closeOwnerMenu(); });
+
 // Opening the card clears its unread: level-1 events and lieutenant replies both
 // derive from the same per-card read marker server-side, so one POST covers
 // both. The chat panel only marks the thread when IT is visible (and only on
@@ -258,7 +306,12 @@ export function renderDetail() {
   // c, so a same-looking attrs row on another card must not skip the rebuild
   const attrsChanged = setHtmlIfChanged(attrsEl,
     '<span class="attr attr-owner" data-card="' + esc(c.id) + '" title="filter by lieutenant"><span class="k">lieutenant</span>' +
-    '<span class="v" style="color:' + esc(lieutenantColor(c.owner)) + '">' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span></span>' +
+    '<span class="v" style="color:' + esc(lieutenantColor(c.owner)) + '">' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span>' +
+    // ✎ only while no worker is bound — mirrors the server guard on owner PATCH.
+    // Rendered in the markup (not appended after) so a worker binding/unbinding
+    // changes the innerHTML signature and setHtmlIfChanged rebuilds the row.
+    (worker ? '' : '<button type="button" class="owner-edit" title="change owner (only while no worker is bound)">✎</button>') +
+    '</span>' +
     (c.pendingOrder ? '<span class="attr"><span class="k">pending</span><span class="v">⏳ ' + esc(c.pendingOrder.kind) + '</span></span>' : '') +
     Object.entries(at)
       .filter(([k]) => k !== 'emoji' && k !== 'prs' && k !== 'artifacts')
@@ -268,20 +321,12 @@ export function renderDetail() {
   if (ownerChip) {
     ownerChip.style.cursor = 'pointer';
     ownerChip.onclick = () => toggleFilter('owner', c.owner);
-    // Owner reassignment (allowed server-side only while no worker is bound):
-    // a small ✎ on the chip cycles through a prompt of the other lieutenants.
-    const edit = document.createElement('button');
-    edit.type = 'button'; edit.textContent = '✎'; edit.title = 'change owner (only while no worker is bound)';
-    edit.style.cssText = 'border:none;background:none;cursor:pointer;padding:0 2px;font-size:11px;opacity:.6';
-    edit.onclick = async (e) => {
-      e.stopPropagation();
-      const others = lieutenants().filter((l) => l.id !== c.owner);
-      if (!others.length) return alert('no other lieutenant to hand this card to');
-      const pick = prompt('new owner id (' + others.map((l) => l.id).join(', ') + '):', others[0].id);
-      if (!pick || pick === c.owner) return;
-      try { await api.patchCard(c.id, { owner: pick }); } catch (err) { alert(err.message); }
+    const edit = ownerChip.querySelector('.owner-edit');
+    if (edit) edit.onclick = (e) => {
+      e.stopPropagation(); // the chip click is the owner filter, not the menu
+      const r = edit.getBoundingClientRect();
+      openOwnerMenu(c.id, r.left, r.bottom + 4);
     };
-    ownerChip.appendChild(edit);
   }
 
   // labels (user-owned) — DOM-built, so guarded by a signature (card + each

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -5,7 +5,7 @@ import { refreshAgoLabels } from './util.js';
 import { trackMessages } from './voice.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
-import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen } from './detail.js';
+import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import './resize.js'; // draggable side-panel widths
@@ -106,6 +106,7 @@ document.addEventListener('keydown', (e) => {
     else if (newCardOpen()) closeNewCard();
     else if (newLieutenantOpen()) closeNewLieutenant();
     else if (pickerIsOpen()) closeLabelPicker();
+    else if (ownerMenuOpen()) closeOwnerMenu(); // just the menu — keep the detail open
     else if (S.notifOpen) { S.notifOpen = false; render(); }
     else if (!spEl.hidden) { spEl.hidden = true; gearBtn.classList.remove('on'); }
     else if (detailOpen()) closeDetail();


### PR DESCRIPTION
Captain-reported: the owner-change control on the card detail's lieutenant chip used a browser `prompt()` asking for a lieutenant **id** typed by hand. This replaces it with a real dropdown.

## What changed

- **`ui/js/detail.js`** — the ✎ on the owner chip now opens an `#owner-menu` popover (twin of the board's move-menu) listing the OTHER lieutenants by **name** with their color dot; clicking one PATCHes `{owner}` and the SSE push repaints the chip/tile live. Closes on select / outside click / Esc.
- **Guard**: the ✎ only renders while no worker is bound (`cardStatus(c).worker` absent — the client proxy for the server's `findWorker` refusal). It lives in the attrs markup (not appended after), so worker bind/unbind changes the `setHtmlIfChanged` signature and the row rebuilds.
- **`ui/js/main.js`** — Esc closes just the owner menu (keeps the detail open), slotted into the existing popover-priority chain.
- **`ui/index.html` / `ui/app.css`** — `#owner-menu` div + styling shared with `#move-menu`; `.owner-edit` styles moved from inline `cssText` to the stylesheet.

Server untouched — `PATCH /api/cards/:id { owner }` already validates the lieutenant, refuses with a bound worker, and writes the timeline event.

## Validation

- `node --test test/*.test.js` — **125/125 pass**.
- Live-verified in real Chrome on a throwaway server (port 4799, workspace in scratchpad, pid captured at spawn and killed by pid) with 3 lieutenants (Alpha/Bravo/Charlie) and 2 cards:
  1. Free card (no worker): ✎ shows; clicking it opens "HAND CARD TO" menu listing **Bravo, Charlie** by name (owner Alpha excluded), each with its lieutenant color dot (verified computed `background-color` = `#3ecf8e` / `#e6c04a`).
  2. Clicking **Bravo**: menu closes, detail chip → Bravo, board tile → Bravo, timeline gains "🔁 owner: alpha → bravo", `card show` confirms `owner=bravo` — all live via SSE, no typing.
  3. Card with a worker lease bound (`status busy-card working --worker w-test-1`): worker chip shows, **no ✎ control**.
  4. Click outside the menu (inside the detail): menu closes, detail stays open.
  5. Esc: menu closes, detail stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
