### PR TITLE
feat: workers as tmux windows in the lieutenant's session (papercut #8)

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -539,6 +539,7 @@ async function cmdStart() {
   const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/start', body, 180000);
   const w = r.worker;
   console.log((r.resumed ? 'resumed' : 'started') + ' worker ' + w.ref.harness + ':' + w.ref.session
+    + (w.ref.window ? ':' + w.ref.window : '')
     + '\n  worktree: ' + w.worktree.path + (w.branch ? '\n  branch:   ' + w.branch : '')
     + '\n  card ' + id + ' -> working');
 }

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -101,7 +101,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 
 | Verb | Signature | Called by | Purpose |
 |---|---|---|---|
-| `harness.spawn` | `cwd, prompt, opts → HarnessRef` | ⚙️ | birth a lieutenant or worker session (`opts`: session name, state dir, turn-end callback URL, hook install mode) |
+| `harness.spawn` | `cwd, prompt, opts → HarnessRef` | ⚙️ | birth a lieutenant session or a worker WINDOW inside its lieutenant's session (`opts`: session name, window name — non-numeric, `w-<card-id>` —, state dir, turn-end callback URL, hook install mode) |
 | `harness.send` | `ref, text` | ⚙️ | type into a session (the wake half of delivery) |
 | `harness.alive` | `ref → bool` | ⚙️ | liveness check for supervision |
 | `harness.resumable` | `ref → bool` | ⚙️ | introspection: would `resume` restore memory? The server picks resume vs relaunch-with-charter on it |

--- a/e2e/prwatch.e2e.js
+++ b/e2e/prwatch.e2e.js
@@ -64,8 +64,8 @@ function tmux(...args) {
   return execFileSync('tmux', args, { encoding: 'utf8', env: ENV, stdio: ['ignore', 'pipe', 'pipe'] });
 }
 function tryTmux(...args) { try { return tmux(...args); } catch (e) { return null; } }
