### PR TITLE
fix: derive owed from the queue — buried captain messages stay pending until acked

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -549,6 +549,13 @@ function lastThreadReadMs(target, user) {
   const ts = r && r.threads && r.threads[target];
   return ts ? Date.parse(ts) : 0;
 }
+// owed is QUEUE truth, not thread order: the latest captain message delivered
+// to this target has not been ACKED (consumed) by its lieutenant. Thread order
+// lies under interleaving — a captain message sent mid-turn gets buried when
+// the lieutenant replies to an EARLIER batch, and "last thread message is the
+// captain's" would read not-owed while the message sits genuinely unhandled.
+// Only the ack clears owed; a reply alone does not (in the normal reply-then-ack
+// turn the two coincide, so the simple case still clears promptly).
 // owed splits into a tri-state, because "unanswered" hides two very different
 // situations: the captain's message may still sit UNDRAINED in the owner's queue
 // (the lieutenant never saw it), or the lieutenant drained it — its turn started —
@@ -579,13 +586,19 @@ function targetQueued(target, msgSeqs) {
   const m = msgSeqs.get(target);
   return !!(m && m.seq > seenCursor(m.lt));
 }
+// Owed = the latest captain message delivered to this target is still unacked
+// (not yet consumed). No delivery on record → not owed.
+function targetOwed(target, msgSeqs) {
+  const m = msgSeqs.get(target);
+  return !!(m && m.seq > readAck(m.lt));
+}
 function cardStatus(card, user, msgSeqs) {
   const thread = card.thread || [];
-  const last = thread.length ? thread[thread.length - 1] : null;
-  const owed = !!(last && last.author === 'user'); // latest thread message is the captain's, unanswered
+  const msgs = msgSeqs || latestMessageSeqs();
+  const owed = targetOwed('card:' + card.id, msgs);
   let owedState = null;
   if (owed) {
-    owedState = targetQueued('card:' + card.id, msgSeqs || latestMessageSeqs()) ? 'queued' : 'seen';
+    owedState = targetQueued('card:' + card.id, msgs) ? 'queued' : 'seen';
   }
   const readMs = lastThreadReadMs('card:' + card.id, user);
   let unread = false;
@@ -622,9 +635,12 @@ function publicBoard(user) {
     boot: BOOT_ID,
     kinds: effectiveKinds(),
     cards: board.cards.map((c) => publicCard(c, user, msgSeqs)),
-    // chatQueued mirrors owedState:'queued' for a lieutenant's MAIN chat (the UI
-    // derives main-chat owed client-side; the seen/unseen bit only lives here).
-    lieutenants: board.lieutenants.map((l) => Object.assign({}, l, { chatQueued: targetQueued('lieutenant:' + l.id, msgSeqs) })),
+    // chatOwed/chatQueued mirror status.owed/owedState:'queued' for a
+    // lieutenant's MAIN chat — both queue-derived, same rules as cards.
+    lieutenants: board.lieutenants.map((l) => Object.assign({}, l, {
+      chatOwed: targetOwed('lieutenant:' + l.id, msgSeqs),
+      chatQueued: targetQueued('lieutenant:' + l.id, msgSeqs),
+    })),
   });
 }
 
@@ -1869,7 +1885,7 @@ const server = http.createServer(async (req, res) => {
         const ev = mkEvent({ text: text.slice(0, 200), actor: msg.author, level: body.level, kind: body.kind }, { level: 1 });
         board.events.push(ev);
       }
-      saveBoard(); broadcast(); // a lieutenant reply clears derived owed via broadcast
+      saveBoard(); broadcast(); // owed clears on ACK, not here — the reply alone leaves it derived from the queue
       return sendJson(res, 200, { ok: true });
     }
     if (route === 'POST /api/feedback') { // captain -> lieutenant (chat.say, captain side)

--- a/test/status.test.js
+++ b/test/status.test.js
@@ -121,7 +121,7 @@ test('lease survives a restart; expiry is derived on read, so decay happens even
   }
 });
 
