### PR TITLE
feat(ui): distinguish queued/unseen from seen/responding on a sent message

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -525,15 +525,38 @@ function lastThreadReadMs(target, user) {
   const ts = r && r.threads && r.threads[target];
   return ts ? Date.parse(ts) : 0;
 }
-function cardStatus(card, user) {
+// owed splits into a tri-state, because "unanswered" hides two very different
+// situations: the captain's message may still sit PENDING in the owner's queue
+// (unacked kind:'message' item — the lieutenant never saw it), or the lieutenant
+// drained it and simply hasn't replied yet. owedState says which:
+//   'queued' = owed AND a pending message item targets this thread (unseen)
+//   'seen'   = owed, no pending item (drained; the reply is owed for real)
+//   null     = not owed
+// `pendingMsgs` is the precomputed Set of targets with a pending message item
+// (one queue scan per serialization); absent, it is derived for this card alone.
+function pendingMessageTargets() {
+  const set = new Set();
+  for (const lt of queueIds()) {
+    for (const it of pendingItems(lt)) if (it.kind === 'message' && it.target) set.add(it.target);
+  }
+  return set;
+}
+function cardStatus(card, user, pendingMsgs) {
   const thread = card.thread || [];
   const last = thread.length ? thread[thread.length - 1] : null;
   const owed = !!(last && last.author === 'user'); // latest thread message is the captain's, unanswered
+  let owedState = null;
+  if (owed) {
+    const queued = pendingMsgs
+      ? pendingMsgs.has('card:' + card.id)
+      : pendingItems(card.owner).some((it) => it.kind === 'message' && it.target === 'card:' + card.id);
+    owedState = queued ? 'queued' : 'seen';
+  }
   const readMs = lastThreadReadMs('card:' + card.id, user);
   let unread = false;
   for (const m of thread) if (m.author !== 'user' && Date.parse(m.ts) > readMs) { unread = true; break; }
   if (!unread) for (const e of card.events || []) if (e.level === 1 && Date.parse(e.ts) > readMs) { unread = true; break; }
-  return { worker: derivedWorker(card), owed, unread };
+  return { worker: derivedWorker(card), owed, owedState, unread };
 }
 // Last REAL activity on a card, derived (never persisted). A card's mutable
 // `updated` is bumped by incidental/system writes too — a status-lease refresh or
@@ -549,8 +572,8 @@ function cardActivity(card) {
 }
 // Serialization view: cards go out with the derived `status` and `activity`
 // attached; the stored board keeps only the raw lease.
-function publicCard(card, user) {
-  return Object.assign({}, card, { status: cardStatus(card, user), activity: cardActivity(card) });
+function publicCard(card, user, pendingMsgs) {
+  return Object.assign({}, card, { status: cardStatus(card, user, pendingMsgs), activity: cardActivity(card) });
 }
 // The served board carries the EFFECTIVE kinds map (built-ins merged under the
 // registered entries); the stored board keeps only the registered map.
@@ -559,7 +582,15 @@ function publicCard(card, user) {
 // the old stream.
 const BOOT_ID = process.pid + '-' + Date.now();
 function publicBoard(user) {
-  return Object.assign({}, board, { boot: BOOT_ID, kinds: effectiveKinds(), cards: board.cards.map((c) => publicCard(c, user)) });
+  const pendingMsgs = pendingMessageTargets(); // one queue scan for the whole payload
+  return Object.assign({}, board, {
+    boot: BOOT_ID,
+    kinds: effectiveKinds(),
+    cards: board.cards.map((c) => publicCard(c, user, pendingMsgs)),
+    // chatQueued mirrors owedState:'queued' for a lieutenant's MAIN chat (the UI
+    // derives main-chat owed client-side; the seen/unseen bit only lives here).
+    lieutenants: board.lieutenants.map((l) => Object.assign({}, l, { chatQueued: pendingMsgs.has('lieutenant:' + l.id) })),
+  });
 }
 
 // status.set — the ONLY writer of card.status.worker.
@@ -1943,6 +1974,7 @@ const server = http.createServer(async (req, res) => {
       const r = commitAck(seq, ackOwner || null);
       if (r.error) return sendJson(res, r.code || 400, { error: r.error });
       nudged.delete(r.lieutenant); // handled: a fresh append nudges anew
+      broadcast(); // the ack moved owedState queued→seen; the UI must see the flip
       return sendJson(res, 200, r);
     }
 

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -48,7 +48,7 @@ test('absent when no worker; state absent (or worker null) unlinks', async () =>
   try {
     await s.api('POST', '/api/cards', withOwner({ title: 'Bare' }));
     let st = await cardStatus(s, 'bare');
-    assert.deepStrictEqual(st, { worker: { id: null, state: 'absent' }, owed: false, unread: false });
+    assert.deepStrictEqual(st, { worker: { id: null, state: 'absent' }, owed: false, owedState: null, unread: false });
 
     await s.api('POST', '/api/cards/bare/status', { worker: { id: 'w1', state: 'idle' } });
     st = await cardStatus(s, 'bare');
@@ -148,6 +148,67 @@ test('owed: flips true on a captain thread message, false on lieutenant reply, s
   } finally {
     if (s) await s.stop();
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('owedState: queued while the message sits unacked, seen after the drain is acked, null on reply', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-test-'));
+  let s = null;
+  try {
+    s = await startServerWithLieutenant({ dir });
+    await s.api('POST', '/api/cards', withOwner({ title: 'Tri' }));
+    assert.strictEqual((await cardStatus(s, 'tri')).owedState, null);
+
+    // captain message → durable queue item, unacked: the lieutenant has NOT seen it
+    const f = await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'you there?' });
+    let st = await cardStatus(s, 'tri');
+    assert.strictEqual(st.owed, true);
+    assert.strictEqual(st.owedState, 'queued');
+
+    // queued derives from the queue files, so a restart must not forget it
+    await s.stop();
+    s = await startServer({ dir });
+    assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'queued');
+
+    // draining alone is not seeing — only the committed ack advances the cursor
+    await s.api('GET', '/api/feed?lieutenant=ada');
+    assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'queued');
+    await s.api('POST', '/api/feed/ack', { seq: f.body.seq });
+    st = await cardStatus(s, 'tri');
+    assert.strictEqual(st.owed, true);
+    assert.strictEqual(st.owedState, 'seen'); // drained, reply still owed
+
+    await s.api('POST', '/api/message', { target: 'card:tri', text: 'here' });
+    st = await cardStatus(s, 'tri');
+    assert.strictEqual(st.owed, false);
+    assert.strictEqual(st.owedState, null);
+  } finally {
+    if (s) await s.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('board payload: cards carry owedState and lieutenants carry chatQueued for the main chat', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Pay' }));
+    let b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatQueued, false);
+    assert.strictEqual(b.cards[0].status.owedState, null);
+
+    const f = await s.api('POST', '/api/feedback', { target: 'lieutenant:ada', text: 'ping' });
+    const fc = await s.api('POST', '/api/feedback', { target: 'card:pay', text: 'ping card' });
+    b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatQueued, true);
+    assert.strictEqual(b.cards[0].status.owedState, 'queued');
+
+    // ack both messages: main chat pickup and card pickup are independent bits
+    await s.api('POST', '/api/feed/ack', { seq: Math.max(f.body.seq, fc.body.seq) });
+    b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatQueued, false);
+    assert.strictEqual(b.cards[0].status.owedState, 'seen');
+  } finally {
+    await s.stop();
   }
 });
 