-function capture(session, lines = 120) {
-  const out = tryTmux('capture-pane', '-p', '-t', '=' + session + ':', '-S', '-' + lines);
+function capture(target, lines = 120) {
+  const out = tryTmux('capture-pane', '-p', '-t', target, '-S', '-' + lines);
   return out === null ? '' : out;
 }
 function gh(...args) {
@@ -92,7 +92,11 @@ async function until(what, fn, ms, step = 2000) {
 
 const RUN = crypto.randomBytes(3).toString('hex');
 const CARD = 'prwatch-' + RUN;
-const SESSION = require(path.join(__dirname, '..', 'server', 'names.js')).workerSession(ws, CARD);
+// the worker lives as a WINDOW inside the owning lieutenant's session
+const names = require(path.join(__dirname, '..', 'server', 'names.js'));
+const SESSION = names.lieutenantSession(ws, 'ada');
+const WINDOW = names.workerWindow(CARD);
+const TARGET = '=' + SESSION + ':=' + WINDOW;
 const FILE = 'runs/' + RUN + '.txt';
 const WANT = 'pr watch e2e ' + RUN;
 
@@ -105,7 +109,7 @@ async function stepCase(name, fn) {
   } catch (e) {
     console.error('  ✖ ' + name);
     console.error(e && e.stack ? e.stack : e);
-    console.error('--- worker pane tail ---\n' + capture(SESSION).split('\n').slice(-60).join('\n'));
+    console.error('--- worker pane tail ---\n' + capture(TARGET).split('\n').slice(-60).join('\n'));
     process.exitCode = 1;
     throw e;
   }
@@ -208,8 +212,12 @@ async function stepCase(name, fn) {
       assert.ok(landed && landed.level === 1, 'landed level-1 event');
       // worktree released (worker committed everything — clean)
       await until('worktree released', async () => !fs.existsSync(worktree), 30000);
-      // the lingering done-worker session was killed (harness.kill)
-      await until('worker session killed', async () => tryTmux('has-session', '-t', '=' + SESSION + ':') === null, 30000);
+      // the lingering done-worker WINDOW was killed (harness.kill is
+      // window-granular; list-windows is the strict existence check)
+      await until('worker window killed', async () => {
+        const wins = tryTmux('list-windows', '-t', '=' + SESSION + ':', '-F', '#{window_name}');
+        return wins === null || !wins.split('\n').includes(WINDOW);
+      }, 30000);
       // the owner got the pr-merged QueueItem
       const items = (await api('GET', '/api/feed?lieutenant=ada')).body.items;
       assert.ok(items.some((i) => i.kind === 'pr-merged' && i.card === CARD && i.text === prUrl), 'pr-merged QueueItem');

--- a/e2e/worker.e2e.js
+++ b/e2e/worker.e2e.js
@@ -58,8 +58,8 @@ function tmux(...args) {
   return execFileSync('tmux', args, { encoding: 'utf8', env: ENV, stdio: ['ignore', 'pipe', 'pipe'] });
 }
 function tryTmux(...args) { try { return tmux(...args); } catch (e) { return null; } }
-function capture(session, lines = 120) {
-  const out = tryTmux('capture-pane', '-p', '-t', '=' + session + ':', '-S', '-' + lines);
+function capture(target, lines = 120) {
+  const out = tryTmux('capture-pane', '-p', '-t', target, '-S', '-' + lines);
   return out === null ? '' : out;
 }
 function git(dir, ...args) {
@@ -84,10 +84,13 @@ async function until(what, fn, ms, step = 1000) {
   }
 }
 
-const { workerSession } = require(path.join(__dirname, '..', 'server', 'names.js'));
+const { lieutenantSession, workerWindow } = require(path.join(__dirname, '..', 'server', 'names.js'));
 
 const CARD = 'hello-file';
-const SESSION = workerSession(ws, CARD); // workspace-discriminated
+// the worker lives as a WINDOW inside the owning lieutenant's session
+const SESSION = lieutenantSession(ws, 'ada'); // workspace-discriminated
+const WINDOW = workerWindow(CARD);
+const TARGET = '=' + SESSION + ':=' + WINDOW; // exact-match session:window pane target
 const WANT = 'bridge command was here';
 
 let passed = 0;
@@ -99,7 +102,7 @@ async function stepCase(name, fn) {
   } catch (e) {
     console.error('  ✖ ' + name);
     console.error(e && e.stack ? e.stack : e);
-    console.error('--- worker pane tail ---\n' + capture(SESSION).split('\n').slice(-50).join('\n'));
+    console.error('--- worker pane tail ---\n' + capture(TARGET).split('\n').slice(-50).join('\n'));
     process.exitCode = 1;
     throw e;
   }
@@ -157,12 +160,13 @@ async function stepCase(name, fn) {
 
       r = await runCli(['card', 'start', CARD, '--workspace', ws, '--port', String(port)]);
       assert.strictEqual(r.code, 0, r.stderr + r.stdout);
-      assert.match(r.stdout, new RegExp('started worker claude:' + SESSION.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+      assert.match(r.stdout, new RegExp('started worker claude:'
+        + (SESSION + ':' + WINDOW).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 
       // the card moved to Working AT START (system move), attrs bound
       const card = (await api('GET', '/api/cards/' + CARD)).body;
       assert.strictEqual(card.column, 'working');
-      assert.strictEqual(card.attributes.session, SESSION);
+      assert.strictEqual(card.attributes.session, SESSION + ':' + WINDOW);
       assert.strictEqual(card.attributes.branch, 'bc/' + CARD);
       worktree = card.attributes.worktree;
       assert.ok(worktree && fs.existsSync(worktree), 'worktree exists: ' + worktree);
@@ -174,8 +178,13 @@ async function stepCase(name, fn) {
       assert.strictEqual(fs.realpathSync(git(worktree, 'rev-parse', '--show-toplevel')), fs.realpathSync(worktree));
       assert.notStrictEqual(git(worktree, 'rev-parse', '--absolute-git-dir'), git(clone, 'rev-parse', '--absolute-git-dir'));
 
-      // the claude session is really up (pane not sitting at a shell)
-      const cmd = tmux('display-message', '-p', '-t', '=' + SESSION + ':', '#{pane_current_command}').trim();
+      // the worker landed as a named WINDOW inside the lieutenant's session
+      // (list-windows is the strict existence check — display-message silently
+      // falls back to another pane when the window is missing)
+      const windows = tmux('list-windows', '-t', '=' + SESSION + ':', '-F', '#{window_name}').split('\n');
+      assert.ok(windows.includes(WINDOW), 'window ' + WINDOW + ' in ' + SESSION + ', got: ' + windows.join(','));
+      // and its pane really runs claude (not sitting at a shell)
+      const cmd = tmux('display-message', '-p', '-t', TARGET, '#{pane_current_command}').trim();
       assert.ok(!['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh'].includes(cmd), 'worker alive, pane runs: ' + cmd);
     });
 
@@ -201,7 +210,7 @@ async function stepCase(name, fn) {
 
     console.log('\nworker e2e: ' + passed + ' steps passed');
   } finally {
-    tryTmux('kill-session', '-t', '=' + SESSION + ':');
+    tryTmux('kill-session', '-t', '=' + SESSION + ':'); // takes the worker windows with it
     tryTmux('kill-server');
     if (server && server.exitCode == null) server.kill('SIGTERM');
     await sleep(300);

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -1,8 +1,15 @@
 'use strict';
 // claude-tmux — the claude implementation of the harness port, over tmux.
 //
-// HarnessRef: { harness: 'claude', session: 'bc-<id>', cwd, resumeId? }
+// HarnessRef: { harness: 'claude', session: 'bc-<id>', window?, cwd, resumeId? }
 //   session  — tmux session name (predictable `bc-*`, the captain's attach escape hatch)
+//   window   — when present, the agent lives in a named WINDOW of that session
+//              instead of owning the whole session (papercut #8: workers as
+//              windows inside their lieutenant's session). Window names must
+//              start with a letter — a numeric name would be parsed by tmux as
+//              a window INDEX — and every tmux call addresses the pane with the
+//              exact-match `=session:=window` form. Lifecycle coupling is
+//              accepted design: the session dying takes its windows with it.
 //   resumeId — the claude session uuid. Set deterministically at spawn via
 //              `--session-id <uuid>` (verified claude 2.1.202), refreshed from
 //              Stop-hook payloads. `claude --resume <resumeId>` keeps the SAME
@@ -53,21 +60,70 @@ function newSessionName() {
   return 'bc-' + crypto.randomBytes(3).toString('hex');
 }
 
-// paneTarget — exact-match tmux target for a session's active pane.
-// The bare `=name` exact-match form resolves for session-level commands but
-// NOT for pane-level ones (verified tmux 3.4: `send-keys -t =name` fails with
-// "can't find pane"); the trailing colon (`=name:`) resolves for both.
-function paneTarget(session) {
-  return `=${session}:`;
+// stateKey — the per-agent key for prompt/turnend/session-id state files and
+// the Stop-hook `session` argument. Window-granular agents share their tmux
+// session name with the lieutenant (and sibling workers), so the bare session
+// would collide; the `session:window` form is unique — tmux session names can
+// never contain ':'.
+function stateKey(session, window) {
+  return window ? `${session}:${window}` : session;
 }
 
-async function paneCommand(session) {
-  const out = await t.tryTmux('display-message', '-p', '-t', paneTarget(session), '#{pane_current_command}');
+// paneTarget — exact-match tmux target for an agent's pane.
+// Session-granular: the bare `=name` exact-match form resolves for
+// session-level commands but NOT for pane-level ones (verified tmux 3.4:
+// `send-keys -t =name` fails with "can't find pane"); the trailing colon
+// (`=name:`) resolves for both. Window-granular: `=session:=window`, exact on
+// both halves, so tmux never pattern-matches or reads the window as an index.
+function paneTarget(session, window) {
+  return window ? `=${session}:=${window}` : `=${session}:`;
+}
+
+async function paneCommand(target) {
+  const out = await t.tryTmux('display-message', '-p', '-t', target, '#{pane_current_command}');
   return out === null ? null : out.trim();
 }
 
 async function hasSession(session) {
-  return (await t.tryTmux('has-session', '-t', paneTarget(session))) !== null;
+  return (await t.tryTmux('has-session', '-t', `=${session}:`)) !== null;
+}
+
+// hasWindow — strict window existence. `display-message -t =ses:=missing`
+// does NOT error — tmux silently falls back to another pane (verified tmux
+// 3.4) — so existence is checked against the session's actual window list.
+async function hasWindow(session, window) {
+  const out = await t.tryTmux('list-windows', '-t', `=${session}:`, '-F', '#{window_name}');
+  return out !== null && out.split('\n').includes(window);
+}
+
+function paneExists(session, window) {
+  return window ? hasWindow(session, window) : hasSession(session);
+}
+
+// createPane — bring the agent's pane into existence. Session-granular: a
+// fresh detached session. Window-granular: a new window appended to the
+// session, created with -d so a worker spawn never steals the lieutenant's
+// focus; when the session is not up yet it is created with this window as its
+// first (the accepted lifecycle coupling — no separate fleet session).
+async function createPane(session, window, cwd) {
+  if (!window) {
+    await t.tmux('new-session', '-d', '-s', session, '-c', cwd);
+  } else if (await hasSession(session)) {
+    await t.tmux('new-window', '-d', '-t', `=${session}:`, '-n', window, '-c', cwd);
+  } else {
+    await t.tmux('new-session', '-d', '-s', session, '-n', window, '-c', cwd);
+  }
+}
+
+// killPane — session-granular kills the session; window-granular kills ONLY
+// the window (the lieutenant and sibling workers cohabit the session).
+// Killing a session's last window ends the session — tmux's own semantics.
+async function killPane(session, window) {
+  if (window) {
+    if (await hasWindow(session, window)) await t.tryTmux('kill-window', '-t', paneTarget(session, window));
+  } else if (await hasSession(session)) {
+    await t.tryTmux('kill-session', '-t', paneTarget(session));
+  }
 }
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
@@ -122,31 +178,34 @@ async function installHooks(cwd, session, stateDir, callbackUrl) {
 // busy footer, permission-mode footer) and the trust screen does not.
 const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
 
-async function launchAndSettle(session, launchCmd) {
-  await t.sendLiteral(paneTarget(session), launchCmd);
+async function launchAndSettle(target, launchCmd) {
+  await t.sendLiteral(target, launchCmd);
   await t.sleep(300);
-  await t.sendKey(paneTarget(session), 'Enter');
+  await t.sendKey(target, 'Enter');
 
   const deadline = Date.now() + 45000;
   while (Date.now() < deadline) {
     await t.sleep(500);
-    const cmd = await paneCommand(session);
-    if (cmd === null) throw new Error(`tmux session ${session} vanished during launch`);
+    const cmd = await paneCommand(target);
+    if (cmd === null) throw new Error(`tmux pane ${target} vanished during launch`);
     if (SHELLS.has(cmd)) continue; // claude not up yet (or it already exited — captured by timeout)
-    const pane = await t.capture(paneTarget(session), 40);
+    const pane = await t.capture(target, 40);
     if (TRUST_RE.test(pane)) {
-      await t.sendKey(paneTarget(session), 'Enter');
+      await t.sendKey(target, 'Enter');
       await t.sleep(1000);
       continue;
     }
     if (UI_READY_RE.test(pane)) return;
   }
-  const tail = await t.capture(paneTarget(session), 20);
-  throw new Error(`claude did not start in session ${session} within 45s; pane tail:\n${tail}`);
+  const tail = await t.capture(target, 20);
+  throw new Error(`claude did not start at ${target} within 45s; pane tail:\n${tail}`);
 }
 
 // spawn(cwd, prompt, opts?) -> HarnessRef
-// opts: { session?, stateDir?, callbackUrl?, extraArgs?: string[], installHooks?: boolean }
+// opts: { session?, window?, stateDir?, callbackUrl?, extraArgs?: string[], installHooks?: boolean }
+// window: birth the agent as a named window inside `session` (which must then
+// be given too) instead of owning a whole session; the session is created on
+// demand when it is not up yet.
 // installHooks: false skips the per-spawn Stop-hook install — for sessions born
 // into a cwd that already carries a workspace-level hook (installing another
 // would clobber it: installHooks keeps ONE bc entry per settings file).
@@ -157,58 +216,71 @@ async function spawn(cwd, prompt, opts = {}) {
   if (!/^bc-[A-Za-z0-9_-]+$/.test(session)) {
     throw new Error(`invalid session name "${session}" (must match bc-<id>)`);
   }
-  if (await hasSession(session)) throw new Error(`tmux session ${session} already exists`);
+  const window = opts.window === undefined || opts.window === null ? undefined : String(opts.window);
+  if (window !== undefined && !/^[A-Za-z][A-Za-z0-9_-]*$/.test(window)) {
+    throw new Error(`invalid window name "${window}" (must start with a letter — tmux parses numeric names as window indexes)`);
+  }
+  if (window) {
+    if (await hasWindow(session, window)) throw new Error(`tmux window ${session}:${window} already exists`);
+  } else if (await hasSession(session)) {
+    throw new Error(`tmux session ${session} already exists`);
+  }
   const stateDir = stateDirOf(opts);
   const resumeId = crypto.randomUUID();
+  const key = stateKey(session, window);
 
   if (opts.installHooks !== false) {
-    await installHooks(cwdAbs, session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
+    await installHooks(cwdAbs, key, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
   }
 
-  const promptFile = path.join(stateDir, `${session}.prompt`);
+  const promptFile = path.join(stateDir, `${key}.prompt`);
   fs.writeFileSync(promptFile, prompt);
 
-  await t.tmux('new-session', '-d', '-s', session, '-c', cwdAbs);
+  await createPane(session, window, cwdAbs);
   try {
     const extra = (opts.extraArgs || []).map(shellQuote).join(' ');
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + `claude --dangerously-skip-permissions --session-id ${resumeId} `
       + (extra ? extra + ' ' : '')
       + `"$(cat ${shellQuote(promptFile)})"`;
-    await launchAndSettle(session, launchCmd);
+    await launchAndSettle(paneTarget(session, window), launchCmd);
   } catch (err) {
-    await t.tryTmux('kill-session', '-t', paneTarget(session));
+    await killPane(session, window);
     try { fs.unlinkSync(promptFile); } catch { /* best-effort */ }
     throw err;
   }
 
-  return { harness: 'claude', session, cwd: cwdAbs, resumeId };
+  const ref = { harness: 'claude', session, cwd: cwdAbs, resumeId };
+  if (window) ref.window = window;
+  return ref;
 }
 
 // send(ref, text) — type into the session with verified submission.
 // Enter is retried, never the text. Throws when the submit provably failed.
 async function send(ref, text) {
-  if (!(await alive(ref))) throw new Error(`session ${ref.session} is not alive`);
-  const verdict = await t.submit(paneTarget(ref.session), text, {
+  const name = stateKey(ref.session, ref.window);
+  if (!(await alive(ref))) throw new Error(`session ${name} is not alive`);
+  const verdict = await t.submit(paneTarget(ref.session, ref.window), text, {
     retries: Number(process.env.BC_SEND_RETRIES || 3),
     enterSleep: Number(process.env.BC_SEND_SLEEP_MS || 400),
   });
   if (verdict === 'pending') {
-    throw new Error(`text not submitted to ${ref.session} (Enter swallowed; text left in composer)`);
+    throw new Error(`text not submitted to ${name} (Enter swallowed; text left in composer)`);
   }
   if (verdict === 'send-failed') {
-    throw new Error(`text not sent to ${ref.session} (tmux send failed)`);
+    throw new Error(`text not sent to ${name} (tmux send failed)`);
   }
   // 'empty' = confirmed; 'unknown' = pane unreadable, assume sent (lenient —
   // an unreadable pane must not turn a normal send into a false error).
   await t.sleep(1000); // let the turn spin up so an immediate capture sees it working
 }
 
-// alive(ref) — tmux session exists AND its pane is still running the agent
-// (a pane sitting back at a bare shell means claude exited).
+// alive(ref) — the ref's session (and window, for window-granular refs) exists
+// AND its pane is still running the agent (a pane sitting back at a bare shell
+// means claude exited).
 async function alive(ref) {
-  if (!(await hasSession(ref.session))) return false;
-  const cmd = await paneCommand(ref.session);
+  if (!(await paneExists(ref.session, ref.window))) return false;
+  const cmd = await paneCommand(paneTarget(ref.session, ref.window));
   return cmd !== null && !SHELLS.has(cmd);
 }
 
@@ -219,7 +291,7 @@ async function alive(ref) {
 async function resumable(ref, opts = {}) {
   if (ref.resumeId) return true;
   try {
-    return !!fs.readFileSync(path.join(stateDirOf(opts), `${ref.session}.session-id`), 'utf8').trim();
+    return !!fs.readFileSync(path.join(stateDirOf(opts), `${stateKey(ref.session, ref.window)}.session-id`), 'utf8').trim();
   } catch {
     return false;
   }
@@ -232,38 +304,42 @@ async function resumable(ref, opts = {}) {
 async function resume(ref, opts = {}) {
   if (await alive(ref)) return { ...ref };
   const stateDir = stateDirOf(opts);
+  const key = stateKey(ref.session, ref.window);
   let resumeId = ref.resumeId;
   try {
-    const rec = fs.readFileSync(path.join(stateDir, `${ref.session}.session-id`), 'utf8').trim();
+    const rec = fs.readFileSync(path.join(stateDir, `${key}.session-id`), 'utf8').trim();
     if (rec) resumeId = rec;
   } catch {
     // no recorded id — fall back to the ref's
   }
-  if (await hasSession(ref.session)) await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+  await killPane(ref.session, ref.window); // clear any dead pane still holding the name
 
   if (opts.installHooks !== false) {
-    await installHooks(ref.cwd, ref.session, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
+    await installHooks(ref.cwd, key, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
   }
-  await t.tmux('new-session', '-d', '-s', ref.session, '-c', ref.cwd);
+  await createPane(ref.session, ref.window, ref.cwd);
   try {
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + 'claude --dangerously-skip-permissions '
       + (resumeId ? `--resume ${resumeId}` : '');
-    await launchAndSettle(ref.session, launchCmd.trim());
+    await launchAndSettle(paneTarget(ref.session, ref.window), launchCmd.trim());
   } catch (err) {
-    await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+    await killPane(ref.session, ref.window);
     throw err;
   }
-  return { harness: 'claude', session: ref.session, cwd: ref.cwd, resumeId };
+  const out = { harness: 'claude', session: ref.session, cwd: ref.cwd, resumeId };
+  if (ref.window) out.window = ref.window;
+  return out;
 }
 
-// kill(ref) — end the session for good. Idempotent: killing a dead or missing
-// session is a no-op. The tmux session goes away (claude inside dies with its
-// pane); harness state files are left behind on purpose — resumeId and the
-// turn-end log are cheap, and a later resume(ref) can still reincarnate the
-// conversation if the kill turns out to have been premature.
+// kill(ref) — end the agent's pane for good. Idempotent: killing a dead or
+// missing one is a no-op. Session-granular refs take the whole session;
+// window-granular refs take ONLY their window (the lieutenant and sibling
+// workers cohabit the session). Harness state files are left behind on
+// purpose — resumeId and the turn-end log are cheap, and a later resume(ref)
+// can still reincarnate the conversation if the kill turns out premature.
 async function kill(ref) {
-  if (await hasSession(ref.session)) await t.tryTmux('kill-session', '-t', paneTarget(ref.session));
+  await killPane(ref.session, ref.window);
 }
 
 // onTurnEnd(ref, hook) -> unsubscribe()
@@ -273,7 +349,7 @@ async function kill(ref) {
 // backstop, so no boundary is missed on filesystems with flaky watch.
 function onTurnEnd(ref, hook, opts = {}) {
   const stateDir = stateDirOf(opts);
-  const file = path.join(stateDir, `${ref.session}.turnend.jsonl`);
+  const file = path.join(stateDir, `${stateKey(ref.session, ref.window)}.turnend.jsonl`);
   let offset = 0;
   try {
     offset = fs.statSync(file).size;

--- a/harness/fake.js
+++ b/harness/fake.js
@@ -2,7 +2,11 @@
 // fake — in-memory harness implementing the same seven verbs, for unit tests
 // of server code. No tmux, no claude, no filesystem.
 //
-// Refs look like the real thing: { harness: 'fake', session: 'bc-<id>', cwd, resumeId }.
+// Refs look like the real thing: { harness: 'fake', session: 'bc-<id>', window?, cwd, resumeId }.
+// A window-granular ref (opts.window at spawn — workers as windows in their
+// lieutenant's session) is keyed as `session:window` everywhere the plain
+// session name would be: the in-memory map, marker files, sends log, and the
+// emitted turn-end event's `session` field.
 //
 // Behavior model:
 //   spawn   — creates a live session, records the prompt as transcript[0],
@@ -33,7 +37,14 @@ const crypto = require('node:crypto');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const sessions = new Map(); // session name -> { alive, cwd, resumeId, transcript, hooks, turns }
+const sessions = new Map(); // key (session or session:window) -> { alive, cwd, resumeId, transcript, hooks, turns }
+
+function keyOf(session, window) {
+  return window ? session + ':' + window : session;
+}
+function refKey(ref) {
+  return keyOf(ref.session, ref.window);
+}
 
 function fakeStateDir() {
   const dir = process.env.BC_FAKE_STATE;
@@ -53,8 +64,8 @@ function logSend(session, text) {
 }
 
 function get(ref) {
-  const s = sessions.get(ref.session);
-  if (!s) throw new Error(`fake: unknown session ${ref.session}`);
+  const s = sessions.get(refKey(ref));
+  if (!s) throw new Error(`fake: unknown session ${refKey(ref)}`);
   return s;
 }
 
@@ -84,11 +95,13 @@ function emitTurnEnd(name) {
 
 async function spawn(cwd, prompt, opts = {}) {
   const session = opts.session || 'bc-' + crypto.randomBytes(3).toString('hex');
-  if (sessions.has(session) && sessions.get(session).alive) {
-    throw new Error(`fake: session ${session} already exists`);
+  const window = opts.window === undefined || opts.window === null ? undefined : String(opts.window);
+  const key = keyOf(session, window);
+  if (sessions.has(key) && sessions.get(key).alive) {
+    throw new Error(`fake: session ${key} already exists`);
   }
   const resumeId = crypto.randomUUID();
-  sessions.set(session, {
+  sessions.set(key, {
     alive: true,
     cwd,
     resumeId,
@@ -96,63 +109,69 @@ async function spawn(cwd, prompt, opts = {}) {
     hooks: [],
     turns: 0,
   });
-  const marker = markerFile(session);
+  const marker = markerFile(key);
   if (marker) {
     // stateDir rides along so a watching test can verify what dir the caller
     // plumbed through the port (the fake itself never writes state there).
     fs.writeFileSync(marker,
       JSON.stringify({ cwd, resumeId, prompt, stateDir: opts.stateDir || null }, null, 2) + '\n');
   }
-  emitTurnEnd(session);
-  return { harness: 'fake', session, cwd, resumeId };
+  emitTurnEnd(key);
+  const ref = { harness: 'fake', session, cwd, resumeId };
+  if (window) ref.window = window;
+  return ref;
 }
 
 async function send(ref, text) {
-  const s = sessions.get(ref.session);
+  const key = refKey(ref);
+  const s = sessions.get(key);
   if (!s) {
     // Cross-process fake session: alive iff its marker file exists.
-    const marker = markerFile(ref.session);
-    if (marker && fs.existsSync(marker)) return logSend(ref.session, text);
-    throw new Error(`fake: unknown session ${ref.session}`);
+    const marker = markerFile(key);
+    if (marker && fs.existsSync(marker)) return logSend(key, text);
+    throw new Error(`fake: unknown session ${key}`);
   }
-  if (!s.alive) throw new Error(`session ${ref.session} is not alive`);
+  if (!s.alive) throw new Error(`session ${key} is not alive`);
   s.transcript.push(text);
-  logSend(ref.session, text);
-  emitTurnEnd(ref.session);
+  logSend(key, text);
+  emitTurnEnd(key);
 }
 
 async function alive(ref) {
-  const s = sessions.get(ref.session);
+  const s = sessions.get(refKey(ref));
   if (s) return s.alive;
-  const marker = markerFile(ref.session);
+  const marker = markerFile(refKey(ref));
   return !!(marker && fs.existsSync(marker));
 }
 
 // resumable — introspection only: memory survives a resume iff this process
 // still holds the session's transcript under the same resumeId.
 async function resumable(ref) {
-  const s = sessions.get(ref.session);
+  const s = sessions.get(refKey(ref));
   return !!(s && ref.resumeId && ref.resumeId === s.resumeId);
 }
 
 async function resume(ref) {
-  const s = sessions.get(ref.session);
+  const key = refKey(ref);
+  const s = sessions.get(key);
   if (s && s.alive) return { ...ref };
+  const out = { harness: 'fake', session: ref.session, cwd: ref.cwd, resumeId: ref.resumeId };
+  if (ref.window) out.window = ref.window;
   if (s && ref.resumeId === s.resumeId) {
     s.alive = true; // memory (transcript) preserved
-    return { harness: 'fake', session: ref.session, cwd: s.cwd, resumeId: s.resumeId };
+    return { ...out, cwd: s.cwd };
   }
   // No matching memory: fresh session under the same name (transcript lost).
-  const resumeId = crypto.randomUUID();
-  sessions.set(ref.session, {
+  out.resumeId = crypto.randomUUID();
+  sessions.set(key, {
     alive: true,
     cwd: ref.cwd,
-    resumeId,
+    resumeId: out.resumeId,
     transcript: [],
     hooks: s ? s.hooks : [],
     turns: 0,
   });
-  return { harness: 'fake', session: ref.session, cwd: ref.cwd, resumeId };
+  return out;
 }
 
 function onTurnEnd(ref, hook) {
@@ -169,9 +188,9 @@ function onTurnEnd(ref, hook) {
 // already-dead sessions are a no-op). File-backed mode also removes the
 // marker so a WATCHING process sees alive() flip false.
 function kill(ref) {
-  const s = sessions.get(ref.session);
+  const s = sessions.get(refKey(ref));
   if (s) s.alive = false;
-  const marker = markerFile(ref.session);
+  const marker = markerFile(refKey(ref));
   if (marker) { try { fs.unlinkSync(marker); } catch { /* already gone */ } }
 }
 

--- a/harness/port.js
+++ b/harness/port.js
@@ -14,7 +14,10 @@
 //
 // A HarnessRef is a plain, JSON-serializable object; `harness` names the
 // implementation and the rest is that implementation's opaque address:
-//   { harness: 'claude', session: 'bc-<id>', cwd: '/abs/path', resumeId?: '<uuid>' }
+//   { harness: 'claude', session: 'bc-<id>', window?: 'w-<id>', cwd: '/abs/path', resumeId?: '<uuid>' }
+// `window` marks a window-granular ref: the agent lives in a named window of
+// a shared session (workers inside their lieutenant's session) instead of
+// owning the whole session.
 //
 // Adding a harness = implementing the seven verbs and registering it here
 // (or shipping it as a builtin module). Nothing else.
@@ -64,6 +67,7 @@ function isHarnessRef(ref) {
     && typeof ref === 'object'
     && typeof ref.harness === 'string' && ref.harness.length > 0
     && typeof ref.session === 'string' && ref.session.length > 0
+    && (ref.window === undefined || (typeof ref.window === 'string' && ref.window.length > 0))
     && typeof ref.cwd === 'string' && ref.cwd.length > 0
     && (ref.resumeId === undefined || typeof ref.resumeId === 'string');
 }

--- a/harness/test/claude-tmux.test.js
+++ b/harness/test/claude-tmux.test.js
@@ -21,3 +21,28 @@ test('resumable: ref.resumeId, else the hook-recorded session-id file, else fals
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+test('resumable for a window-granular ref reads the session:window keyed record', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-state-'));
+  try {
+    const ref = { harness: 'claude', session: 'bc-lt-a', window: 'w-card-7', cwd: '/tmp' };
+    // a record under the bare session name belongs to the LIEUTENANT, not this worker
+    fs.writeFileSync(path.join(dir, 'bc-lt-a.session-id'), 'uuid-lieutenant\n');
+    assert.strictEqual(await claude.resumable(ref, { stateDir: dir }), false, 'never reads the cohabited session record');
+    fs.writeFileSync(path.join(dir, 'bc-lt-a:w-card-7.session-id'), 'uuid-worker\n');
+    assert.strictEqual(await claude.resumable(ref, { stateDir: dir }), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('spawn validates the window name before touching tmux: numeric or hostile names refused', async () => {
+  // tmux parses a numeric window "name" in a target as a window INDEX — the
+  // harness refuses such names outright (papercut #8's core trap).
+  for (const window of ['123', '7', '-w', 'w:x', 'w.x', '']) {
+    await assert.rejects(
+      claude.spawn('/tmp', 'hi', { session: 'bc-t', window }),
+      /invalid window name/,
+      `window "${window}" must be refused`);
+  }
+});

--- a/server/names.js
+++ b/server/names.js
@@ -32,8 +32,13 @@ function lieutenantSession(workspace, id) {
   return 'bc-' + workspaceDisc(workspace) + '-lt-' + safe(id);
 }
 
-function workerSession(workspace, cardId) {
-  return 'bc-' + workspaceDisc(workspace) + '-w-' + safe(cardId);
+// workerWindow(cardId) -> tmux window name for a card's worker inside its
+// owning lieutenant's session (papercut #8). The 'w-' prefix guarantees the
+// name can never read as a bare number, which tmux would parse as a window
+// INDEX instead of a name. No workspace discriminator: the enclosing
+// lieutenant session already carries it, and card ids are unique per board.
+function workerWindow(cardId) {
+  return 'w-' + safe(cardId);
 }
 
-module.exports = { workspaceDisc, lieutenantSession, workerSession };
+module.exports = { workspaceDisc, lieutenantSession, workerWindow };

--- a/server/server.js
+++ b/server/server.js
@@ -939,9 +939,24 @@ async function addProject(body) {
 }
 
 // ---------- workers (F5: card.start, worker.signal, worker done) ----------
-// Session names carry the workspace discriminator (names.js) — refs are data,
-// so workers recorded under older name schemes keep working via ref.session.
-function workerSession(cardId) { return names.workerSession(WORKSPACE, cardId); }
+// A worker lives as a tmux WINDOW inside its owning lieutenant's session
+// (papercut #8): ref = { session: <lieutenant session>, window: 'w-<card-id>' }.
+// The 'w-' prefix keeps tmux from ever parsing the window name as an index.
+// Lifecycle coupling is accepted design — the lieutenant's session dying takes
+// its worker windows with it (supervision then flags them as died). Refs are
+// data, so workers recorded under the old one-session-per-worker scheme keep
+// working via their session-only ref.
+function ownerSession(card) {
+  const lt = board.lieutenants.find((l) => l.id === card.owner);
+  // Mirror the supervision respawn rule: a founder's foreign session name is
+  // not spawnable — those workers get the workspace-scoped lieutenant name.
+  return lt && isHarnessRef(lt.ref) && /^bc-[A-Za-z0-9_-]+$/.test(lt.ref.session)
+    ? lt.ref.session
+    : names.lieutenantSession(WORKSPACE, card.owner);
+}
+// workerName(ref) — the attach-facing address of a worker's pane:
+// `session:window` for window-granular refs, the bare session for legacy ones.
+function workerName(ref) { return ref.window ? ref.session + ':' + ref.window : ref.session; }
 function findWorker(cardId) { return board.workers.find((w) => w.card === cardId); }
 
 // The system move into Working — card.start is the ONE way in (invariant:
@@ -1012,13 +1027,13 @@ async function doStartCard(card, body) {
     delete existing.flagged;
     delete existing.stopNotified;
     delete existing.paused; // a revived worker is watched again
-    enterWorking(card, 'worker ' + ref.session + ' resumed in ' + existing.worktree.path);
+    enterWorking(card, 'worker ' + workerName(ref) + ' resumed in ' + existing.worktree.path);
     return { worker: existing, resumed: true };
   }
 
   if (card.column === 'working') return { error: 'card is already Working', code: 409 };
   if (existing && !existing.done) {
-    return { error: 'card already has a worker (' + existing.ref.session + ') — resume it (card start --resume) or archive first', code: 409 };
+    return { error: 'card already has a worker (' + workerName(existing.ref) + ') — resume it (card start --resume) or archive first', code: 409 };
   }
   const repoAttr = card.attributes && card.attributes.repo;
   if (!repoAttr) return { error: 'card has no repo attribute — set it first: card patch ' + card.id + ' --attr repo=<project>' };
@@ -1037,7 +1052,7 @@ async function doStartCard(card, body) {
     let up = false;
     try { up = await harnessFor(existing.ref).alive(existing.ref); } catch (e) { up = false; }
     if (up) {
-      return { error: 'previous worker session ' + existing.ref.session + ' is still alive — resume it (card start --resume) or steer it instead of spawning over it', code: 409 };
+      return { error: 'previous worker session ' + workerName(existing.ref) + ' is still alive — resume it (card start --resume) or steer it instead of spawning over it', code: 409 };
     }
     const prevProject = findProject(existing.project) || project;
     const rel = await releaseWorktree(existing.worktree, prevProject.path);
@@ -1052,14 +1067,15 @@ async function doStartCard(card, body) {
   try { wt = await createWorktree(project.path, card.id, WORKSPACE); }
   catch (e) { return { error: 'worktree provisioning failed: ' + String((e && e.message) || e), code: 502 }; }
 
-  const session = workerSession(card.id);
+  const session = ownerSession(card);
+  const window = names.workerWindow(card.id);
   const branch = card.type === 'investigation' ? null : 'bc/' + card.id;
   const prompt = workerBrief({
     card, task: body && body.brief, thread: card.thread || [],
     project, worktree: wt.path, branch: branch || '', workspace: WORKSPACE,
     cli: path.join(__dirname, '..', 'cli', 'bc-axi'),
   });
-  const spawnOpts = { session, stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL };
+  const spawnOpts = { session, window, stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL };
   if (body && body.model) spawnOpts.extraArgs = ['--model', String(body.model)];
   let ref;
   try {
@@ -1074,13 +1090,13 @@ async function doStartCard(card, body) {
     return { error: 'card left the board during start: ' + card.id, code: 409 };
   }
 
-  card.attributes.session = session;
+  card.attributes.session = workerName(ref);
   card.attributes.worktree = wt.path;
   if (branch) card.attributes.branch = branch;
   const worker = { card: card.id, ref, worktree: wt, project: project.name, spawnedAt: now(), done: false };
   if (branch) worker.branch = branch;
   board.workers.push(worker);
-  enterWorking(card, 'worker ' + session + ' started in ' + wt.path);
+  enterWorking(card, 'worker ' + workerName(ref) + ' started in ' + wt.path);
   return { worker };
 }
 
@@ -1151,17 +1167,17 @@ async function workerSend(card, body) {
   let up = false;
   try { up = await harnessFor(w.ref).alive(w.ref); } catch (e) { up = false; }
   if (!up) {
-    return { error: 'worker session ' + w.ref.session + ' is not alive — resume it first (card start ' + card.id + ' --resume), then send', code: 409 };
+    return { error: 'worker session ' + workerName(w.ref) + ' is not alive — resume it first (card start ' + card.id + ' --resume), then send', code: 409 };
   }
   try {
     await harnessFor(w.ref).send(w.ref, text);
   } catch (e) {
-    return { error: 'delivery to ' + w.ref.session + ' failed: ' + String((e && e.message) || e), code: 502 };
+    return { error: 'delivery to ' + workerName(w.ref) + ' failed: ' + String((e && e.message) || e), code: 502 };
   }
   const ev = mkEvent({ text: 'sent to worker: ' + text.slice(0, 1900), actor: (body && body.actor) || 'agent' }, { kind: 'worker-send' });
   card.events.push(ev);
   card.updated = now();
-  return { ok: true, event: ev, session: w.ref.session };
+  return { ok: true, event: ev, session: workerName(w.ref) };
 }
 
 // worker.pause — a DELIBERATE stop: kill the worker's session but record the
@@ -1186,16 +1202,16 @@ async function pauseWorker(card, body) {
     await harnessFor(w.ref).kill(w.ref);
   } catch (e) {
     delete w.paused; // the session may still be alive — stay honest, let supervision judge
-    return { error: 'pause failed killing session ' + w.ref.session + ': ' + String((e && e.message) || e), code: 502 };
+    return { error: 'pause failed killing session ' + workerName(w.ref) + ': ' + String((e && e.message) || e), code: 502 };
   }
   const actor = String((body && body.actor) || 'agent').slice(0, 60);
   const ev = mkEvent({
-    text: 'worker ' + w.ref.session + ' paused (deliberate) — resume: card start ' + card.id + ' --resume',
+    text: 'worker ' + workerName(w.ref) + ' paused (deliberate) — resume: card start ' + card.id + ' --resume',
     actor,
   }, { kind: 'worker-paused' });
   card.events.push(ev);
   card.updated = now();
-  const out = { ok: true, event: ev, session: w.ref.session };
+  const out = { ok: true, event: ev, session: workerName(w.ref) };
   if (body && body.park) {
     const p = await parkCard(card, body);
     if (p.error) { out.parked = false; out.parkError = p.error; }
@@ -1219,9 +1235,9 @@ async function parkCard(card, body) {
     try { up = await harnessFor(w.ref).alive(w.ref); } catch (e) { up = false; }
     if (up) {
       return w.done
-        ? { error: 'refusing to park ' + card.id + ': its worker reported done and session ' + w.ref.session
+        ? { error: 'refusing to park ' + card.id + ': its worker reported done and session ' + workerName(w.ref)
             + ' is still alive — verify the work and hand off (card move ' + card.id + ' review), or archive', code: 409 }
-        : { error: 'refusing to park ' + card.id + ': worker session ' + w.ref.session
+        : { error: 'refusing to park ' + card.id + ': worker session ' + workerName(w.ref)
             + ' is ALIVE — pause it first (worker pause ' + card.id + ' [--park]) or let it finish', code: 409 };
     }
   }
@@ -1232,7 +1248,7 @@ async function parkCard(card, body) {
   if (w) delete w.stopNotified; // leaving Working ends the stop-state
   const ev = mkEvent({
     actor: (body && body.actor) || 'agent',
-    text: 'parked (worker ' + (w ? w.ref.session + (w.paused ? ', paused' : ', dead') : 'absent') + '): '
+    text: 'parked (worker ' + (w ? workerName(w.ref) + (w.paused ? ', paused' : ', dead') : 'absent') + '): '
       + columnTitle(from) + ' → ' + columnTitle('backlog'),
   }, { kind: 'parked' });
   card.events.push(ev);
@@ -1323,13 +1339,13 @@ async function superviseTick() {
       const card = findCard(w.card);
       if (card) {
         card.events.push(mkEvent({
-          text: 'worker session ' + w.ref.session + ' died without reporting done',
+          text: 'worker session ' + workerName(w.ref) + ' died without reporting done',
           actor: 'server',
         }, { kind: 'worker-died' }));
         card.updated = now();
         queuePush(card.owner, {
           kind: 'worker-died', card: card.id,
-          text: 'worker session ' + w.ref.session + ' died without reporting done',
+          text: 'worker session ' + workerName(w.ref) + ' died without reporting done',
         });
       }
     }
@@ -1534,7 +1550,9 @@ const server = http.createServer(async (req, res) => {
       if (!lt && sname) lt = board.lieutenants.find((l) => isHarnessRef(l.ref) && l.ref.session === sname);
       if (!lt) {
         let w = sid ? board.workers.find((x) => x.ref.resumeId === sid) : null;
-        if (!w && sname) w = board.workers.find((x) => x.ref.session === sname);
+        // A window-granular worker's hook posts the `session:window` key —
+        // never the bare session name it shares with its lieutenant.
+        if (!w && sname) w = board.workers.find((x) => workerName(x.ref) === sname);
         if (w) {
           if (sid && w.ref.resumeId !== sid) w.ref.resumeId = sid; // hook payload is ground truth
           w.lastTurnEnd = now();
@@ -1548,7 +1566,7 @@ const server = http.createServer(async (req, res) => {
           if (card && card.column === 'working' && !w.done && !w.stopNotified) {
             w.stopNotified = true;
             stopped = true;
-            const text = 'worker ' + w.ref.session + ' stopped without reporting done';
+            const text = 'worker ' + workerName(w.ref) + ' stopped without reporting done';
             card.events.push(mkEvent({ text, actor: 'server' }, { kind: 'worker-stopped' }));
             card.updated = now();
             queuePush(card.owner, { kind: 'worker-stopped', card: card.id, text });
@@ -1558,7 +1576,12 @@ const server = http.createServer(async (req, res) => {
           return sendJson(res, 200, { ok: true, lieutenant: null, worker: w.card });
         }
       }
-      if (!lt && tmux) lt = board.lieutenants.find((l) => isHarnessRef(l.ref) && l.ref.session === tmux);
+      // Window-granular worker hooks are excluded from tmux attribution: their
+      // `session:window` key carries a ':' no session name can (names.js emits
+      // [A-Za-z0-9-] only), and their pane's tmux_session IS the lieutenant
+      // session they cohabit — without this guard a stale worker POST (its
+      // record already gone) would corrupt that lieutenant's resumeId.
+      if (!lt && tmux && !sname.includes(':')) lt = board.lieutenants.find((l) => isHarnessRef(l.ref) && l.ref.session === tmux);
       if (!lt && tmux === null && sid) {
         const cands = board.lieutenants.filter((l) => isHarnessRef(l.ref) && !l.ref.resumeId);
         if (cands.length === 1 && body.cwd && path.resolve(String(body.cwd)) === cands[0].ref.cwd) lt = cands[0];

--- a/test/names.test.js
+++ b/test/names.test.js
@@ -1,12 +1,13 @@
 'use strict';
 // Workspace-scoped session naming: deterministic per workspace, distinct
-// across workspaces, ASCII-only, tmux-safe (no dots/colons).
+// across workspaces, ASCII-only, tmux-safe (no dots/colons). Worker WINDOW
+// names (papercut #8) are non-numeric so tmux can never read them as indexes.
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { workspaceDisc, lieutenantSession, workerSession } = require('../server/names.js');
+const { workspaceDisc, lieutenantSession, workerWindow } = require('../server/names.js');
 
 const TMUX_SAFE = /^bc-[A-Za-z0-9-]+$/; // no dots, no colons, ASCII only
 
@@ -19,14 +20,23 @@ test('names are deterministic per workspace and distinct across workspaces', () 
     assert.strictEqual(lieutenantSession(a, 'monica'), lieutenantSession(a, 'monica'));
     assert.notStrictEqual(lieutenantSession(a, 'monica'), lieutenantSession(b, 'monica'),
       'same-named lieutenant on two boards gets distinct sessions');
-    assert.notStrictEqual(workerSession(a, 'fix-1'), workerSession(b, 'fix-1'));
     // shape: discriminator between the bc- prefix and the role marker
     assert.match(lieutenantSession(a, 'monica'), /^bc-.+-lt-monica$/);
-    assert.match(workerSession(a, 'fix-1'), /^bc-.+-w-fix-1$/);
   } finally {
     fs.rmSync(a, { recursive: true, force: true });
     fs.rmSync(b, { recursive: true, force: true });
   }
+});
+
+test('workerWindow: deterministic, w- prefixed, never numeric (the tmux index trap)', () => {
+  assert.strictEqual(workerWindow('fix-1'), 'w-fix-1');
+  assert.strictEqual(workerWindow('fix-1'), workerWindow('fix-1'));
+  // a numeric-looking card id must still yield a NON-numeric window name —
+  // tmux parses a bare number in a target as a window INDEX, not a name
+  assert.strictEqual(workerWindow('123'), 'w-123');
+  assert.doesNotMatch(workerWindow('123'), /^\d/);
+  // hostile ids collapse to the tmux-safe charset
+  assert.match(workerWindow('fix.a:b'), /^w-[A-Za-z0-9_-]+$/);
 });
 
 test('names are tmux-safe ASCII even for hostile workspace basenames and ids', () => {
@@ -36,7 +46,6 @@ test('names are tmux-safe ASCII even for hostile workspace basenames and ids', (
     fs.mkdirSync(emojiWs);
     for (const s of [
       lieutenantSession(emojiWs, 'marcela'),
-      workerSession(emojiWs, 'fix.a:b'),
       lieutenantSession(root, 'a'.repeat(40)), // the server's derived-id cap
     ]) {
       assert.match(s, TMUX_SAFE, s);

--- a/test/pause-park.test.js
+++ b/test/pause-park.test.js
@@ -14,8 +14,13 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { startServer, startServerWithLieutenant, withOwner, runCli, sleep } = require('./helper');
-const { workerSession } = require('../server/names.js');
+const { startServer, startServerWithLieutenant, withOwner, runCli, sleep, LT } = require('./helper');
+const { lieutenantSession, workerWindow } = require('../server/names.js');
+
+// The worker's harness key: a window inside the owning lieutenant's session.
+function workerKey(dir, cardId) {
+  return lieutenantSession(dir, LT) + ':' + workerWindow(cardId);
+}
 
 function git(dir, ...args) {
   return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
@@ -62,7 +67,7 @@ test('worker pause: deliberate stop — session killed, worker-paused event, NO 
     await s.api('POST', '/api/cards', withOwner({ title: 'Nap', id: 'nap', attributes: { repo: 'proj' } }));
     const started = await s.api('POST', '/api/cards/nap/start', { harness: 'fake' });
     assert.strictEqual(started.status, 200, JSON.stringify(started.body));
-    const session = workerSession(s.dir, 'nap');
+    const session = workerKey(s.dir, 'nap');
 
     const r = await s.api('POST', '/api/cards/nap/worker/pause', { actor: 'agent' });
     assert.strictEqual(r.status, 200, JSON.stringify(r.body));
@@ -205,7 +210,7 @@ test('worker pause --park composes: one call, session dead + card in Backlog, no
     assert.strictEqual(card.column, 'backlog');
     assert.ok(card.events.some((e) => e.kind === 'worker-paused'));
     assert.ok(card.events.some((e) => e.kind === 'parked'));
-    assert.ok(!fs.existsSync(path.join(fdir, workerSession(s.dir, 'shelve') + '.json')), 'session killed');
+    assert.ok(!fs.existsSync(path.join(fdir, workerKey(s.dir, 'shelve') + '.json')), 'session killed');
 
     await sleep(700); // ticks over the paused+parked worker: silence
     const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;

--- a/test/supervise.test.js
+++ b/test/supervise.test.js
@@ -164,31 +164,33 @@ test('dead worker without done: worker-died QueueItem + card event, card stays W
       lieutenants: [{ id: 'ada', name: 'Ada', color: '#58b6ff', charter: '', chat: [], created: nowIso }],
       cards: [{
         id: 'doomed', title: 'Doomed', type: 'implementation', owner: 'ada', column: 'working',
-        labels: [], attributes: { repo: 'proj', session: 'bc-w-doomed' }, body: '',
+        labels: [], attributes: { repo: 'proj', session: 'bc-lt-ada:w-doomed' }, body: '',
         created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
       }, {
         id: 'fine', title: 'Fine', type: 'implementation', owner: 'ada', column: 'working',
-        labels: [], attributes: { repo: 'proj', session: 'bc-w-fine' }, body: '',
+        labels: [], attributes: { repo: 'proj', session: 'bc-lt-ada:w-fine' }, body: '',
         created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
       }, {
         id: 'finished', title: 'Finished', type: 'implementation', owner: 'ada', column: 'working',
         labels: [], attributes: {}, body: '',
         created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
       }],
+      // workers live as windows inside their lieutenant's session — liveness
+      // and kill are window-granular (the session:window key)
       workers: [
-        { card: 'doomed', ref: { harness: 'fake', session: 'bc-w-doomed', cwd: '/tmp', resumeId: 'a' },
+        { card: 'doomed', ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-doomed', cwd: '/tmp', resumeId: 'a' },
           worktree: { path: '/tmp/none', tool: 'git' }, branch: 'bc/doomed', project: 'proj', spawnedAt: nowIso, done: false },
-        { card: 'fine', ref: { harness: 'fake', session: 'bc-w-fine', cwd: '/tmp', resumeId: 'b' },
+        { card: 'fine', ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-fine', cwd: '/tmp', resumeId: 'b' },
           worktree: { path: '/tmp/none2', tool: 'git' }, branch: 'bc/fine', project: 'proj', spawnedAt: nowIso, done: false },
-        // done long ago and its session gone — supervision must NOT nag about it
-        { card: 'finished', ref: { harness: 'fake', session: 'bc-w-finished', cwd: '/tmp', resumeId: 'c' },
+        // done long ago and its window gone — supervision must NOT nag about it
+        { card: 'finished', ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-finished', cwd: '/tmp', resumeId: 'c' },
           worktree: { path: '/tmp/none3', tool: 'git' }, branch: 'bc/finished', project: 'proj', spawnedAt: nowIso,
           done: true, outcome: 'shipped' },
       ],
     }),
   });
   try {
-    fakeSession(fdir, 'bc-w-fine'); // alive via marker; bc-w-doomed and bc-w-finished are dead
+    fakeSession(fdir, 'bc-lt-ada:w-fine'); // alive via marker; w-doomed and w-finished windows are dead
     await until('worker-died queue item', async () => {
       const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
       return items.some((i) => i.kind === 'worker-died' && i.card === 'doomed');

--- a/test/turnend-attribution.test.js
+++ b/test/turnend-attribution.test.js
@@ -60,6 +60,27 @@ test('a stray session with a foreign tmux_session is dropped, never adopted', as
   }
 });
 
+test('a window-worker hook (session:window key) is never attributed to the cohabited lieutenant', async () => {
+  const s = await startServer();
+  try {
+    // Workers live as windows INSIDE the lieutenant's session, so a worker
+    // hook's tmux_session IS the lieutenant's session name. A stale worker
+    // POST (its registry record already gone) must not fall through to tmux
+    // attribution and corrupt the lieutenant's resumeId.
+    await s.api('POST', '/api/lieutenants', { name: 'Monica', id: 'monica',
+      ref: { harness: 'fake', session: 'bc-x-lt-monica', cwd: '/tmp', resumeId: 'uuid-lt' } });
+    const r = await s.api('POST', '/api/turn-end', {
+      session: 'bc-x-lt-monica:w-gone-card', session_id: 'uuid-stale-worker',
+      cwd: '/tmp/worktree', tmux_session: 'bc-x-lt-monica',
+    });
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.body.lieutenant, null);
+    assert.strictEqual((await lts(s))[0].ref.resumeId, 'uuid-lt', 'lieutenant resumeId untouched');
+  } finally {
+    await s.stop();
+  }
+});
+
 test('legacy hooks (no tmux_session field): single-candidate adoption holds, foreign cwd refused', async () => {
   const s = await startServer();
   try {

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -11,7 +11,14 @@ const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 const { startServerWithLieutenant, withOwner, runCli, LT } = require('./helper');
-const { workerSession } = require('../server/names.js');
+const { lieutenantSession, workerWindow } = require('../server/names.js');
+
+// A worker's harness key/address: a WINDOW inside the owning lieutenant's
+// session (papercut #8) — `session:window`, the form marker files and
+// turn-end payloads carry.
+function workerKey(dir, cardId) {
+  return lieutenantSession(dir, LT) + ':' + workerWindow(cardId);
+}
 
 function git(dir, ...args) {
   return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
@@ -100,10 +107,12 @@ test('card.start: worktree + spawn + bind + system move, brief contract, registr
     const r = await s.api('POST', '/api/cards/fix-login/start', { harness: 'fake' });
     assert.strictEqual(r.status, 200, JSON.stringify(r.body));
     const w = r.body.worker;
-    // workspace-scoped session name: discriminator between bc- and -w-
-    const sess = workerSession(s.dir, 'fix-login');
-    assert.strictEqual(w.ref.session, sess);
-    assert.match(sess, /^bc-[A-Za-z0-9-]+-w-fix-login$/);
+    // the worker is a WINDOW inside the owning lieutenant's session; the
+    // window name is w- prefixed so tmux never parses it as an index
+    assert.strictEqual(w.ref.session, lieutenantSession(s.dir, LT));
+    assert.strictEqual(w.ref.window, 'w-fix-login');
+    const sess = workerKey(s.dir, 'fix-login');
+    assert.match(sess, /^bc-[A-Za-z0-9-]+-lt-ada:w-fix-login$/);
     assert.ok(w.ref.resumeId, 'resumeId known at birth');
     assert.strictEqual(w.branch, 'bc/fix-login');
     assert.strictEqual(w.project, 'proj');
@@ -147,7 +156,8 @@ test('card.start: worktree + spawn + bind + system move, brief contract, registr
     const disk = boardOnDisk(s);
     assert.strictEqual(disk.workers.length, 1);
     assert.strictEqual(disk.workers[0].card, 'fix-login');
-    assert.strictEqual(disk.workers[0].ref.session, sess);
+    assert.strictEqual(disk.workers[0].ref.session, lieutenantSession(s.dir, LT));
+    assert.strictEqual(disk.workers[0].ref.window, 'w-fix-login');
   } finally { await teardown(); }
 });
 
@@ -210,7 +220,7 @@ test('investigation: brief carries the report contract, no branch; done attaches
     const card0 = r.body.card;
     assert.strictEqual(card0.attributes.branch, undefined);
 
-    const rec = JSON.parse(fs.readFileSync(path.join(fdir, workerSession(s.dir, 'why-slow') + '.json'), 'utf8'));
+    const rec = JSON.parse(fs.readFileSync(path.join(fdir, workerKey(s.dir, 'why-slow') + '.json'), 'utf8'));
     assert.match(rec.prompt, /investigation/);
     assert.match(rec.prompt, /reports\/why-slow\.md/);
     assert.doesNotMatch(rec.prompt, /git checkout -b/);
@@ -237,14 +247,15 @@ test('turn-end resolves worker refs (before lieutenant adoption), hook payload i
     await s.api('PATCH', '/api/lieutenants/' + LT, { ref: { harness: 'fake', session: 'lt-tmux', cwd: '/tmp' } });
     await s.api('POST', '/api/cards', withOwner({ title: 'Turns', id: 'turns', attributes: { repo: 'proj' } }));
     const w = (await s.api('POST', '/api/cards/turns/start', { harness: 'fake' })).body.worker;
+    const key = w.ref.session + ':' + w.ref.window; // what the worker's hook posts
 
     // match by the worker's resumeId
-    let r = await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: w.ref.resumeId });
+    let r = await s.api('POST', '/api/turn-end', { session: key, session_id: w.ref.resumeId });
     assert.strictEqual(r.body.worker, 'turns');
     assert.strictEqual(r.body.lieutenant, null);
 
-    // match by session name; a CHANGED session_id is adopted as ground truth
-    r = await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: 'uuid-after-resume' });
+    // match by the session:window key; a CHANGED session_id is adopted as ground truth
+    r = await s.api('POST', '/api/turn-end', { session: key, session_id: 'uuid-after-resume' });
     assert.strictEqual(r.body.worker, 'turns');
     const disk = boardOnDisk(s);
     assert.strictEqual(disk.workers[0].ref.resumeId, 'uuid-after-resume');
@@ -260,11 +271,12 @@ test('worker turn-end without done on a Working card wakes the owner (worker-sto
   try {
     await s.api('POST', '/api/cards', withOwner({ title: 'Wedged', id: 'wedged', attributes: { repo: 'proj' } }));
     const w = (await s.api('POST', '/api/cards/wedged/start', { harness: 'fake' })).body.worker;
+    const key = w.ref.session + ':' + w.ref.window;
     const stopItems = async () => (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items
       .filter((i) => i.kind === 'worker-stopped' && i.card === 'wedged');
 
     // first stop: QueueItem + level-2 card event; the card does NOT move
-    let r = await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: w.ref.resumeId });
+    let r = await s.api('POST', '/api/turn-end', { session: key, session_id: w.ref.resumeId });
     assert.strictEqual(r.body.worker, 'wedged');
     assert.strictEqual((await stopItems()).length, 1);
     const card = (await s.api('GET', '/api/cards/wedged')).body;
@@ -275,23 +287,23 @@ test('worker turn-end without done on a Working card wakes the owner (worker-sto
     assert.match(ev.text, /stopped without reporting done/);
 
     // repeat turn-ends in the same stop-state coalesce — no stacking
-    await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: w.ref.resumeId });
+    await s.api('POST', '/api/turn-end', { session: key, session_id: w.ref.resumeId });
     assert.strictEqual((await stopItems()).length, 1);
 
     // a signal opens a fresh stop-state: the next stop re-notifies
     await s.api('POST', '/api/cards/wedged/worker/signal', { text: 'steered — back at it' });
-    await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: w.ref.resumeId });
+    await s.api('POST', '/api/turn-end', { session: key, session_id: w.ref.resumeId });
     assert.strictEqual((await stopItems()).length, 2);
 
-    // the drain hint names the stop and the session to peek
+    // the drain hint names the stop and the session:window to peek
     const cli = await runCli(['drain', '--lieutenant', LT, '--workspace', s.dir, '--port', String(s.port)]);
     assert.strictEqual(cli.code, 0, cli.stderr);
     assert.match(cli.stdout, /WORKER STOPPED — card wedged/);
-    assert.match(cli.stdout, new RegExp('tmux attach -t ' + w.ref.session.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+    assert.match(cli.stdout, new RegExp('tmux attach -t ' + key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
 
     // after done, turn-ends only bump counters — never a worker-stopped item
     await s.api('POST', '/api/cards/wedged/worker/done', { outcome: 'finished for real' });
-    await s.api('POST', '/api/turn-end', { session: w.ref.session, session_id: w.ref.resumeId });
+    await s.api('POST', '/api/turn-end', { session: key, session_id: w.ref.resumeId });
     assert.strictEqual((await stopItems()).length, 2);
   } finally { await teardown(); }
 });
@@ -310,7 +322,8 @@ test('card start --resume reincarnates a dead recorded worker in the same worktr
     assert.strictEqual(r.status, 200, JSON.stringify(r.body));
     assert.strictEqual(r.body.resumed, true);
     const w = r.body.worker;
-    assert.strictEqual(w.ref.session, workerSession(s.dir, 'crashy'));
+    assert.strictEqual(w.ref.session, lieutenantSession(s.dir, LT));
+    assert.strictEqual(w.ref.window, workerWindow('crashy'));
     assert.strictEqual(w.worktree.path, first.worktree.path, 'same worktree — context preserved');
     assert.strictEqual(w.done, false);
     assert.strictEqual((await s.api('GET', '/api/cards/crashy')).body.column, 'working');
@@ -350,7 +363,7 @@ test('fresh restart after done: refuses over a live session; releases the dead o
     // the session dies (server restart clears the in-process fake; drop its
     // cross-process marker too), then a fresh start reprovisions
     await s.stop();
-    fs.rmSync(path.join(fdir, workerSession(wsDir, 'redo') + '.json'), { force: true });
+    fs.rmSync(path.join(fdir, workerKey(wsDir, 'redo') + '.json'), { force: true });
     s = await startServerWithLieutenant({ dir: wsDir, env });
     r = await s.api('POST', '/api/cards/redo/start', { harness: 'fake', brief: 'redo it with tests' });
     assert.strictEqual(r.status, 200, JSON.stringify(r.body));
@@ -362,7 +375,7 @@ test('fresh restart after done: refuses over a live session; releases the dead o
     assert.strictEqual(wtList.length, 2, 'clone + exactly one linked worktree:\n' + wtList.join('\n'));
     assert.ok(fs.existsSync(r.body.worker.worktree.path), 'new worktree provisioned');
     assert.strictEqual(r.body.worker.worktree.path, first.worktree.path, 'same deterministic path reused');
-    assert.match(JSON.parse(fs.readFileSync(path.join(fdir, workerSession(wsDir, 'redo') + '.json'), 'utf8')).prompt, /redo it with tests/);
+    assert.match(JSON.parse(fs.readFileSync(path.join(fdir, workerKey(wsDir, 'redo') + '.json'), 'utf8')).prompt, /redo it with tests/);
     const disk = boardOnDisk(s);
     assert.strictEqual(disk.workers.filter((w) => w.card === 'redo').length, 1, 'one registry entry per card');
     assert.strictEqual(disk.workers.find((w) => w.card === 'redo').done, false);
@@ -386,9 +399,9 @@ test('worker send: delivers into the live worker session + level-2 card event; l
     assert.strictEqual(cli.code, 1);
     assert.match(cli.stderr, /no worker bound/);
 
-    // live worker → text typed into its session (the fake logs sends), event recorded
+    // live worker → text typed into its window (the fake logs sends), event recorded
     assert.strictEqual((await s.api('POST', '/api/cards/steer/start', { harness: 'fake' })).status, 200);
-    const sess = workerSession(s.dir, 'steer');
+    const sess = workerKey(s.dir, 'steer');
     cli = await runCli(['worker', 'send', 'steer', 'also fix the flaky test', ...wsArgs]);
     assert.strictEqual(cli.code, 0, cli.stderr);
     assert.match(cli.stdout, /sent -> worker /);


### PR DESCRIPTION
## Workers as tmux windows in the lieutenant's session (papercut #8)

### Captain's binding design decisions (honored exactly)
- Workers spawn as **windows inside the owning lieutenant's session** (`bc-<ws>-lt-<id>`), window name = card id with a **`w-` prefix** so tmux can never parse the target as a window index. All addressing uses the exact-match `=session:=window` form.
- **Lifecycle coupling is accepted**: no fleet session, no window-rescue. The lieutenant's session dying takes its worker windows with it; supervision then flags them as died.
- **No migration / no dual-form addressing**: `names.workerSession` is removed. Existing live workers are killed and recreated by the operator after deploy.

### Ref shape change
`HarnessRef` gains an optional `window`:
```
{ harness, session, window?, cwd, resumeId? }
```
- Session-granular refs (lieutenants, old recorded workers) behave exactly as before.
- Window-granular refs key **all** per-agent state by `session:window` (prompt file, `.session-id`, `.turnend.jsonl`, Stop-hook argv, fake-harness markers/sends) — the bare session name now belongs to the cohabiting lieutenant and would collide. tmux session names can never contain `:`, so the key is unambiguous.
- `isHarnessRef` accepts the optional `window` (port.js).

### Every tmux call site touched (`harness/claude-tmux.js`)
- `paneTarget(session, window)` → `=ses:=win` (window) / `=ses:` (session).
- `spawn`: validates window name `/^[A-Za-z][A-Za-z0-9_-]*$/` (numeric names refused outright), then `new-window -d -t '=ses:' -n win -c cwd` when the session exists, else `new-session -d -s ses -n win -c cwd` (session created on demand, `-d` so a spawn never steals the lieutenant's focus).
- `hasWindow`: strict existence via `list-windows` — **verified tmux 3.4 quirk: `display-message -t '=ses:=missing'` does NOT error, it silently falls back to another pane**, so display-message is never used for existence.
- `launchAndSettle`, `paneCommand`, `send/submit`, `capture`: all take the pane target (window-aware).
- `kill`/failure-cleanup/`resume` pre-kill → `kill-window` for window refs (session + siblings survive), `kill-session` for session refs.
- `resume`: recreates the window in the (possibly recreated) lieutenant session and relaunches `claude --resume` with the `session:window`-keyed recorded id.
- `harness/tmux.js` primitives unchanged — confirmed they pass targets through opaquely.

### Server (`server/server.js`)
- `ownerSession(card)`: worker spawns into the owner lieutenant's `ref.session` when it matches `/^bc-[A-Za-z0-9_-]+$/` (mirrors the supervision respawn rule), else the workspace-scoped `names.lieutenantSession`. `names.workerWindow(cardId)` = `w-<card-id>`.
- `workerName(ref)` (`session:window`, legacy fallback bare session) used in `card.attributes.session`, all worker-facing events/errors, and the `worker send`/`pause` responses.
- Turn-end route: worker match by the `session:window` key; **tmux attribution for lieutenants is guarded with `!sname.includes(':')`** — a worker's pane `tmux_session` IS the lieutenant's session, and without the guard a stale worker POST (record already gone) would corrupt the lieutenant's `resumeId`.
- Supervision/pause/park/archive/PR-watch kill paths all go through the port → window-granular automatically.

### Tests (all green: `node --test test/*.test.js harness/test/*.test.js` → 158 pass)
- `names.test.js`: `workerWindow` deterministic, `w-` prefixed, non-numeric even for numeric card ids, hostile-charset safe.
- `workers.test.js` / `pause-park.test.js` / `supervise.test.js`: reworked to the window scheme (ref `{session: lt, window: w-<id>}`, `session:window` marker files, turn-end by key, window-granular alive/kill).
- `turnend-attribution.test.js`: **new** — a stale window-worker POST with `tmux_session` = the cohabited lieutenant's session is never attributed to that lieutenant.
- `harness/test/claude-tmux.test.js`: **new** — window-keyed `resumable` never reads the cohabited session's record; numeric/hostile window names refused before any tmux call.
- `e2e/worker.e2e.js` + `e2e/prwatch.e2e.js` updated to assert windows via strict `list-windows`.

### Live evidence (throwaway server on :4899, throwaway workspace, real claude workers — never touched :4780)
1. `card start noop-a` → `started worker claude:bc-ws-0fb683-lt-monica:w-noop-a` (lieutenant session auto-created with the worker window).
2. `card start 123` (numeric card id) → `w-123` landed in the SAME session: `list-windows` → `1:w-noop-a pane=claude`, `2:w-123 pane=claude`. Targeting `=ses:=w-123` resolves by name — the index trap is dead.
3. `worker send 123 "MARKER..."` → marker present in `w-123` pane capture (grep 1), absent from `w-noop-a` (grep 0) — send resolves the right window.
4. `worker pause noop-a` → only `w-noop-a` died; `w-123` + session survived (window-granular kill).
5. `card start noop-a --resume` → window recreated in the same session via `claude --resume`.
6. Turn-end POSTs from both workers attributed by the `session:window` key (`turns` counted, `lastTurnEnd` set on both registry entries).
7. Cleanup: killed only the throwaway session + server pid.

### ⚠️ DEPLOY-RISK
This reshapes **spawn for the whole fleet** — a bad deploy breaks every new worker spawn and supervision liveness. Deploy checklist:
- All **live workers must be killed and recreated** after restart (their old `bc-<ws>-w-<card>` session refs still answer alive/kill, but state-file keys and the removed `names.workerSession` mean the old sessions should simply be retired — captain-approved no-migration).
- Lieutenant respawn (`resume`/`kill` on a session-granular lieutenant ref) now also kills that session's worker windows — the accepted coupling; expect worker-died flags after a lieutenant respawn.
- Verify post-deploy: start one card, `tmux list-windows -t 'bc-<ws>-lt-<owner>'` shows `w-<card>` running claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
