### PR TITLE
fix(ui): 'seen/responding' keys off the drain boundary, not ack

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -663,7 +663,9 @@ async function cmdDrain() {
   // feed.drain — at-least-once: the server serves everything past each
   // lieutenant's committed ack cursor and drain never advances it. After
   // HANDLING the items, run `bc-axi ack <seq>` with the highest seq handled;
-  // until then every drain re-offers the same items (dedupe by seq).
+  // until then every drain re-offers the same items (dedupe by seq). An
+  // identified drain does advance the separate drained cursor — the captain's
+  // board flips the message from queued/unseen to seen/responding.
   // Default output is agent-ergonomic (card context + next-action hint per
   // item); --json prints the raw QueueItems, one JSON line each.
   const sess = currentTmuxSession();

--- a/server/server.js
+++ b/server/server.js
@@ -399,6 +399,7 @@ async function retireLieutenant(id, body) {
   // A retired lieutenant can never drain again: its queue files go too.
   try { fs.unlinkSync(queueFile(id)); } catch (e) { /* none */ }
   try { fs.unlinkSync(ackFile(id)); } catch (e) { /* none */ }
+  try { fs.unlinkSync(drainedFile(id)); } catch (e) { /* none */ }
   const ev = mkEvent({ text: 'lieutenant ' + lt.name + ' retired',
     actor: (body && body.actor) || 'user', level: 1 }, {});
   board.events.push(ev);
@@ -410,10 +411,14 @@ async function retireLieutenant(id, body) {
 // drag-order, or (future) worker event. At-least-once: drain serves everything
 // past the lieutenant's committed ack cursor and never advances it; only
 // POST /api/feed/ack does. Unacked items re-offer forever (dedupe by seq).
+// A second, delivery-neutral cursor rides alongside: <lt>.drained, the high-water
+// seq a drain has SERVED this lieutenant — it feeds the UI's seen/unseen split
+// and nothing else.
 // The durable queue is the write-ahead ground truth; the wake half (one
 // coalesced harness.send per append burst) rides behind it, below.
 function queueFile(lt) { return path.join(QUEUE_DIR, lt + '.jsonl'); }
 function ackFile(lt) { return path.join(QUEUE_DIR, lt + '.ack'); }
+function drainedFile(lt) { return path.join(QUEUE_DIR, lt + '.drained'); }
 function readQueue(lt) {
   try {
     return fs.readFileSync(queueFile(lt), 'utf8').split('\n').filter(Boolean).map((l) => JSON.parse(l));
@@ -434,6 +439,25 @@ function readAck(lt) {
   try { return parseInt(fs.readFileSync(ackFile(lt), 'utf8'), 10) || 0; }
   catch (e) { return 0; }
 }
+// The drained cursor is a durable high-water mark of the highest seq ever SERVED
+// to this lieutenant by a drain. It never gates delivery (only the ack cursor
+// does — unacked items re-offer forever); it exists purely so the UI can tell
+// "sitting unread in the queue" from "drained and being worked on": drain marks
+// the turn START, ack marks the turn END, and without this file the whole
+// drain→ack working window would still read as queued/unseen.
+function readDrained(lt) {
+  try { return parseInt(fs.readFileSync(drainedFile(lt), 'utf8'), 10) || 0; }
+  catch (e) { return 0; }
+}
+function advanceDrained(lt, seq) {
+  if (seq <= readDrained(lt)) return false;
+  fs.writeFileSync(drainedFile(lt), String(seq));
+  return true;
+}
+// The seen boundary: a seq at or below it has been drained OR acked. Acked
+// implies seen even when the drained file lags (an ack written with no drain
+// on record — e.g. cursors that predate the drained file).
+function seenCursor(lt) { return Math.max(readDrained(lt), readAck(lt)); }
 function queuePush(lt, rec) {
   const item = Object.assign({ seq: ++qseq, ts: now(), lieutenant: lt }, rec);
   fs.appendFileSync(queueFile(lt), JSON.stringify(item) + '\n');
@@ -526,31 +550,42 @@ function lastThreadReadMs(target, user) {
   return ts ? Date.parse(ts) : 0;
 }
 // owed splits into a tri-state, because "unanswered" hides two very different
-// situations: the captain's message may still sit PENDING in the owner's queue
-// (unacked kind:'message' item — the lieutenant never saw it), or the lieutenant
-// drained it and simply hasn't replied yet. owedState says which:
-//   'queued' = owed AND a pending message item targets this thread (unseen)
-//   'seen'   = owed, no pending item (drained; the reply is owed for real)
+// situations: the captain's message may still sit UNDRAINED in the owner's queue
+// (the lieutenant never saw it), or the lieutenant drained it — its turn started —
+// and simply hasn't replied yet. The boundary is the drained cursor, NOT the ack
+// cursor: a lieutenant drains at the START of a turn and acks at the END, so
+// keying off ack would leave the whole working phase reading as queued/unseen.
+// owedState says which side of the drain the latest captain message is on:
+//   'queued' = owed AND its delivery seq is past the seen cursor (unseen)
+//   'seen'   = owed and drained (turn underway; the reply is owed for real)
 //   null     = not owed
-// `pendingMsgs` is the precomputed Set of targets with a pending message item
-// (one queue scan per serialization); absent, it is derived for this card alone.
-function pendingMessageTargets() {
-  const set = new Set();
+// `msgSeqs` is the precomputed target -> latest-message-delivery map (one queue
+// scan per serialization); absent, it is derived on the spot.
+function latestMessageSeqs() {
+  const map = new Map(); // target -> {seq, lt} of the latest kind:'message' delivery
   for (const lt of queueIds()) {
-    for (const it of pendingItems(lt)) if (it.kind === 'message' && it.target) set.add(it.target);
+    for (const it of readQueue(lt)) {
+      if (it.kind !== 'message' || !it.target) continue;
+      const cur = map.get(it.target);
+      if (!cur || it.seq > cur.seq) map.set(it.target, { seq: it.seq, lt });
+    }
   }
-  return set;
+  return map;
 }
-function cardStatus(card, user, pendingMsgs) {
+// Queued = the latest captain message delivered to this target has not crossed
+// its lieutenant's seen cursor. No delivery on record → not queued (a thread
+// message that never became a QueueItem has nothing to sit unseen in).
+function targetQueued(target, msgSeqs) {
+  const m = msgSeqs.get(target);
+  return !!(m && m.seq > seenCursor(m.lt));
+}
+function cardStatus(card, user, msgSeqs) {
   const thread = card.thread || [];
   const last = thread.length ? thread[thread.length - 1] : null;
   const owed = !!(last && last.author === 'user'); // latest thread message is the captain's, unanswered
   let owedState = null;
   if (owed) {
-    const queued = pendingMsgs
-      ? pendingMsgs.has('card:' + card.id)
-      : pendingItems(card.owner).some((it) => it.kind === 'message' && it.target === 'card:' + card.id);
-    owedState = queued ? 'queued' : 'seen';
+    owedState = targetQueued('card:' + card.id, msgSeqs || latestMessageSeqs()) ? 'queued' : 'seen';
   }
   const readMs = lastThreadReadMs('card:' + card.id, user);
   let unread = false;
@@ -572,8 +607,8 @@ function cardActivity(card) {
 }
 // Serialization view: cards go out with the derived `status` and `activity`
 // attached; the stored board keeps only the raw lease.
-function publicCard(card, user, pendingMsgs) {
-  return Object.assign({}, card, { status: cardStatus(card, user, pendingMsgs), activity: cardActivity(card) });
+function publicCard(card, user, msgSeqs) {
+  return Object.assign({}, card, { status: cardStatus(card, user, msgSeqs), activity: cardActivity(card) });
 }
 // The served board carries the EFFECTIVE kinds map (built-ins merged under the
 // registered entries); the stored board keeps only the registered map.
@@ -582,14 +617,14 @@ function publicCard(card, user, pendingMsgs) {
 // the old stream.
 const BOOT_ID = process.pid + '-' + Date.now();
 function publicBoard(user) {
-  const pendingMsgs = pendingMessageTargets(); // one queue scan for the whole payload
+  const msgSeqs = latestMessageSeqs(); // one queue scan for the whole payload
   return Object.assign({}, board, {
     boot: BOOT_ID,
     kinds: effectiveKinds(),
-    cards: board.cards.map((c) => publicCard(c, user, pendingMsgs)),
+    cards: board.cards.map((c) => publicCard(c, user, msgSeqs)),
     // chatQueued mirrors owedState:'queued' for a lieutenant's MAIN chat (the UI
     // derives main-chat owed client-side; the seen/unseen bit only lives here).
-    lieutenants: board.lieutenants.map((l) => Object.assign({}, l, { chatQueued: pendingMsgs.has('lieutenant:' + l.id) })),
+    lieutenants: board.lieutenants.map((l) => Object.assign({}, l, { chatQueued: targetQueued('lieutenant:' + l.id, msgSeqs) })),
   });
 }
 
@@ -1957,7 +1992,13 @@ const server = http.createServer(async (req, res) => {
       // still-unacked items) wakes again. Only a truly unidentified caller
       // (no lieutenant, no session — raw tooling) drains all queues.
       if (lt) nudged.delete(lt); else nudged.clear();
-      return sendJson(res, 200, { items: drainItems(lt), head: qseq });
+      const items = drainItems(lt);
+      // Draining is SEEING: advance the lieutenant's durable drained cursor to
+      // the highest seq just served, and let the UI flip queued→seen. Only an
+      // identified drain advances — an unscoped all-queues drain is raw tooling
+      // peeking, not a lieutenant starting its turn.
+      if (lt && items.length && advanceDrained(lt, items[items.length - 1].seq)) broadcast();
+      return sendJson(res, 200, { items, head: qseq });
     }
 
     // ----- feed.ack: commit the cursor AFTER the items were handled -----
@@ -1974,7 +2015,7 @@ const server = http.createServer(async (req, res) => {
       const r = commitAck(seq, ackOwner || null);
       if (r.error) return sendJson(res, r.code || 400, { error: r.error });
       nudged.delete(r.lieutenant); // handled: a fresh append nudges anew
-      broadcast(); // the ack moved owedState queued→seen; the UI must see the flip
+      broadcast(); // the ack advances the seen cursor too (drain normally beat it here)
       return sendJson(res, 200, r);
     }
 

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -151,7 +151,7 @@ test('owed: flips true on a captain thread message, false on lieutenant reply, s
   }
 });
 
-test('owedState: queued while the message sits unacked, seen after the drain is acked, null on reply', async () => {
+test('owedState: queued while undrained, seen the moment a drain serves it (no ack), null on reply', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-test-'));
   let s = null;
   try {
@@ -159,8 +159,8 @@ test('owedState: queued while the message sits unacked, seen after the drain is 
     await s.api('POST', '/api/cards', withOwner({ title: 'Tri' }));
     assert.strictEqual((await cardStatus(s, 'tri')).owedState, null);
 
-    // captain message → durable queue item, unacked: the lieutenant has NOT seen it
-    const f = await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'you there?' });
+    // captain message → durable queue item, undrained: the lieutenant has NOT seen it
+    await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'you there?' });
     let st = await cardStatus(s, 'tri');
     assert.strictEqual(st.owed, true);
     assert.strictEqual(st.owedState, 'queued');
@@ -170,21 +170,43 @@ test('owedState: queued while the message sits unacked, seen after the drain is 
     s = await startServer({ dir });
     assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'queued');
 
-    // draining alone is not seeing — only the committed ack advances the cursor
+    // DRAINING IS SEEING: a lieutenant drains at turn start and acks only at
+    // turn end, so the drain alone — no ack — must flip queued→seen. (The
+    // ack-keyed version shipped in PR #9 left the whole working phase 'queued'.)
     await s.api('GET', '/api/feed?lieutenant=ada');
-    assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'queued');
-    await s.api('POST', '/api/feed/ack', { seq: f.body.seq });
     st = await cardStatus(s, 'tri');
     assert.strictEqual(st.owed, true);
-    assert.strictEqual(st.owedState, 'seen'); // drained, reply still owed
+    assert.strictEqual(st.owedState, 'seen'); // drained, reply still owed — the working window
+
+    // the drained cursor is durable: seen survives a restart with no ack ever written
+    await s.stop();
+    s = await startServer({ dir });
+    assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'seen');
 
     await s.api('POST', '/api/message', { target: 'card:tri', text: 'here' });
     st = await cardStatus(s, 'tri');
     assert.strictEqual(st.owed, false);
     assert.strictEqual(st.owedState, null);
+
+    // a FRESH captain message re-queues: the old cursor must not mark it seen
+    await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'and now?' });
+    assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'queued');
   } finally {
     if (s) await s.stop();
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('owedState: ack with no drain on record still reads seen (ack implies seen)', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Ackonly' }));
+    const f = await s.api('POST', '/api/feedback', { target: 'card:ackonly', text: 'ping' });
+    assert.strictEqual((await cardStatus(s, 'ackonly')).owedState, 'queued');
+    await s.api('POST', '/api/feed/ack', { seq: f.body.seq });
+    assert.strictEqual((await cardStatus(s, 'ackonly')).owedState, 'seen');
+  } finally {
+    await s.stop();
   }
 });
 
@@ -202,8 +224,9 @@ test('board payload: cards carry owedState and lieutenants carry chatQueued for 
     assert.strictEqual(b.lieutenants[0].chatQueued, true);
     assert.strictEqual(b.cards[0].status.owedState, 'queued');
 
-    // ack both messages: main chat pickup and card pickup are independent bits
-    await s.api('POST', '/api/feed/ack', { seq: Math.max(f.body.seq, fc.body.seq) });
+    // one drain (no ack) picks up both: main chat and card flip to seen together
+    assert.ok(f.body.seq && fc.body.seq);
+    await s.api('GET', '/api/feed?lieutenant=ada');
     b = (await s.api('GET', '/api/board')).body;
     assert.strictEqual(b.lieutenants[0].chatQueued, false);
     assert.strictEqual(b.cards[0].status.owedState, 'seen');


### PR DESCRIPTION
## What

Correction to the tri-state message delivery shipped in #9: `owedState` (and `chatQueued`) now key off the **drain boundary**, not the ack cursor.

## Why the merged version didn't work

A lieutenant `drain`s at the START of a turn (sees the message) and `ack`s at the END (after replying) — and drain persisted nothing. Keying off `pendingItems` (seq > ack) meant:

- `queued` spanned both "unseen" AND the whole "seen, actively being worked on" phase.
- `seen` only appeared on an ack-without-reply, which the real flow never does — effectively dead code (PR #9's browser verification only saw it because the test acked without replying).

The state the captain actually wants — "sitting in a queue nobody's read" vs "being worked on right now" — is exactly the drain→ack window.

## The fix

- **New durable per-lieutenant cursor `<lt>.drained`** (mirrors the `.ack` file plumbing): an identified `GET /api/feed` drain advances it to the highest seq it served, and broadcasts so the UI flips immediately. Session-scoped drains advance only their own lieutenant's cursor; an unscoped all-queues drain (raw tooling) advances nothing. Retire cleanup removes the file.
- **`owedState`/`chatQueued` re-derived**: the latest `kind:'message'` delivery seq per target is compared against `max(drained, ack)` — ack still implies seen, covering cursors that predate the drained file.
- **Delivery semantics untouched**: only the ack cursor gates re-offers; the drained cursor feeds the UI's seen/unseen split and nothing else. Wake/nudge logic unchanged.

Net: `queued` shows only while the message genuinely sits unread; the instant the lieutenant drains, it flips to `seen`/responding and stays there until the reply lands.

## Validation

- `node --test test/*.test.js harness/test/*.test.js` — **163/163 green**.
- `status.test.js` now asserts the exact case #9 got wrong: undrained → `queued`; after a drain with **no ack** → `seen`; seen survives a restart; reply clears; a fresh captain message re-queues past the old cursor. Plus an ack-implies-seen test and a drain-flips-`chatQueued` assertion.
- Live end-to-end check on a throwaway server/port (pid captured, killed by handle): all 6 checks passed, including the durable `ada.drained` file and the main-chat flip.

**DEPLOY note: server restart required.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