--- a/ui/app.css
+++ b/ui/app.css
@@ -139,6 +139,9 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg.typing.stale { border-color: var(--warn); }
 .msg.typing.stale .twarn { color: var(--warn); font-size: 13px; line-height: 1; }
 .msg.typing.stale .lbl { color: var(--warn); }
+/* queued-owed: delivered but not picked up yet — static single check, no animation,
+   so a message sitting unseen in the inbox never reads as "being responded to" */
+.msg.typing.queued .tcheck { color: var(--dim); font-size: 13px; line-height: 1; }
 /* per-message speak button (agent bubbles only): hover-revealed on desktop */
 .msg.agent { position: relative; }
 .msg-speak {
@@ -202,6 +205,7 @@ body.resizing { user-select: none; cursor: col-resize; }
 .lt-card .t-typing .tdot:nth-child(2) { animation-delay: .2s; }
 .lt-card .t-typing .tdot:nth-child(3) { animation-delay: .4s; }
 .lt-card .t-typing.stale { color: var(--warn); font-size: 11px; line-height: 1; }
+.lt-card .t-typing.queued { color: var(--dim); font-size: 11px; line-height: 1; }
 .lt-card .lt-menu { color: var(--faint); font-size: 14px; line-height: 1; padding: 0 3px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
 .lt-card:hover .lt-menu { opacity: 1; }
 .lt-card .lt-menu:hover { color: var(--fg); background: var(--panel2); }
@@ -282,6 +286,8 @@ body.resizing { user-select: none; cursor: col-resize; }
 .tile .t-typing .tdot:nth-child(3) { animation-delay: .4s; }
 /* stale-owed corner: static amber ⚠ mirroring the chat's "may be stuck" bubble */
 .tile .t-typing.stale { color: var(--warn); font-size: 11px; line-height: 1; margin-top: 3px; }
+/* queued-owed corner: static ✓ mirroring the chat's "delivered, not picked up" bubble */
+.tile .t-typing.queued { color: var(--dim); font-size: 11px; line-height: 1; margin-top: 3px; }
 /* pending drag-order marker: the captain ordered a start/rework; the card moves
    when the lieutenant acts — subtle amber chip, deliberately quiet */
 .tile .t-order {

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -1,6 +1,6 @@
 // board: lieutenant lane above the columns, dense tiles, drag&drop, long-press
 // move menu, new-card / new-lieutenant modals.
-import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, lieutenantUnread, cardVisible, cardStatus, cardRecency, targetOwed, targetOwedStale, toggleFilter, filterSelected, render } from './state.js';
+import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, lieutenantUnread, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, render } from './state.js';
 import { api } from './api.js';
 import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, setHtmlIfChanged } from './util.js';
 import { labelChipHtml } from './labels.js';
