### PR TITLE
fix(ui): queued indicator is ⏳, not ✓ — waiting, not done

### DIFF
--- a/ui/app.css
+++ b/ui/app.css
@@ -139,7 +139,7 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg.typing.stale { border-color: var(--warn); }
 .msg.typing.stale .twarn { color: var(--warn); font-size: 13px; line-height: 1; }
 .msg.typing.stale .lbl { color: var(--warn); }
-/* queued-owed: delivered but not picked up yet — static single check, no animation,
+/* queued-owed: delivered but not picked up yet — static hourglass, no animation,
    so a message sitting unseen in the inbox never reads as "being responded to" */
 .msg.typing.queued .tcheck { color: var(--dim); font-size: 13px; line-height: 1; }
 /* per-message speak button (agent bubbles only): hover-revealed on desktop */
@@ -286,7 +286,7 @@ body.resizing { user-select: none; cursor: col-resize; }
 .tile .t-typing .tdot:nth-child(3) { animation-delay: .4s; }
 /* stale-owed corner: static amber ⚠ mirroring the chat's "may be stuck" bubble */
 .tile .t-typing.stale { color: var(--warn); font-size: 11px; line-height: 1; margin-top: 3px; }
-/* queued-owed corner: static ✓ mirroring the chat's "delivered, not picked up" bubble */
+/* queued-owed corner: static ⏳ mirroring the chat's "delivered, not picked up" bubble */
 .tile .t-typing.queued { color: var(--dim); font-size: 11px; line-height: 1; margin-top: 3px; }
 /* pending drag-order marker: the captain ordered a start/rework; the card moves
    when the lieutenant acts — subtle amber chip, deliberately quiet */

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -28,7 +28,7 @@ function ltCardHtml(l) {
   const ind = staleW
     ? '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>'
     : owed === 'queued'
-    ? '<span class="t-typing queued" title="delivered — not picked up yet">✓</span>'
+    ? '<span class="t-typing queued" title="delivered — not picked up yet">⏳</span>'
     : owed
     ? '<span class="t-typing" title="owes you a reply"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>'
     : '';
@@ -94,13 +94,13 @@ function tileHtml(c) {
   // bubble (card.status.owedState, server-derived), so tile and chat can never
   // drift. Takes priority over the unread dot — one unambiguous corner indicator.
   // stale-owed mirrors the chat's "may be stuck" state: static amber ⚠, no dots.
-  // queued mirrors the chat's "delivered, not picked up": static check, no dots.
+  // queued mirrors the chat's "delivered, not picked up": static hourglass, no dots.
   const owed = targetOwedState('card:' + c.id);
   const staleW = owed && targetOwedStale('card:' + c.id);
   const cornerInd = staleW
     ? '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>'
     : owed === 'queued'
-    ? '<span class="t-typing queued" title="delivered — the lieutenant hasn\'t picked it up yet">✓</span>'
+    ? '<span class="t-typing queued" title="delivered — the lieutenant hasn\'t picked it up yet">⏳</span>'
     : owed
     ? '<span class="t-typing" title="the lieutenant owes you a reply here"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>'
     : (st.unread ? '<span class="t-unread" title="unread activity"></span>' : '');

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -96,7 +96,7 @@ function typingHtml(state, name) {
   // 'stale'  = owed past the threshold: a DISTINCT "may be stuck" state, static
   //            and amber, so a dropped message never looks healthy forever
   // 'queued' = delivered to the durable inbox but NOT drained yet — static
-  //            single check, "waiting to be picked up", no typing animation
+  //            hourglass, "waiting to be picked up", no typing animation
   // 'seen'   = drained; the lieutenant owes the reply for real — animated dots
   if (state === 'stale') {
     return '<div class="msg agent typing stale" title="no response for a while — the message may not have reached ' + esc(name) + '">' +
@@ -105,7 +105,7 @@ function typingHtml(state, name) {
   }
   if (state === 'queued') {
     return '<div class="msg agent typing queued" title="delivered — ' + esc(name) + ' hasn\'t picked it up yet">' +
-      '<span class="tcheck">✓</span>' +
+      '<span class="tcheck">⏳</span>' +
       '<span class="lbl">delivered — waiting for ' + esc(name) + ' to pick it up</span></div>';
   }
   return '<div class="msg agent typing" title="' + esc(name) + ' owes you a reply here">' +


### PR DESCRIPTION
## What

Captain-requested: the queued (delivered-but-unseen) indicator now renders ⏳ instead of ✓. A check reads as "delivered and handled"; this state means the message is sitting unread in the queue. Glyph only — labels, titles, and state logic untouched.

- `ui/js/chat.js` — chat balloon queued bubble
- `ui/js/board.js` — lieutenant lane corner + card tile corner
- `ui/app.css` — stale ✓-referencing comments updated; no sizing changes needed (emoji renders clean at existing 13px/11px)

## Validation

- `node --test test/*.test.js harness/test/*.test.js` — 163 pass, 0 fail
- Live-checked on a throwaway server (port 4917, killed after): queued message shows ⏳ in the chat balloon, lane corner, and tile corner; flips to the animated responding dots after drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