-test('owed: flips true on a captain thread message, false on lieutenant reply, survives restart', async () => {
+test('owed: flips true on a captain message, clears on ACK (not on the reply alone), survives restart', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-test-'));
   let s = null;
   try {
@@ -129,25 +129,67 @@ test('owed: flips true on a captain thread message, false on lieutenant reply, s
     await s.api('POST', '/api/cards', withOwner({ title: 'Ask' }));
     assert.strictEqual((await cardStatus(s, 'ask')).owed, false);
 
-    await s.api('POST', '/api/feedback', { target: 'card:ask', text: 'please check' });
+    const f1 = await s.api('POST', '/api/feedback', { target: 'card:ask', text: 'please check' });
     assert.strictEqual((await cardStatus(s, 'ask')).owed, true);
 
+    // owed is queue truth: the reply alone does NOT consume the message
     await s.api('POST', '/api/message', { target: 'card:ask', text: 'on it' });
+    assert.strictEqual((await cardStatus(s, 'ask')).owed, true);
+
+    // the ack consumes it — owed clears
+    await s.api('POST', '/api/feed/ack', { seq: f1.body.seq });
     assert.strictEqual((await cardStatus(s, 'ask')).owed, false);
 
-    await s.api('POST', '/api/feedback', { target: 'card:ask', text: 'and this?' });
+    const f2 = await s.api('POST', '/api/feedback', { target: 'card:ask', text: 'and this?' });
     assert.strictEqual((await cardStatus(s, 'ask')).owed, true);
 
-    // owed is derived from persisted state: a restart must not forget it
+    // owed is derived from persisted state (queue + ack cursor): a restart must not forget it
     await s.stop();
     s = await startServer({ dir });
     assert.strictEqual((await cardStatus(s, 'ask')).owed, true);
 
     await s.api('POST', '/api/message', { target: 'card:ask', text: 'answered' });
+    await s.api('POST', '/api/feed/ack', { seq: f2.body.seq });
     assert.strictEqual((await cardStatus(s, 'ask')).owed, false);
   } finally {
     if (s) await s.stop();
     fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('owed: a buried captain message (interleaved reply to an earlier batch) stays owed until acked', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Buried' }));
+
+    // captain msg A: drained AND acked — fully handled
+    const a = await s.api('POST', '/api/feedback', { target: 'card:buried', text: 'msg A' });
+    await s.api('GET', '/api/feed?lieutenant=ada');
+    await s.api('POST', '/api/feed/ack', { seq: a.body.seq });
+    assert.strictEqual((await cardStatus(s, 'buried')).owed, false);
+
+    // captain msg B lands mid-turn; the lieutenant then replies to the EARLIER
+    // batch, so the reply becomes the last thread message. B is unhandled and
+    // must STILL read owed+queued — this is the case that regressed live.
+    const b = await s.api('POST', '/api/feedback', { target: 'card:buried', text: 'msg B' });
+    await s.api('POST', '/api/message', { target: 'card:buried', text: 'reply to A' });
+    let st = await cardStatus(s, 'buried');
+    assert.strictEqual(st.owed, true);
+    assert.strictEqual(st.owedState, 'queued'); // undrained: the lieutenant never saw B
+
+    // draining B flips it to seen (turn underway) — still owed
+    await s.api('GET', '/api/feed?lieutenant=ada');
+    st = await cardStatus(s, 'buried');
+    assert.strictEqual(st.owed, true);
+    assert.strictEqual(st.owedState, 'seen');
+
+    // only the ack consumes B
+    await s.api('POST', '/api/feed/ack', { seq: b.body.seq });
+    st = await cardStatus(s, 'buried');
+    assert.strictEqual(st.owed, false);
+    assert.strictEqual(st.owedState, null);
+  } finally {
+    await s.stop();
   }
 });
 
@@ -160,7 +202,7 @@ test('owedState: queued while undrained, seen the moment a drain serves it (no a
     assert.strictEqual((await cardStatus(s, 'tri')).owedState, null);
 
     // captain message → durable queue item, undrained: the lieutenant has NOT seen it
-    await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'you there?' });
+    const f = await s.api('POST', '/api/feedback', { target: 'card:tri', text: 'you there?' });
     let st = await cardStatus(s, 'tri');
     assert.strictEqual(st.owed, true);
     assert.strictEqual(st.owedState, 'queued');
@@ -183,7 +225,14 @@ test('owedState: queued while undrained, seen the moment a drain serves it (no a
     s = await startServer({ dir });
     assert.strictEqual((await cardStatus(s, 'tri')).owedState, 'seen');
 
+    // the reply alone does NOT clear owed — the message is still unconsumed
     await s.api('POST', '/api/message', { target: 'card:tri', text: 'here' });
+    st = await cardStatus(s, 'tri');
+    assert.strictEqual(st.owed, true);
+    assert.strictEqual(st.owedState, 'seen');
+
+    // the ack (turn end) consumes it: owed clears
+    await s.api('POST', '/api/feed/ack', { seq: f.body.seq });
     st = await cardStatus(s, 'tri');
     assert.strictEqual(st.owed, false);
     assert.strictEqual(st.owedState, null);
@@ -197,39 +246,52 @@ test('owedState: queued while undrained, seen the moment a drain serves it (no a
   }
 });
 
-test('owedState: ack with no drain on record still reads seen (ack implies seen)', async () => {
+test('owedState: ack with no drain on record consumes the message — owed clears entirely', async () => {
   const s = await startServerWithLieutenant();
   try {
     await s.api('POST', '/api/cards', withOwner({ title: 'Ackonly' }));
     const f = await s.api('POST', '/api/feedback', { target: 'card:ackonly', text: 'ping' });
     assert.strictEqual((await cardStatus(s, 'ackonly')).owedState, 'queued');
     await s.api('POST', '/api/feed/ack', { seq: f.body.seq });
-    assert.strictEqual((await cardStatus(s, 'ackonly')).owedState, 'seen');
+    const st = await cardStatus(s, 'ackonly');
+    assert.strictEqual(st.owed, false); // acked = consumed, even with no drain ever recorded
+    assert.strictEqual(st.owedState, null);
   } finally {
     await s.stop();
   }
 });
 
-test('board payload: cards carry owedState and lieutenants carry chatQueued for the main chat', async () => {
+test('board payload: cards carry owedState and lieutenants carry chatOwed/chatQueued for the main chat', async () => {
   const s = await startServerWithLieutenant();
   try {
     await s.api('POST', '/api/cards', withOwner({ title: 'Pay' }));
     let b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatOwed, false);
     assert.strictEqual(b.lieutenants[0].chatQueued, false);
     assert.strictEqual(b.cards[0].status.owedState, null);
 
     const f = await s.api('POST', '/api/feedback', { target: 'lieutenant:ada', text: 'ping' });
     const fc = await s.api('POST', '/api/feedback', { target: 'card:pay', text: 'ping card' });
     b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatOwed, true);
     assert.strictEqual(b.lieutenants[0].chatQueued, true);
     assert.strictEqual(b.cards[0].status.owedState, 'queued');
 
-    // one drain (no ack) picks up both: main chat and card flip to seen together
+    // one drain (no ack) picks up both: main chat and card flip to seen together,
+    // but both stay OWED — the drain starts the turn, only the ack consumes
     assert.ok(f.body.seq && fc.body.seq);
     await s.api('GET', '/api/feed?lieutenant=ada');
     b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatOwed, true);
     assert.strictEqual(b.lieutenants[0].chatQueued, false);
     assert.strictEqual(b.cards[0].status.owedState, 'seen');
+
+    // acking the highest drained seq consumes both
+    await s.api('POST', '/api/feed/ack', { seq: fc.body.seq });
+    b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.lieutenants[0].chatOwed, false);
+    assert.strictEqual(b.cards[0].status.owed, false);
+    assert.strictEqual(b.cards[0].status.owedState, null);
   } finally {
     await s.stop();
   }

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -73,16 +73,24 @@ export function cardStatus(c) {
 }
 // owed on a target, as a tri-state: null (nothing owed), 'queued' (the message
 // is durably in the lieutenant's inbox but NOT yet drained — unseen), or 'seen'
-// (drained; the lieutenant is actively on the hook for a reply). Cards carry the
-// server-derived status.owedState; a lieutenant's main chat uses the same
-// latest-message rule derived here plus the server's chatQueued bit.
+// (drained; the lieutenant is actively on the hook for a reply). Both are
+// server-derived from the delivery queue — owed means the latest captain
+// message is unACKED, regardless of who spoke last in the thread, so a message
+// buried under an interleaved reply keeps showing until actually consumed.
+// Cards carry status.owed/owedState; a lieutenant's main chat carries the
+// equivalent chatOwed/chatQueued bits.
 export function targetOwedState(target) {
   const lt = /^lieutenant:(.+)$/.exec(target || '');
   if (lt) {
     const l = lieutenant(lt[1]);
-    const ch = (l && l.chat) || [];
-    const last = ch[ch.length - 1];
-    if (!(last && last.author === USER)) return null;
+    if (!l) return null;
+    let owed = l.chatOwed;
+    if (owed === undefined) { // older server payload: fall back to the last-message rule
+      const ch = l.chat || [];
+      const last = ch[ch.length - 1];
+      owed = !!(last && last.author === USER);
+    }
+    if (!owed) return null;
     return l.chatQueued ? 'queued' : 'seen';
   }
   const c = card((target || '').slice(5));


### PR DESCRIPTION
## Problem

A captain message sent while the lieutenant was mid-turn (between drain and ack) never showed a pending state and looked forgotten (the "tests 7/9" case observed live 2026-07-08). Root cause: `owed` was `last thread message is the captain's` — strict ping-pong. Under interleaving, the lieutenant's reply to an EARLIER batch became the last message and the ⏳/responding indicator vanished while the newer captain message sat genuinely unhandled.

## Fix

Derive `owed` from the durable delivery queue, not thread order:

- **`owed`** = the latest `kind:'message'` delivery for the target is unacked (`seq > readAck(its lt)`) — independent of who spoke last. Only the ack (consume) clears it; a reply alone does not. In the normal reply-then-ack turn the two coincide, so the simple case still clears promptly.
- **`owedState`** derivation unchanged: `seq > seenCursor` → `'queued'` (⏳), else `'seen'` (responding).
- Lieutenant MAIN chat gets the same rule via a new server-derived `chatOwed` bit alongside `chatQueued`; the UI uses it with a fallback to the old last-message rule for older payloads.

Net: a buried captain message keeps showing ⏳/responding continuously until the lieutenant actually acks it.

## Validation

- Full suite green (164/164), including a new interleaving regression test: msg A drained+acked, msg B delivered, reply buries B → `owed` stays true, `'queued'` undrained / `'seen'` drained, clears only on ack. Updated the three tests that encoded reply-clears-owed.
- Live-checked on a throwaway server (port 47911): card thread and main chat both keep `owed`/`chatOwed` true for a buried message through the reply, flip queued→seen on drain, clear on ack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