@@ -23,10 +23,12 @@ function ltCardHtml(l) {
   const working = mine.filter((c) => c.column === 'working').length;
   const unread = lieutenantUnread(l);
   const active = S.chatMode && S.chatMode.mode === 'lieutenant' && S.chatMode.id === l.id;
-  const owed = targetOwed('lieutenant:' + l.id);
+  const owed = targetOwedState('lieutenant:' + l.id);
   const staleW = owed && targetOwedStale('lieutenant:' + l.id);
   const ind = staleW
     ? '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>'
+    : owed === 'queued'
+    ? '<span class="t-typing queued" title="delivered — not picked up yet">✓</span>'
     : owed
     ? '<span class="t-typing" title="owes you a reply"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>'
     : '';
@@ -89,13 +91,16 @@ function tileHtml(c) {
   const msgs = (c.thread || []).length;
   const st = cardStatus(c);
   // "the lieutenant owes you a reply" balloon: SAME source as the chat typing
-  // bubble (card.status.owed, server-derived), so tile and chat can never drift.
-  // Takes priority over the unread dot — one unambiguous corner indicator.
+  // bubble (card.status.owedState, server-derived), so tile and chat can never
+  // drift. Takes priority over the unread dot — one unambiguous corner indicator.
   // stale-owed mirrors the chat's "may be stuck" state: static amber ⚠, no dots.
-  const owed = !!st.owed;
+  // queued mirrors the chat's "delivered, not picked up": static check, no dots.
+  const owed = targetOwedState('card:' + c.id);
   const staleW = owed && targetOwedStale('card:' + c.id);
   const cornerInd = staleW
     ? '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>'
+    : owed === 'queued'
+    ? '<span class="t-typing queued" title="delivered — the lieutenant hasn\'t picked it up yet">✓</span>'
     : owed
     ? '<span class="t-typing" title="the lieutenant owes you a reply here"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>'
     : (st.unread ? '<span class="t-unread" title="unread activity"></span>' : '');

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -2,7 +2,7 @@
 // the lieutenant's main chat or one of its card threads (a card thread's
 // interlocutor is always the owning lieutenant). Whole-window mode switch,
 // premium composer.
-import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, cardStatus, cardActivityTs, render, threadUnread, targetOwed, targetOwedStale, USER } from './state.js';
+import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
 import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged } from './util.js';
 import { md } from './md.js';
@@ -90,14 +90,23 @@ function msgHtml(m) {
   return '<div class="msg ' + (mine ? 'user' : 'agent') + '">' + body +
     '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
 }
