### PR TITLE
feat: worker-stalled watchdog — close the alive-but-hung gap

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -714,6 +714,11 @@ async function cmdDrain() {
       const sess = (c && c.attributes && c.attributes.session) || '<session>';
       head = 'WORKER STOPPED — ' + cardBit(it.card);
       hint = 'worker stopped without reporting — peek its session (tmux attach -t ' + sess + ') or steer it, then act';
+    } else if (it.kind === 'worker-stalled') {
+      const c = cards.find((x) => x.id === it.card);
+      const sess = (c && c.attributes && c.attributes.session) || '<session>';
+      head = 'WORKER STALLED — ' + cardBit(it.card);
+      hint = 'worker alive but silent — it may be hung: peek its session (tmux attach -t ' + sess + '), steer it (bc-axi worker send ' + it.card + ' --text-file <f|->), or pause and resume later (bc-axi worker pause ' + it.card + ' [--park]); then narrate what you found on the card timeline (bc-axi event ' + it.card + ' --level 2 --text-file -) — a legit long wait is fine, a SILENT one is not';
     } else if (it.kind === 'worker-died') {
       head = 'WORKER DIED — ' + cardBit(it.card);
       hint = 'the worker session died without done: resume it (bc-axi card start ' + it.card + ' --resume) or park the card back to backlog (bc-axi card park ' + it.card + ')';

--- a/server/server.js
+++ b/server/server.js
@@ -17,7 +17,7 @@
 //                            lastTurnEnd?, turns?}],
 //             projects: [{name, path, mode, source?, added}],   // registered repos (F6)
 //             workers:  [{card, ref, worktree: {path, tool}, branch?, project,
-//                         spawnedAt, done?, outcome?, flagged?, paused?, lastTurnEnd?, turns?}],
+//                         spawnedAt, done?, outcome?, flagged?, paused?, lastTurnEnd?, lastSignalAt?, turns?}],
 //             cards:   [{id, title, type, owner, column, labels[], attributes{}, body,
 //                        created, updated, threadStart, pendingOrder,
 //                        status: {worker: null|{id, state, expires}},  // lease; only status.set writes it
@@ -245,6 +245,7 @@ const BUILTIN_KINDS = {
   'worker-done': { emoji: '✅', level: 2 },
   'worker-died': { emoji: '💀', level: 2 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
+  'worker-stalled': { emoji: '🐢', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },
   parked: { emoji: '🅿️', level: 2 },
   respawned: { emoji: '♻️', level: 1 },
@@ -863,7 +864,7 @@ function moveCard(card, body, actorDefault) {
   card.updated = now();
   if (from === 'working') {
     const w = findWorker(card.id);
-    if (w) delete w.stopNotified; // leaving Working ends the stop-state
+    if (w) { delete w.stopNotified; delete w.staleNotified; } // leaving Working ends the stop/stale-state
   }
   // A move is a deliberate act: it always lands on the timeline. Default kind:
   // a lieutenant move is a handoff (level 1 from the kinds map — rings the
@@ -1117,6 +1118,7 @@ async function doStartCard(card, body) {
     delete existing.outcome;
     delete existing.flagged;
     delete existing.stopNotified;
+    delete existing.staleNotified;
     delete existing.paused; // a revived worker is watched again
     enterWorking(card, 'worker ' + workerName(ref) + ' resumed in ' + existing.worktree.path);
     return { worker: existing, resumed: true };
@@ -1197,7 +1199,11 @@ function workerSignal(card, body) {
   const text = String((body && body.text) || '').trim();
   if (!text) return { error: 'text required' };
   const w = findWorker(card.id);
-  if (w) delete w.stopNotified; // a fresh signal starts a fresh stop-state
+  if (w) {
+    delete w.stopNotified; // a fresh signal starts a fresh stop-state
+    delete w.staleNotified;
+    w.lastSignalAt = now(); // a milestone is real activity: resets the stale clock
+  }
   const ev = mkEvent({ text: text.slice(0, 2000), actor: (body && body.actor) || 'worker' }, { kind: 'signal' });
   card.events.push(ev);
   card.updated = now();
@@ -1215,7 +1221,7 @@ function workerDone(card, body) {
   const outcome = String((body && body.outcome) || '').trim();
   if (!outcome) return { error: 'outcome required' };
   const w = findWorker(card.id);
-  if (w) { w.done = true; w.outcome = outcome.slice(0, 2000); delete w.flagged; delete w.stopNotified; }
+  if (w) { w.done = true; w.outcome = outcome.slice(0, 2000); delete w.flagged; delete w.stopNotified; delete w.staleNotified; }
   const urls = outcome.match(PR_URL_RE) || [];
   if (urls.length) {
     if (!Array.isArray(card.attributes.prs)) card.attributes.prs = [];
@@ -1289,6 +1295,7 @@ async function pauseWorker(card, body) {
   }
   w.paused = now(); // BEFORE the kill: the death must never look like a crash
   delete w.stopNotified;
+  delete w.staleNotified;
   try {
     await harnessFor(w.ref).kill(w.ref);
   } catch (e) {
@@ -1336,7 +1343,7 @@ async function parkCard(card, body) {
   card.column = 'backlog';
   card.pendingOrder = null;
   card.updated = now();
-  if (w) delete w.stopNotified; // leaving Working ends the stop-state
+  if (w) { delete w.stopNotified; delete w.staleNotified; } // leaving Working ends the stop/stale-state
   const ev = mkEvent({
     actor: (body && body.actor) || 'agent',
     text: 'parked (worker ' + (w ? workerName(w.ref) + (w.paused ? ', paused' : ', dead') : 'absent') + '): '
@@ -1359,6 +1366,14 @@ async function parkCard(card, body) {
 //   worker done      -> nothing to watch (the done QueueItem already landed).
 const SUPERVISE_MS = process.env.BC_SUPERVISE_INTERVAL_MS !== undefined
   ? parseInt(process.env.BC_SUPERVISE_INTERVAL_MS, 10) : 30000;
+// The alive-but-hung gap: a worker stuck inside a single turn (e.g. an
+// infinite tool loop) emits NONE of the three end-of-life signals — alive()
+// stays true (no worker-died), the turn never ends (no worker-stopped), and
+// done is never reached. Long silence on a Working card is the only tell.
+// 30min default: the brief cadence is a milestone every 10–30min, so a
+// healthy worker resets the clock well inside the window.
+const BC_WORKER_STALE_SECS = process.env.BC_WORKER_STALE_SECS !== undefined
+  ? parseInt(process.env.BC_WORKER_STALE_SECS, 10) : 1800;
 const respawnAttempts = new Map(); // lieutenant id -> consecutive failed respawns
 let supervising = false;
 async function superviseTick() {
@@ -1430,6 +1445,29 @@ async function superviseTick() {
       if (w.done || w.flagged || w.paused) continue;
       let up = false;
       try { up = await harnessFor(w.ref).alive(w.ref); } catch (e) { up = false; }
+      // Staleness watchdog (alive-but-hung): checked BEFORE the alive
+      // early-continue, only for a genuinely live, unpaused worker on a
+      // Working card. One item per stall (staleNotified mirrors the
+      // stopNotified lifecycle); any real activity — signal, turn-end,
+      // resume — re-arms it.
+      if (up && !w.paused && BC_WORKER_STALE_SECS > 0 && !w.staleNotified) {
+        const card = findCard(w.card);
+        if (card && card.column === 'working') {
+          const stamps = [w.spawnedAt, w.lastTurnEnd, w.lastSignalAt]
+            .map((t) => (t ? Date.parse(t) : NaN)).filter((n) => !Number.isNaN(n));
+          const lastActivity = stamps.length ? Math.max(...stamps) : 0;
+          if (lastActivity && Date.now() - lastActivity > BC_WORKER_STALE_SECS * 1000) {
+            w.staleNotified = true;
+            const mins = Math.round((Date.now() - lastActivity) / 60000);
+            const text = 'worker ' + workerName(w.ref) + ' alive but silent for '
+              + mins + 'min (no signal/turn-end) — may be hung';
+            card.events.push(mkEvent({ text, actor: 'server' }, { kind: 'worker-stalled' }));
+            card.updated = now();
+            queuePush(card.owner, { kind: 'worker-stalled', card: card.id, text });
+            changed = true;
+          }
+        }
+      }
       // paused re-checked after the await: a pause landing mid-tick (marked,
       // then killed while alive() was in flight) must not read as a crash.
       if (up || w.paused) continue;

--- a/test/kinds.test.js
+++ b/test/kinds.test.js
@@ -23,6 +23,7 @@ const BUILTINS = {
   'worker-done': { emoji: '✅', level: 2 },
   'worker-died': { emoji: '💀', level: 2 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
+  'worker-stalled': { emoji: '🐢', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },
   parked: { emoji: '🅿️', level: 2 },
   respawned: { emoji: '♻️', level: 1 },

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -19,7 +19,7 @@ function fakeSession(dir, session) {
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, session + '.json'), JSON.stringify({ cwd: '/tmp', resumeId: null }) + '\n');
 }
-async function until(what, fn, ms = 5000) {
+async function until(what, fn, ms = 15000) {
   const deadline = Date.now() + ms;
   for (;;) {
     const v = await fn();

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -1,0 +1,174 @@
+'use strict';
+// The staleness watchdog — the "alive but hung" gap between the three worker
+// end-of-life signals: a worker stuck inside a single turn (infinite tool
+// loop) is alive (no worker-died), never ends its turn (no worker-stopped),
+// and never reaches done. superviseTick notices a live, unpaused worker on a
+// Working card with no activity (spawn / turn-end / signal) for
+// BC_WORKER_STALE_SECS and fires ONE worker-stalled card event + QueueItem;
+// any real activity re-arms it. Uses the file-backed fake harness: a marker
+// file makes the ref alive.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { startServer, sleep } = require('./helper');
+
+const TICK = '150';
+function fakeSession(dir, session) {
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, session + '.json'), JSON.stringify({ cwd: '/tmp', resumeId: null }) + '\n');
+}
+async function until(what, fn, ms = 5000) {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() > deadline) throw new Error('timeout waiting for: ' + what);
+    await sleep(50);
+  }
+}
+function seedBoard(dir, board) {
+  const sd = path.join(dir, '.bridge-command');
+  fs.mkdirSync(sd, { recursive: true });
+  fs.writeFileSync(path.join(sd, 'board.json'), JSON.stringify(Object.assign({
+    title: 'seeded', seq: 0, lieutenants: [], cards: [], events: [], labels: [], reads: {}, kinds: {},
+    projects: [], workers: [],
+  }, board), null, 2));
+}
+// One lieutenant + one Working card + one worker whose last activity is
+// `ageMs` in the past — the minimal stall-shaped board.
+function stallSeed(cardId, ageMs) {
+  const nowIso = new Date().toISOString();
+  const oldIso = new Date(Date.now() - ageMs).toISOString();
+  return {
+    lieutenants: [{ id: 'ada', name: 'Ada', color: '#58b6ff', charter: '', chat: [], created: nowIso }],
+    cards: [{
+      id: cardId, title: 'Slow', type: 'implementation', owner: 'ada', column: 'working',
+      labels: [], attributes: { repo: 'proj', session: 'bc-lt-ada:w-' + cardId }, body: '',
+      created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
+    }],
+    workers: [
+      { card: cardId, ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-' + cardId, cwd: '/tmp', resumeId: 'a' },
+        worktree: { path: '/tmp/none', tool: 'git' }, branch: 'bc/' + cardId, project: 'proj', spawnedAt: oldIso, done: false },
+    ],
+  };
+}
+
+test('alive worker silent past the threshold: ONE worker-stalled item + level-1 card event, no duplicates on later ticks', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
+    seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
+  });
+  try {
+    fakeSession(fdir, 'bc-lt-ada:w-slug'); // ALIVE — the whole point: not dead, just silent
+    await until('worker-stalled queue item', async () => {
+      const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+      return items.some((i) => i.kind === 'worker-stalled' && i.card === 'slug');
+    });
+    const card = (await s.api('GET', '/api/cards/slug')).body;
+    assert.strictEqual(card.column, 'working', 'the card stays Working — the owner decides');
+    const ev = card.events.find((e) => e.kind === 'worker-stalled');
+    assert.ok(ev, 'worker-stalled event on the card');
+    assert.strictEqual(ev.level, 1, 'a stall rings the bell — actionable, not ambient');
+    assert.match(ev.text, /alive but silent for \d+min/);
+
+    await sleep(600); // several more ticks: notified once, no item spam
+    const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+    assert.strictEqual(items.filter((i) => i.kind === 'worker-stalled').length, 1);
+    assert.ok(!items.some((i) => i.kind === 'worker-died'), 'an alive worker is never reported dead');
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+test('a fresh worker.signal re-arms the watchdog: lastSignalAt resets the clock, then a second stall fires AGAIN', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
+    seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
+  });
+  try {
+    fakeSession(fdir, 'bc-lt-ada:w-slug');
+    await until('first worker-stalled item', async () => {
+      const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+      return items.filter((i) => i.kind === 'worker-stalled').length === 1;
+    });
+    // a real milestone: clears staleNotified AND stamps lastSignalAt
+    const r = await s.api('POST', '/api/cards/slug/worker/signal', { text: 'still alive, honest' });
+    assert.strictEqual(r.status, 200);
+    const w = (await s.api('GET', '/api/board')).body.workers[0];
+    assert.ok(!w.staleNotified, 'signal cleared staleNotified');
+    assert.ok(w.lastSignalAt, 'signal stamped lastSignalAt');
+    // silence resumes: after another full threshold the watchdog fires again
+    await until('second worker-stalled item (re-armed)', async () => {
+      const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+      return items.filter((i) => i.kind === 'worker-stalled').length === 2;
+    });
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+test('a worker within the threshold is left alone', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '3600' },
+    seed: (dir) => seedBoard(dir, stallSeed('slug', 0)),
+  });
+  try {
+    fakeSession(fdir, 'bc-lt-ada:w-slug');
+    await sleep(600); // several ticks
+    const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+    assert.strictEqual(items.filter((i) => i.kind === 'worker-stalled').length, 0);
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+test('a DEAD silent worker takes the worker-died path, never worker-stalled (mutual exclusion)', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
+    seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
+    // no fakeSession marker: the window is dead
+  });
+  try {
+    await until('worker-died queue item', async () => {
+      const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+      return items.some((i) => i.kind === 'worker-died' && i.card === 'slug');
+    });
+    await sleep(600);
+    const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+    assert.strictEqual(items.filter((i) => i.kind === 'worker-stalled').length, 0, 'dead is dead — not stalled');
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+test('leaving Working clears staleNotified (mirrors the stopNotified lifecycle)', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
+    seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
+  });
+  try {
+    fakeSession(fdir, 'bc-lt-ada:w-slug');
+    await until('worker-stalled fired (flag set)', async () => {
+      const b = (await s.api('GET', '/api/board')).body;
+      return b.workers[0] && b.workers[0].staleNotified;
+    });
+    const r = await s.api('POST', '/api/cards/slug/move', { column: 'review', actor: 'agent' });
+    assert.strictEqual(r.status, 200);
+    const w = (await s.api('GET', '/api/board')).body.workers[0];
+    assert.ok(!w.staleNotified, 'the handoff out of Working ends the stale-state');
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## The gap

bridge-command has three worker end-of-life signals — `worker-done` (explicit), `worker-died` (session gone), `worker-stopped` (turn ended without done) — and a real worker fell through all three: alive, hung inside a single turn (infinite `gh pr checks` loop), turn never ending. The card sat in Working in total silence for >1h; the board read as healthy in-progress work.

## The fix — a staleness watchdog on the existing supervision tick

No new timer. `superviseTick`'s worker loop now checks, for a **live, unpaused** worker on a **Working** card, `max(spawnedAt, lastTurnEnd, lastSignalAt)` against `BC_WORKER_STALE_SECS` (default **1800s** — the brief cadence is a milestone every 10–30min, so a healthy worker resets the clock well inside the window; env-overridable). Past the threshold it fires **one** `worker-stalled` level-1 card event 🐢 + a QueueItem to the owning lieutenant, then arms `staleNotified`.

- `worker.signal` now stamps `w.lastSignalAt` — a milestone resets the stale clock.
- `staleNotified` mirrors the `stopNotified` lifecycle at every clear point (leaving Working, start/resume, signal, done, pause, park): one item per stall, re-armed by any real activity.
- Dead workers still take the `worker-died` path untouched (the check runs only when `alive()` is true).
- `bc-axi drain` hint for `worker-stalled`: peek the session (it may be hung), steer or pause/park it, **then narrate the finding on the card timeline** (`bc-axi event <card> --level 2`) — a legit long wait is fine, a silent one is not.

## Tests

5 new tests in `test/stale.test.js` (node test runner, fake harness, seeded boards): single-fire + no duplicate stacking, signal re-arms and it fires again, within-threshold silence is left alone, dead-vs-stalled mutual exclusion, leaving Working clears the flag. Kinds builtin map test updated. Full suite: **144/144 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