-function typingHtml(stale, name) {
-  // the "owes you a reply" balloon (card.status.owed / the main-chat rule).
-  // stale = owed past the threshold: a DISTINCT "may be stuck" state, static and
-  // amber, so a dropped message never looks like a healthy pending reply forever
-  if (stale) {
+function typingHtml(state, name) {
+  // the "owes you a reply" balloon (card.status.owedState / the main-chat rule),
+  // one visual per state so queued-unseen never masquerades as being worked on:
+  // 'stale'  = owed past the threshold: a DISTINCT "may be stuck" state, static
+  //            and amber, so a dropped message never looks healthy forever
+  // 'queued' = delivered to the durable inbox but NOT drained yet — static
+  //            single check, "waiting to be picked up", no typing animation
+  // 'seen'   = drained; the lieutenant owes the reply for real — animated dots
+  if (state === 'stale') {
     return '<div class="msg agent typing stale" title="no response for a while — the message may not have reached ' + esc(name) + '">' +
       '<span class="twarn">⚠</span>' +
       '<span class="lbl">no response yet — ' + esc(name) + ' may be stuck</span></div>';
+  }
+  if (state === 'queued') {
+    return '<div class="msg agent typing queued" title="delivered — ' + esc(name) + ' hasn\'t picked it up yet">' +
+      '<span class="tcheck">✓</span>' +
+      '<span class="lbl">delivered — waiting for ' + esc(name) + ' to pick it up</span></div>';
   }
   return '<div class="msg agent typing" title="' + esc(name) + ' owes you a reply here">' +
     '<span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>' +
@@ -208,7 +217,8 @@ export function renderChat() {
     if (hidden) blocks.push({ html: '<button class="feed-expand" type="button">show earlier messages (' + hidden + ')</button>' });
     for (const m of msgs.slice(hidden)) push(m);
   }
-  const tail = targetOwed(target) ? typingHtml(targetOwedStale(target), ltName) : '';
+  const owedState = targetOwedState(target);
+  const tail = owedState ? typingHtml(targetOwedStale(target) ? 'stale' : owedState, ltName) : '';
 
   const prev = feed;
   feed = { key: target, blocks, tail };

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -71,19 +71,26 @@ export function cardRecency(c) { return (c && (c.activity || c.updated)) || ''; 
 export function cardStatus(c) {
   return (c && c.status) || { worker: { id: null, state: 'absent' }, owed: false, unread: false };
 }
-// owed on a target: cards carry the server-derived status.owed; a lieutenant's
-// main chat uses the same latest-message rule, derived here from the doc.
-export function targetOwed(target) {
+// owed on a target, as a tri-state: null (nothing owed), 'queued' (the message
+// is durably in the lieutenant's inbox but NOT yet drained — unseen), or 'seen'
+// (drained; the lieutenant is actively on the hook for a reply). Cards carry the
+// server-derived status.owedState; a lieutenant's main chat uses the same
+// latest-message rule derived here plus the server's chatQueued bit.
+export function targetOwedState(target) {
   const lt = /^lieutenant:(.+)$/.exec(target || '');
   if (lt) {
     const l = lieutenant(lt[1]);
     const ch = (l && l.chat) || [];
     const last = ch[ch.length - 1];
-    return !!(last && last.author === USER);
+    if (!(last && last.author === USER)) return null;
+    return l.chatQueued ? 'queued' : 'seen';
   }
   const c = card((target || '').slice(5));
-  return !!c && !!cardStatus(c).owed;
+  const st = c && cardStatus(c);
+  if (!st || !st.owed) return null;
+  return st.owedState || 'seen'; // older server payload: owed only — assume seen
 }
+export function targetOwed(target) { return !!targetOwedState(target); }
 // "may be stuck": owed with no lieutenant reply for longer than the stale
 // threshold. Purely client-derived from thread timestamps; the periodic
 // re-render refreshes it.


### PR DESCRIPTION
## Problem

The "responding…" balloon conflated two very different states of a sent captain message:

1. **Queued, unseen** — durably in the lieutenant's inbox but never drained (the papercut #15 overnight failure: the message sat unseen while the UI showed "responding").
2. **Seen, working** — drained; the lieutenant is actively on it.

## Change

**Server** (`server/server.js`)
- `cardStatus` grows an additive `owedState: 'queued' | 'seen' | null` — `'queued'` when a pending (`seq > ack`) `kind:'message'` queue item targets the thread, `'seen'` once the ack cursor passes it. The existing `owed` boolean stays (backward-safe).
- `publicBoard` computes the pending-message target set once per serialization and stamps each lieutenant with `chatQueued` for its main chat (main-chat owed is derived client-side; only the seen/unseen bit is server-known).
- `POST /api/feed/ack` now broadcasts, so the queued→seen flip reaches the UI live over SSE.

**UI** (`state.js`, `chat.js`, `board.js`, `app.css`)
- `targetOwedState()` tri-state selector (falls back to `'seen'` on an older server payload).
- Chat balloon: `queued` = static single ✓ "delivered — waiting for <lt> to pick it up"; `seen` = the existing animated owes-a-reply dots; `stale` = unchanged amber ⚠.
- Tile corner and lieutenant-lane indicators mirror the same three visuals.

## Acceptance (verified live in the browser)

- Send while the lieutenant is idle → ✓ "delivered — waiting for Ada to pick it up" (chat, tile, lane).
- Ack (drain commit) → flips to the animated "owes you a reply…" with no reload.
- Lieutenant reply → balloon clears.
- Stale threshold behavior unchanged (applies over both queued and seen).

Tests: 2 new (`owedState` tri-state incl. restart survival + board payload `chatQueued`); full suite 137 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
