### PR TITLE
feat: 👁 peek — live pane view over SSE through an optional harness capability

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -114,6 +114,17 @@ The server speaks ONLY this port. v0 ships the `claude` implementation (plus a f
 Harness working state (session ids, prompts, turn-end logs) lives in the workspace's
 `.bridge-command/harness/` — never global; spawned session names are unique per workspace.
 
+**Optional capability verbs.** Beyond the seven REQUIRED verbs a harness MAY expose extra
+verbs for features not every harness can honor. The port never validates them (requiring
+one would force every harness, `fake` included, to implement it); the server
+capability-checks at the call site (`typeof impl.openPane === 'function'`) and degrades
+gracefully when the verb is absent. Current optional verbs (pane viewing — the UI's 👁 peek):
+
+| Verb | Signature | Called by | Purpose |
+|---|---|---|---|
+| `harness.openPane` | `ref, {onFrame, intervalMs?, lines?} → {close()}` | ⚙️ pane hub | stream the pane's rendered screen as change-detected frames (strings, MAY carry ANSI SGR) — served to the captain over a dedicated per-target SSE (`GET /api/cards/:id/pane/stream`, `GET /api/lieutenants/:id/pane/stream`), ref-counted so N viewers share ONE feed and the last disconnect releases it; harness lacks the verb → `unsupported`, nothing to watch → `no-pane`, concurrent-pane cap → `busy` (all clean SSE events, never an HTTP error) |
+| `harness.paneSnapshot` | `ref, {lines?} → string` | ⚙️ pane hub | one-shot capture for the stream's initial paint |
+
 ## Invariants
 
 1. **Board is truth.** No shadow files, no mirror: cards + charters + queues in `.bridge-command/` ARE the state. Agent conversation memory is a cache; restart of any session is a non-event.

--- a/harness/README.md
+++ b/harness/README.md
@@ -14,6 +14,35 @@ Seven verbs, nothing else:
 | `onTurnEnd` | `(ref, hook) → unsubscribe()` | turn-boundary detection, push not poll |
 
 All verbs may be async. Zero dependencies — plain Node (>= 18; uses `node:test`, `fetch`).
+Beyond the seven, a harness MAY expose **optional capability verbs** — see below.
+
+## Optional capability verbs (pane viewing)
+
+Optional verbs are features not every harness can honor, so `port.js` never
+validates them — adding one to the required list would force every harness
+(the `fake` included) to implement it and break validation. The server
+capability-checks at the call site (`typeof impl.openPane === 'function'`)
+and degrades gracefully when the verb is absent (the pane endpoints answer
+`unsupported`). Current optional verbs:
+
+| Verb | Signature | Purpose |
+|---|---|---|
+| `openPane` | `(ref, {onFrame, intervalMs?, lines?}) → {close()}` | deliver the pane's CURRENT RENDERED SCREEN as successive frames: `onFrame(frameString)` fires whenever the content changes (identical frames are skipped); `close()` stops delivery and releases resources |
+| `paneSnapshot` | `(ref, {lines?}) → Promise<string>` | one-shot capture — the initial paint / non-streaming fallback |
+
+`intervalMs` defaults to ~1000, `lines` (scrollback depth) to ~200. A frame is
+a string that MAY carry ANSI SGR escapes (colors/bold).
+
+The claude implementation polls `capture-pane -e` — deliberately **rendered
+frames, not a `pipe-pane` byte stream**: the target is a full-screen TUI that
+repaints in place, so raw pty bytes would need a client-side terminal emulator
+(a dependency we won't add), while `capture-pane` returns the already-composed
+screen and keeps the client a plain `<pre>`. When the pane disappears it emits
+a final `\n[pane gone]` frame and stops. The fake emits deterministic counter
+frames (file-backed mode logs open/close to `<key>.pane.jsonl` for
+cross-process refcount assertions); `BC_FAKE_NO_PANE=1` hides both verbs to
+test capability-absent degradation, `BC_FAKE_PANE_MS` overrides its default
+frame interval.
 
 ## HarnessRef
 

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -410,7 +410,62 @@ function onTurnEnd(ref, hook, opts = {}) {
   };
 }
 
+// ---------- pane viewing (OPTIONAL capability verbs — see port.js) ----------
+// openPane(ref, { onFrame, intervalMs?, lines? }) -> { close() }
+// Streams the pane's CURRENT RENDERED SCREEN as successive frames: every
+// intervalMs the pane is captured with ANSI styling and scrollback, and
+// onFrame(frame) fires only when the content changed since the last frame.
+// close() stops delivery and releases the interval.
+//
+// Deliberately rendered frames via capture-pane, NOT a pipe-pane byte stream:
+// the target (claude) is a full-screen TUI that repaints in place, so raw pty
+// bytes would need a client-side terminal emulator (xterm.js — a dependency we
+// will not add). capture-pane returns the already-composed screen, works for
+// any TUI, and keeps the client a plain <pre>.
+function openPane(ref, opts = {}) {
+  const onFrame = typeof opts.onFrame === 'function' ? opts.onFrame : () => {};
+  const intervalMs = opts.intervalMs > 0 ? opts.intervalMs : 1000;
+  const lines = opts.lines > 0 ? opts.lines : 200;
+  const target = paneTarget(ref.session, ref.window);
+  let last = null;
+  let closed = false;
+  let busy = false; // never overlap captures — a slow tmux must not stack children
+
+  async function tick() {
+    if (closed || busy) return;
+    busy = true;
+    try {
+      if (!(await paneExists(ref.session, ref.window))) {
+        close();
+        try { onFrame('\n[pane gone]'); } catch { /* subscriber's problem */ }
+        return;
+      }
+      const frame = await t.captureStyled(target, lines);
+      if (closed || frame === null || frame === last) return;
+      last = frame;
+      try { onFrame(frame); } catch { /* a throwing subscriber must not kill the feed */ }
+    } finally {
+      busy = false;
+    }
+  }
+
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  tick(); // immediate first frame — the subscriber paints without waiting a tick
+  function close() { closed = true; clearInterval(timer); }
+  return { close };
+}
+
+// paneSnapshot(ref, { lines? }) -> Promise<string> — one-shot styled capture
+// (initial paint / non-streaming fallback). Empty string when unreadable.
+async function paneSnapshot(ref, opts = {}) {
+  const lines = opts.lines > 0 ? opts.lines : 200;
+  const out = await t.captureStyled(paneTarget(ref.session, ref.window), lines);
+  return out === null ? '' : out;
+}
+
 // installHooks is exported beyond the seven port verbs so `bc-axi init` can
 // install the workspace-level Stop hook (session-agnostic; the server dedupes
-// turn-end POSTs by session_id).
-module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd, installHooks };
+// turn-end POSTs by session_id). openPane/paneSnapshot are OPTIONAL capability
+// verbs (port.js) — pane viewing; every tmux specific of the feature lives here.
+module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd, installHooks, openPane, paneSnapshot };

--- a/harness/fake.js
+++ b/harness/fake.js
@@ -194,6 +194,52 @@ function kill(ref) {
   if (marker) { try { fs.unlinkSync(marker); } catch { /* already gone */ } }
 }
 
+// ---------- pane viewing (OPTIONAL capability verbs — see port.js) ----------
+// openPane emits deterministic counter frames on the interval — each frame
+// differs from the last, so change-detecting consumers always deliver — letting
+// server tests assert subscribe → frames → teardown without tmux. In
+// file-backed mode every open/close also appends to <key>.pane.jsonl, so a
+// WATCHING test process can assert refcounting (one open, one close) across
+// the process boundary.
+//   BC_FAKE_PANE_MS   default frame interval (callers' intervalMs still wins)
+//   BC_FAKE_NO_PANE   hides both verbs — the "harness without pane support"
+function logPane(session, event) {
+  const dir = fakeStateDir();
+  if (!dir) return;
+  fs.appendFileSync(path.join(dir, session + '.pane.jsonl'),
+    JSON.stringify({ ts: new Date().toISOString(), session, event }) + '\n');
+}
+
+function openPane(ref, opts = {}) {
+  const key = refKey(ref);
+  const onFrame = typeof opts.onFrame === 'function' ? opts.onFrame : () => {};
+  const intervalMs = opts.intervalMs > 0 ? opts.intervalMs
+    : (parseInt(process.env.BC_FAKE_PANE_MS, 10) > 0 ? parseInt(process.env.BC_FAKE_PANE_MS, 10) : 1000);
+  let n = 0;
+  let closed = false;
+  const emit = () => {
+    if (closed) return;
+    n += 1;
+    try { onFrame('fake pane ' + key + ' — frame ' + n + '\n'); } catch { /* subscriber's problem */ }
+  };
+  logPane(key, 'open');
+  const timer = setInterval(emit, intervalMs);
+  timer.unref?.();
+  emit(); // immediate first frame
+  return {
+    close() {
+      if (closed) return;
+      closed = true;
+      clearInterval(timer);
+      logPane(key, 'close');
+    },
+  };
+}
+
+async function paneSnapshot(ref) {
+  return 'fake pane ' + refKey(ref) + ' — snapshot\n';
+}
+
 // --- test helpers ---
 
 function transcript(ref) {
@@ -204,4 +250,11 @@ function reset() {
   sessions.clear();
 }
 
-module.exports = { spawn, send, alive, resumable, resume, onTurnEnd, kill, transcript, reset };
+const impl = { spawn, send, alive, resumable, resume, onTurnEnd, kill, transcript, reset };
+// Pane verbs are OPTIONAL by contract; BC_FAKE_NO_PANE simulates a harness
+// that never implemented them (capability-absent degradation under test).
+if (!process.env.BC_FAKE_NO_PANE) {
+  impl.openPane = openPane;
+  impl.paneSnapshot = paneSnapshot;
+}
+module.exports = impl;

--- a/harness/port.js
+++ b/harness/port.js
@@ -21,6 +21,21 @@
 //
 // Adding a harness = implementing the seven verbs and registering it here
 // (or shipping it as a builtin module). Nothing else.
+//
+// OPTIONAL capability verbs: beyond the seven REQUIRED verbs a harness MAY
+// expose extra verbs for features not every harness can honor. They are
+// deliberately NOT validated here — adding one to VERBS would force every
+// harness (the fake included) to implement it and break validation. The
+// server capability-checks at the call site (`typeof impl.openPane ===
+// 'function'`) and degrades gracefully when the verb is absent. Current
+// optional verbs (pane viewing — the UI's 👁 peek):
+//   openPane(ref, { onFrame, intervalMs?, lines? }) -> { close() }
+//       deliver the pane's CURRENT RENDERED SCREEN as successive frames:
+//       onFrame(frameString) fires whenever the content changes (identical
+//       frames are skipped); a frame MAY carry ANSI SGR escapes. close()
+//       stops delivery and releases resources. All async-safe.
+//   paneSnapshot(ref, { lines? }) -> Promise<string>
+//       one-shot capture — the initial paint / non-streaming fallback.
 
 const VERBS = ['spawn', 'send', 'alive', 'resumable', 'resume', 'kill', 'onTurnEnd'];
 

--- a/harness/tmux.js
+++ b/harness/tmux.js
@@ -144,6 +144,14 @@ async function capture(target, lines = 60) {
   return out === null ? '' : out;
 }
 
+// captureStyled(target, lines) — bounded pane capture WITH ANSI styling (-e
+// keeps SGR colors/bold) and scrollback depth (-S -N): the raw material for
+// pane frames (openPane / paneSnapshot). Unlike capture(), an unreadable pane
+// returns null — callers must tell "pane gone" from "pane blank".
+function captureStyled(target, lines = 200) {
+  return tryTmux('capture-pane', '-e', '-p', '-t', target, '-S', `-${lines}`);
+}
+
 // sendLiteral(target, text) — put text into the composer WITHOUT submitting.
 // Single-line text goes via `send-keys -l`. Multi-line text goes via a tmux
 // buffer paste in bracketed-paste mode (-p) so embedded newlines land as part
@@ -200,6 +208,7 @@ module.exports = {
   composerState,
   paneIsBusy,
   capture,
+  captureStyled,
   sendLiteral,
   sendKey,
   submit,

--- a/server/server.js
+++ b/server/server.js
@@ -673,9 +673,93 @@ function broadcast() {
   const payload = 'event: board\ndata: ' + JSON.stringify(publicBoard('user')) + '\n\n';
   for (const res of sseClients) res.write(payload);
 }
+
+// ---------- pane hub (👁 peek: live pane frames over a per-target SSE) ----------
+// The harness port's OPTIONAL openPane capability, ref-counted per pane key:
+// the FIRST subscriber for a key opens ONE harness pane feed, every frame fans
+// out to that key's SSE clients, and the LAST disconnect closes the feed. A
+// dedicated per-target stream, never /api/events — per-card frames must not
+// spam every board client. The server owns ref resolution (card → its worker's
+// ref, lieutenant → its ref); the harness owns how a pane is actually watched.
+// Guards are clean SSE events then close (never a 500, never a hang):
+//   unsupported — the ref's harness exposes no openPane
+//   no-pane     — nothing to watch (unknown target, card not Working, no worker,
+//                 no live session, or the open itself failed)
+//   busy        — the concurrent-pane cap (bounds child-process load) is hit
+const PANE_MAX = parseInt(process.env.BC_PANE_MAX, 10) > 0 ? parseInt(process.env.BC_PANE_MAX, 10) : 8;
+const panes = new Map(); // paneKey -> { clients: Set<res>, handle, last }
+function paneKey(ref) { return ref.harness + '/' + ref.session + (ref.window ? ':' + ref.window : ''); }
+function paneWrite(res, event, data) {
+  res.write('event: ' + event + '\ndata: ' + JSON.stringify(data === undefined ? {} : data) + '\n\n');
+}
+function paneStream(req, res, ref, reason) {
+  res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
+  if (!ref) { paneWrite(res, 'no-pane', { reason }); return res.end(); }
+  let impl;
+  try { impl = harnessFor(ref); }
+  catch (e) { paneWrite(res, 'no-pane', { reason: String((e && e.message) || e) }); return res.end(); }
+  if (typeof impl.openPane !== 'function') {
+    paneWrite(res, 'unsupported', { harness: ref.harness });
+    return res.end();
+  }
+  const key = paneKey(ref);
+  let hub = panes.get(key);
+  if (!hub) {
+    if (panes.size >= PANE_MAX) { paneWrite(res, 'busy', { max: PANE_MAX }); return res.end(); }
+    hub = { clients: new Set(), handle: null, last: null };
+    panes.set(key, hub);
+    // openPane may be async (the port's verbs all may be); frames can only
+    // start after it resolves, so subscribers added meanwhile just wait. If
+    // everyone left before it resolved, close the freshly opened feed.
+    Promise.resolve()
+      .then(() => impl.openPane(ref, {
+        onFrame: (frame) => {
+          hub.last = String(frame);
+          for (const c of hub.clients) paneWrite(c, 'frame', hub.last);
+        },
+      }))
+      .then((handle) => {
+        if (panes.get(key) === hub) { hub.handle = handle; return; }
+        try { handle && typeof handle.close === 'function' && handle.close(); } catch (e) { /* already gone */ }
+      })
+      .catch((e) => {
+        if (panes.get(key) !== hub) return;
+        panes.delete(key);
+        for (const c of hub.clients) {
+          paneWrite(c, 'no-pane', { reason: 'open failed: ' + String((e && e.message) || e) });
+          c.end();
+        }
+      });
+  }
+  hub.clients.add(res);
+  // Immediate paint: late joiners get the hub's last frame; the first
+  // subscriber gets a one-shot snapshot when the harness offers one and the
+  // live feed hasn't delivered yet (a real frame arriving first wins).
+  if (hub.last != null) paneWrite(res, 'frame', hub.last);
+  else if (typeof impl.paneSnapshot === 'function') {
+    Promise.resolve()
+      .then(() => impl.paneSnapshot(ref))
+      .then((snap) => {
+        if (hub.last == null && hub.clients.has(res) && typeof snap === 'string') paneWrite(res, 'frame', snap);
+      })
+      .catch(() => { /* the interval frame will paint instead */ });
+  }
+  req.on('close', () => {
+    hub.clients.delete(res);
+    if (hub.clients.size) return;
+    panes.delete(key); // last subscriber gone: release the harness feed
+    try { hub.handle && typeof hub.handle.close === 'function' && hub.handle.close(); }
+    catch (e) { /* closing a dead pane is a no-op */ }
+  });
+}
+
 // Named ping (not an SSE comment): comments are invisible to EventSource, so
-// the client's staleness watchdog couldn't see the stream is alive.
-setInterval(() => { for (const res of sseClients) res.write('event: ping\ndata: {}\n\n'); }, 25000).unref();
+// the client's staleness watchdog couldn't see the stream is alive. Pane
+// streams piggyback on the same ping so proxies don't drop them either.
+setInterval(() => {
+  for (const res of sseClients) res.write('event: ping\ndata: {}\n\n');
+  for (const hub of panes.values()) for (const res of hub.clients) res.write('event: ping\ndata: {}\n\n');
+}, 25000).unref();
 
 // ---------- helpers ----------
 function sendJson(res, code, obj) {
@@ -2071,6 +2155,33 @@ const server = http.createServer(async (req, res) => {
       nudged.delete(r.lieutenant); // handled: a fresh append nudges anew
       broadcast(); // the ack advances the seen cursor too (drain normally beat it here)
       return sendJson(res, 200, r);
+    }
+
+    // ----- pane streams (👁 peek — per-target SSE; see the pane hub above) -----
+    // The HTTP connection's lifetime IS the subscription: connect to watch,
+    // disconnect to release (refcounted). Ref resolution happens HERE — the
+    // route knows cards and lieutenants, the hub knows refs, the harness knows
+    // the rest. Every guard is an SSE event, not an HTTP error: the client is
+    // an EventSource, which can't read error bodies.
+    const paneRoute = /^\/api\/(cards|lieutenants)\/([^/]+)\/pane\/stream$/.exec(p);
+    if (paneRoute && req.method === 'GET') {
+      const id = decodeURIComponent(paneRoute[2]);
+      let ref = null;
+      let reason = '';
+      if (paneRoute[1] === 'cards') {
+        const card = findCard(id);
+        const w = card && findWorker(card.id);
+        if (!card) reason = 'unknown card: ' + id;
+        else if (card.column !== 'working') reason = 'card is not Working';
+        else if (!w) reason = 'no worker bound to ' + id;
+        else ref = w.ref;
+      } else {
+        const lt = findLieutenant(id);
+        if (!lt) reason = 'unknown lieutenant: ' + id;
+        else if (!isHarnessRef(lt.ref)) reason = 'lieutenant has no live session';
+        else ref = lt.ref;
+      }
+      return paneStream(req, res, ref, reason);
     }
 
     // ----- SSE -----

--- a/test/ansi.test.js
+++ b/test/ansi.test.js
@@ -1,0 +1,76 @@
+'use strict';
+// ui/js/ansi.js — the zero-dep ANSI SGR → HTML converter behind the 👁 peek
+// drawer. SGR (reset/bold/dim/16-color/256-color) becomes inline-styled spans;
+// text is HTML-escaped FIRST; non-SGR escapes (cursor movement, OSC) are
+// stripped. The module is ESM (it ships to the browser), hence dynamic import.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let ansiToHtml;
+test.before(async () => {
+  ({ ansiToHtml } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'ansi.js')).href));
+});
+
+test('plain text passes through; HTML is escaped', () => {
+  assert.strictEqual(ansiToHtml('hello world'), 'hello world');
+  assert.strictEqual(ansiToHtml('<b> & "quotes" >'), '&lt;b&gt; &amp; "quotes" &gt;');
+});
+
+test('escaping happens before markup: a styled < never becomes a tag', () => {
+  assert.strictEqual(ansiToHtml('\x1b[1m<x>\x1b[0m'),
+    '<span style="font-weight:700">&lt;x&gt;</span>');
+});
+
+test('bold, dim, and their resets', () => {
+  assert.strictEqual(ansiToHtml('\x1b[1mbold\x1b[0m plain'),
+    '<span style="font-weight:700">bold</span> plain');
+  assert.strictEqual(ansiToHtml('\x1b[2mdim\x1b[22mnorm'),
+    '<span style="opacity:.55">dim</span>norm');
+});
+
+test('16-color fg/bg, normal and bright, with 39/49 defaults', () => {
+  assert.strictEqual(ansiToHtml('\x1b[31mred\x1b[39m plain'),
+    '<span style="color:#cd3131">red</span> plain');
+  assert.strictEqual(ansiToHtml('\x1b[91mbright\x1b[0m'),
+    '<span style="color:#f14c4c">bright</span>');
+  assert.strictEqual(ansiToHtml('\x1b[42mbg\x1b[49m.'),
+    '<span style="background:#0dbc79">bg</span>.');
+});
+
+test('256-color fg/bg: base, cube, grayscale (semicolon and colon forms)', () => {
+  assert.strictEqual(ansiToHtml('\x1b[38;5;196mX\x1b[0m'),
+    '<span style="color:#ff0000">X</span>'); // cube 196 = pure red
+  assert.strictEqual(ansiToHtml('\x1b[48;5;28mX\x1b[0m'),
+    '<span style="background:#008700">X</span>');
+  assert.strictEqual(ansiToHtml('\x1b[38;5;244mgray\x1b[0m'),
+    '<span style="color:#808080">gray</span>');
+  assert.strictEqual(ansiToHtml('\x1b[38:5:196mX\x1b[0m'),
+    '<span style="color:#ff0000">X</span>'); // tmux may emit colon subparams
+});
+
+test('truecolor fg (defensive: TUIs render 24-bit, capture keeps it)', () => {
+  assert.strictEqual(ansiToHtml('\x1b[38;2;10;20;30mX\x1b[0m'),
+    '<span style="color:#0a141e">X</span>');
+});
+
+test('combined attributes render as one span; reset splits runs', () => {
+  assert.strictEqual(ansiToHtml('\x1b[1;31mhot\x1b[0mcold'),
+    '<span style="color:#cd3131;font-weight:700">hot</span>cold');
+});
+
+test('cursor-movement and OSC sequences are stripped, not rendered', () => {
+  assert.strictEqual(ansiToHtml('\x1b[2J\x1b[Hhello\x1b[3;7Hthere'), 'hellothere');
+  assert.strictEqual(ansiToHtml('\x1b]0;window title\x07visible'), 'visible');
+  assert.strictEqual(ansiToHtml('a\x1b[Kb'), 'ab'); // erase-line mid-text
+});
+
+test('multi-line frames keep their newlines (the <pre> relies on it)', () => {
+  assert.strictEqual(ansiToHtml('line1\n\x1b[32mline2\x1b[0m\n'),
+    'line1\n<span style="color:#0dbc79">line2</span>\n');
+});
+
+test('unknown SGR codes are ignored without derailing the parse', () => {
+  assert.strictEqual(ansiToHtml('\x1b[4;53munderline-ish\x1b[0m'), 'underline-ish');
+});

--- a/test/pane.test.js
+++ b/test/pane.test.js
@@ -1,0 +1,245 @@
+'use strict';
+// 👁 peek — the pane hub: a worker's / lieutenant's pane streamed over a
+// dedicated per-target SSE, through the harness port's OPTIONAL openPane
+// capability. Ref-counted (N viewers share ONE harness feed; the last
+// disconnect releases it), capability-checked (no openPane → `unsupported`),
+// guarded (`no-pane`, `busy`) — every guard a clean SSE event, never a 500.
+// Uses the file-backed fake harness: opens/closes land in <key>.pane.jsonl so
+// this process can assert refcounting across the server process boundary.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { startServerWithLieutenant, withOwner, sleep, LT } = require('./helper');
+const { lieutenantSession, workerWindow } = require('../server/names.js');
+
+function git(dir, ...args) {
+  return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
+}
+function makeRepo(root, name = 'srcrepo') {
+  const repo = path.join(root, name);
+  fs.mkdirSync(repo, { recursive: true });
+  execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'hello\n');
+  git(repo, 'add', '.');
+  git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init');
+  return repo;
+}
+
+// One temp tree per boot: fake-harness state + source repo + workspace.
+// BC_FAKE_PANE_MS keeps fake frames fast so tests never wait a real second.
+async function boot(extraEnv = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-pane-'));
+  const repo = makeRepo(root);
+  const fdir = path.join(root, 'fake');
+  const s = await startServerWithLieutenant({
+    env: Object.assign({
+      BC_FAKE_STATE: fdir, BC_WORKTREE_TOOL: 'git', BC_FAKE_PANE_MS: '25',
+      BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
+    }, extraEnv),
+  });
+  const r = await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+  assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+  const teardown = async () => { await s.stop(); fs.rmSync(root, { recursive: true, force: true }); };
+  return { s, root, repo, fdir, teardown };
+}
+
+// Start a fake worker on a fresh card and return its harness pane key.
+async function startWorker(s, dir, id) {
+  let r = await s.api('POST', '/api/cards', withOwner({ title: id, id, attributes: { repo: 'proj' } }));
+  assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+  r = await s.api('POST', '/api/cards/' + id + '/start', { harness: 'fake' });
+  assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+  return lieutenantSession(dir, LT) + ':' + workerWindow(id);
+}
+
+// A minimal SSE client over fetch: collects {event, data} frames as they land;
+// waitFor(event) resolves with the first matching event; close() drops the
+// connection (what the server sees as the subscriber leaving).
+async function sseOpen(url) {
+  const ctrl = new AbortController();
+  const res = await fetch(url, { signal: ctrl.signal });
+  assert.strictEqual(res.status, 200);
+  assert.match(res.headers.get('content-type'), /text\/event-stream/);
+  const events = [];
+  const waiters = [];
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  (async () => {
+    try {
+      for (;;) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buf += dec.decode(value, { stream: true });
+        for (;;) {
+          const end = buf.indexOf('\n\n');
+          if (end === -1) break;
+          const frame = buf.slice(0, end);
+          buf = buf.slice(end + 2);
+          const event = (/^event: (.*)$/m.exec(frame) || [])[1] || 'message';
+          const raw = (/^data: (.*)$/m.exec(frame) || [])[1];
+          let data = null;
+          try { data = raw === undefined ? null : JSON.parse(raw); } catch (e) { data = raw; }
+          const ev = { event, data };
+          events.push(ev);
+          for (const w of [...waiters]) {
+            if (w.match(ev)) { waiters.splice(waiters.indexOf(w), 1); w.resolve(ev); }
+          }
+        }
+      }
+    } catch (e) { /* aborted / closed */ }
+    for (const w of [...waiters]) w.reject(new Error('stream ended before event: ' + w.name));
+  })();
+  return {
+    events,
+    waitFor(name, timeoutMs = 4000, extra) {
+      const match = (ev) => ev.event === name && (!extra || extra(ev));
+      const hit = events.find(match);
+      if (hit) return Promise.resolve(hit);
+      return new Promise((resolve, reject) => {
+        const w = { name, match, resolve, reject };
+        waiters.push(w);
+        setTimeout(() => {
+          const i = waiters.indexOf(w);
+          if (i !== -1) { waiters.splice(i, 1); reject(new Error('timeout waiting for event: ' + name)); }
+        }, timeoutMs).unref();
+      });
+    },
+    close() { ctrl.abort(); },
+  };
+}
+
+function paneLog(fdir, key) {
+  try {
+    return fs.readFileSync(path.join(fdir, key + '.pane.jsonl'), 'utf8')
+      .split('\n').filter(Boolean).map((l) => JSON.parse(l));
+  } catch (e) { return []; }
+}
+async function waitLog(fdir, key, pred, timeoutMs = 4000) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const log = paneLog(fdir, key);
+    if (pred(log)) return log;
+    if (Date.now() > deadline) return log;
+    await sleep(30);
+  }
+}
+
+test('card pane stream: frames flow; two subscribers share ONE pane; last close tears it down', async () => {
+  const { s, fdir, teardown } = await boot();
+  try {
+    const key = await startWorker(s, s.dir, 'peek-me');
+    const url = s.base + '/api/cards/peek-me/pane/stream';
+
+    const a = await sseOpen(url);
+    const f1 = await a.waitFor('frame');
+    assert.match(String(f1.data), /fake pane .*w-peek-me/);
+
+    // frames keep flowing (fake counter frames change every tick)
+    await a.waitFor('frame', 4000, (ev) => ev !== f1 && ev.data !== f1.data);
+
+    // a second subscriber shares the pane: immediate paint, still ONE open
+    const b = await sseOpen(url);
+    await b.waitFor('frame');
+    let log = await waitLog(fdir, key, (l) => l.some((e) => e.event === 'open'));
+    assert.strictEqual(log.filter((e) => e.event === 'open').length, 1, 'refcount: one open for two subscribers');
+    assert.strictEqual(log.filter((e) => e.event === 'close').length, 0);
+
+    // first leaves — the pane stays (b still watching)
+    a.close();
+    await sleep(150);
+    log = paneLog(fdir, key);
+    assert.strictEqual(log.filter((e) => e.event === 'close').length, 0, 'pane survives while a subscriber remains');
+    await b.waitFor('frame', 4000, (ev) => ev.data !== f1.data); // b still receives
+
+    // last leaves — close() exactly once
+    b.close();
+    log = await waitLog(fdir, key, (l) => l.some((e) => e.event === 'close'));
+    assert.strictEqual(log.filter((e) => e.event === 'close').length, 1, 'last disconnect closes the pane once');
+
+    // a fresh subscriber reopens (open #2): the hub was really gone
+    const c = await sseOpen(url);
+    await c.waitFor('frame');
+    log = await waitLog(fdir, key, (l) => l.filter((e) => e.event === 'open').length === 2);
+    assert.strictEqual(log.filter((e) => e.event === 'open').length, 2);
+    c.close();
+  } finally { await teardown(); }
+});
+
+test('lieutenant pane stream: resolves the lieutenant ref', async () => {
+  const { s, teardown } = await boot();
+  try {
+    // bind a fake ref to the lieutenant (like a spawned one would carry)
+    const r = await s.api('PATCH', '/api/lieutenants/' + LT,
+      { ref: { harness: 'fake', session: 'bc-lt-pane', cwd: '/tmp' } });
+    assert.strictEqual(r.status, 200);
+    const c = await sseOpen(s.base + '/api/lieutenants/' + LT + '/pane/stream');
+    const f = await c.waitFor('frame');
+    assert.match(String(f.data), /fake pane bc-lt-pane/);
+    c.close();
+  } finally { await teardown(); }
+});
+
+test('capability absent (harness without openPane) → unsupported, clean close', async () => {
+  const { s, teardown } = await boot({ BC_FAKE_NO_PANE: '1' });
+  try {
+    await startWorker(s, s.dir, 'no-cap');
+    const c = await sseOpen(s.base + '/api/cards/no-cap/pane/stream');
+    const ev = await c.waitFor('unsupported');
+    assert.strictEqual(ev.data.harness, 'fake');
+    assert.ok(!c.events.some((e) => e.event === 'frame'), 'no frames from an unsupported harness');
+    c.close();
+  } finally { await teardown(); }
+});
+
+test('no live worker / card not Working / unknown targets → no-pane', async () => {
+  const { s, teardown } = await boot();
+  try {
+    // a card sitting in Backlog: not Working, no worker
+    await s.api('POST', '/api/cards', withOwner({ title: 'Parked idea', id: 'parked-idea' }));
+    let c = await sseOpen(s.base + '/api/cards/parked-idea/pane/stream');
+    let ev = await c.waitFor('no-pane');
+    assert.match(ev.data.reason, /not Working/);
+    c.close();
+
+    c = await sseOpen(s.base + '/api/cards/never-was/pane/stream');
+    ev = await c.waitFor('no-pane');
+    assert.match(ev.data.reason, /unknown card/);
+    c.close();
+
+    c = await sseOpen(s.base + '/api/lieutenants/nobody/pane/stream');
+    ev = await c.waitFor('no-pane');
+    assert.match(ev.data.reason, /unknown lieutenant/);
+    c.close();
+
+    // a lieutenant with no session ref
+    c = await sseOpen(s.base + '/api/lieutenants/' + LT + '/pane/stream');
+    ev = await c.waitFor('no-pane');
+    assert.match(ev.data.reason, /no live session/);
+    c.close();
+  } finally { await teardown(); }
+});
+
+test('concurrent-pane cap → busy (existing streams unaffected)', async () => {
+  const { s, teardown } = await boot({ BC_PANE_MAX: '1' });
+  try {
+    await startWorker(s, s.dir, 'first-pane');
+    await startWorker(s, s.dir, 'second-pane');
+    const a = await sseOpen(s.base + '/api/cards/first-pane/pane/stream');
+    await a.waitFor('frame');
+
+    // a DIFFERENT pane key over the cap → busy; the same key still shares
+    const b = await sseOpen(s.base + '/api/cards/second-pane/pane/stream');
+    const ev = await b.waitFor('busy');
+    assert.strictEqual(ev.data.max, 1);
+    b.close();
+
+    const c = await sseOpen(s.base + '/api/cards/first-pane/pane/stream');
+    await c.waitFor('frame'); // sharing the one open pane never counts against the cap
+    a.close();
+    c.close();
+  } finally { await teardown(); }
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -574,6 +574,44 @@ a.a-uri { color: var(--accent); }
 #lt-create { background: var(--accent2); border-radius: 7px; color: #eaf6ff; padding: 6px 15px; font-size: 12.5px; }
 #lt-create:hover { background: var(--accent); color: #06222f; }
 
+/* ---------- pane peek drawer (👁: live terminal view) ---------- */
+#pane-overlay {
+  position: fixed; inset: 0; z-index: 92; background: rgba(4, 7, 11, .6);
+  display: flex; align-items: center; justify-content: center; backdrop-filter: blur(2px);
+}
+#pane-modal {
+  width: min(1000px, calc(100vw - 28px)); height: min(660px, 86vh); display: flex; flex-direction: column;
+  background: #0a0c11; border: 1px solid var(--line2); border-radius: 14px;
+  box-shadow: var(--shadow); animation: pop-in .15s ease-out; overflow: hidden;
+}
+.pane-head {
+  flex: none; display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+  border-bottom: 1px solid var(--line); background: var(--bg2);
+}
+.pane-live { width: 8px; height: 8px; border-radius: 50%; background: var(--faint); flex: none; transition: background .2s; }
+.pane-live.on { background: var(--ok); box-shadow: 0 0 7px var(--ok); animation: worker-pulse 1.5s ease-in-out infinite; }
+.pane-live-lbl { color: var(--faint); font-size: 10px; text-transform: uppercase; letter-spacing: 1px; flex: none; }
+.pane-live.on + .pane-live-lbl { color: var(--ok); }
+.pane-title { flex: 1; min-width: 0; font-family: var(--mono); font-size: 12.5px; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#pane-close { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; }
+#pane-close:hover { color: var(--text); }
+/* the terminal surface: mono, whole-screen frames, no wrapping — the frame IS
+   the rendered screen, so it scrolls in both axes instead of reflowing */
+#pane-body {
+  flex: 1; min-height: 0; overflow: auto; margin: 0; padding: 12px 14px;
+  font-family: var(--mono); font-size: 11.5px; line-height: 1.4; color: #c9d4e0;
+  white-space: pre; overscroll-behavior: contain;
+}
+#pane-msg { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--dim); font-size: 13px; padding: 24px; text-align: center; }
+/* 👁 affordances: hover-revealed on the tile foot and the lieutenant chip */
+.tile .t-peek { color: var(--faint); font-size: 12px; line-height: 1; padding: 0 2px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
+.tile:hover .t-peek { opacity: 1; }
+.tile .t-peek:hover { color: var(--accent); background: var(--accent-soft); }
+.lt-card .lt-peek { color: var(--faint); font-size: 12px; line-height: 1; padding: 0 3px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
+.lt-card:hover .lt-peek { opacity: 1; }
+.lt-card .lt-peek:hover { color: var(--accent); background: var(--accent-soft); }
+@media (hover: none) { .tile .t-peek, .lt-card .lt-peek { opacity: .6; } } /* touch: always visible */
+
 /* ---------- artifact viewer ---------- */
 #av-overlay {
   position: fixed; inset: 0; z-index: 95; background: rgba(4, 7, 11, .6);
@@ -652,6 +690,8 @@ a.a-uri { color: var(--accent); }
   #board { flex-direction: row; gap: 10px; padding: 10px; scroll-snap-type: x mandatory; -webkit-overflow-scrolling: touch; }
   .column { flex: 0 0 min(300px, 86vw); max-width: none; scroll-snap-align: start; }
   #detail { width: 100vw; border-left: none; }
+  /* the peek drawer goes full-screen — a terminal needs every column it can get */
+  #pane-modal { width: 100vw; height: 100vh; height: 100dvh; border-radius: 0; border: none; }
   .attr .v { max-width: 150px; }
   #notif-panel { top: 48px; }
   #settings-panel { top: 48px; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -168,6 +168,20 @@
   </form>
 </div>
 
+<!-- pane peek drawer (👁): a worker's / lieutenant's terminal, live over SSE -->
+<div id="pane-overlay" hidden>
+  <div id="pane-modal">
+    <div class="pane-head">
+      <span class="pane-live" id="pane-live" title="not streaming"></span>
+      <span class="pane-live-lbl">live</span>
+      <span class="pane-title" id="pane-title"></span>
+      <button id="pane-close" title="close">✕</button>
+    </div>
+    <pre id="pane-body"></pre>
+    <div id="pane-msg" hidden></div>
+  </div>
+</div>
+
 <!-- artifact viewer -->
 <div id="av-overlay" hidden>
   <div id="av-modal">

--- a/ui/js/ansi.js
+++ b/ui/js/ansi.js
@@ -1,0 +1,123 @@
+// ansi.js — tiny zero-dep ANSI SGR → HTML converter for pane frames.
+// Handles reset, bold/dim, 16-color and 256-color (and, defensively, truecolor)
+// fg/bg as inline-styled <span>s. Text is HTML-escaped BEFORE any markup is
+// added. Non-SGR escape sequences (cursor movement, OSC titles, …) are
+// stripped — capture-style frames are mostly SGR + text, but be defensive.
+
+// 16-color terminal palette (normal 0-7, bright 8-15), tuned for a dark surface.
+const BASE16 = [
+  '#3b4453', '#cd3131', '#0dbc79', '#e5e510', '#2472c8', '#bc3fc0', '#11a8cd', '#e5e5e5',
+  '#666666', '#f14c4c', '#23d18b', '#f5f543', '#3b8eea', '#d670d6', '#29b8db', '#ffffff',
+];
+const CUBE = [0, 95, 135, 175, 215, 255]; // xterm 6×6×6 color-cube levels
+
+function hex2(n) { return n.toString(16).padStart(2, '0'); }
+function rgb(r, g, b) { return '#' + hex2(r) + hex2(g) + hex2(b); }
+
+// xterm 256-color index → css color (0-15 base, 16-231 cube, 232-255 grays)
+function color256(n) {
+  if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+  if (n < 16) return BASE16[n];
+  if (n < 232) {
+    const v = n - 16;
+    return rgb(CUBE[Math.floor(v / 36)], CUBE[Math.floor(v / 6) % 6], CUBE[v % 6]);
+  }
+  const g = 8 + (n - 232) * 10;
+  return rgb(g, g, g);
+}
+
+
+// ansiToHtml(frame) -> html string. Runs of text under one SGR state become one
+// <span style>; unstyled runs stay bare text.
+export function ansiToHtml(str) {
+  const st = { bold: false, dim: false, fg: null, bg: null };
+  let out = '';
+  let buf = '';        // pending text under bufStyle
+  let bufStyle = '';   // the css of the text sitting in buf
+
+  const styleOf = () => {
+    const parts = [];
+    if (st.fg) parts.push('color:' + st.fg);
+    if (st.bg) parts.push('background:' + st.bg);
+    if (st.bold) parts.push('font-weight:700');
+    if (st.dim) parts.push('opacity:.55');
+    return parts.join(';');
+  };
+  const flush = () => {
+    if (!buf) return;
+    out += bufStyle ? '<span style="' + bufStyle + '">' + buf + '</span>' : buf;
+    buf = '';
+  };
+
+  // One SGR parameter list. Handles both semicolon args (38;5;196 / 38;2;r;g;b)
+  // and colon subparams (38:5:196, 38:2::r:g:b).
+  const applySgr = (raw) => {
+    const parts = (raw === '' ? '0' : raw).split(';');
+    for (let p = 0; p < parts.length; p++) {
+      const item = parts[p];
+      const code = parseInt(item.split(':')[0], 10);
+      if (Number.isNaN(code) || code === 0) { st.bold = false; st.dim = false; st.fg = null; st.bg = null; }
+      else if (code === 1) st.bold = true;
+      else if (code === 2) st.dim = true;
+      else if (code === 22) { st.bold = false; st.dim = false; }
+      else if (code >= 30 && code <= 37) st.fg = BASE16[code - 30];
+      else if (code >= 90 && code <= 97) st.fg = BASE16[code - 90 + 8];
+      else if (code === 39) st.fg = null;
+      else if (code >= 40 && code <= 47) st.bg = BASE16[code - 40];
+      else if (code >= 100 && code <= 107) st.bg = BASE16[code - 100 + 8];
+      else if (code === 49) st.bg = null;
+      else if (code === 38 || code === 48) {
+        let mode;
+        let args;
+        if (item.includes(':')) { // colon form: self-contained subparams
+          const sub = item.split(':');
+          mode = sub[1];
+          args = sub.length >= 6 ? sub.slice(3) : sub.slice(2); // 38:2::r:g:b carries a colorspace slot
+        } else {
+          mode = parts[p + 1];
+          if (mode === '5') { args = [parts[p + 2]]; p += 2; }
+          else if (mode === '2') { args = parts.slice(p + 2, p + 5); p += 4; }
+          else { args = []; p += 1; }
+        }
+        let col = null;
+        if (mode === '5') col = color256(parseInt(args[0], 10));
+        else if (mode === '2') {
+          const [r, g, b] = args.map((v) => parseInt(v, 10));
+          if ([r, g, b].every((v) => Number.isInteger(v) && v >= 0 && v <= 255)) col = rgb(r, g, b);
+        }
+        if (code === 38) st.fg = col; else st.bg = col;
+      }
+      // anything else (italic, underline, blink, …): ignored, deliberately small
+    }
+  };
+
+  let cur = ''; // css of the CURRENT SGR state (recomputed only on SGR)
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+    if (c === '\x1b') {
+      const n = str[i + 1];
+      if (n === '[') { // CSI: apply if SGR (final 'm'), strip anything else
+        let j = i + 2;
+        while (j < str.length && !/[@-~]/.test(str[j])) j++;
+        if (j < str.length && str[j] === 'm') {
+          applySgr(str.slice(i + 2, j));
+          cur = styleOf();
+        }
+        i = j < str.length ? j : str.length;
+        continue;
+      }
+      if (n === ']') { // OSC: strip to BEL or ST (ESC \)
+        let j = i + 2;
+        while (j < str.length && str[j] !== '\x07' && !(str[j] === '\x1b' && str[j + 1] === '\\')) j++;
+        i = str[j] === '\x1b' ? j + 1 : j;
+        continue;
+      }
+      i++; // lone ESC + one byte: drop
+      continue;
+    }
+    if (cur !== bufStyle) { flush(); bufStyle = cur; }
+    buf += c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c;
+  }
+  flush();
+  return out;
+}

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -6,6 +6,7 @@ import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, setHtmlIfChanged } fr
 import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
+import { openCardPane, openLieutenantPane } from './pane.js';
 
 const laneEl = document.getElementById('lane');
 const boardEl = document.getElementById('board');
@@ -39,6 +40,7 @@ function ltCardHtml(l) {
     '<span class="lt-name">' + esc(l.name || l.id) + '</span>' +
     ind +
     '<span class="lt-counts">' + mine.length + (working ? ' · 🔨' + working : '') + '</span>' +
+    '<button class="lt-peek" title="watch this lieutenant\'s terminal live">👁</button>' +
     '<button class="lt-menu" title="lieutenant actions">⋯</button>' +
     (unread ? '<span class="badge-n">' + (unread > 99 ? '99+' : unread) + '</span>' : '') +
     '</div>';
@@ -51,6 +53,7 @@ function renderLane() {
   laneEl.querySelectorAll('.lt-card').forEach((el) => {
     el.onclick = (e) => {
       if (e.target.closest('.lt-menu')) { e.stopPropagation(); openLtMenu(el.dataset.id, e.clientX, e.clientY); return; }
+      if (e.target.closest('.lt-peek')) { e.stopPropagation(); openLieutenantPane(el.dataset.id); return; }
       openLieutenantChat(el.dataset.id);
     };
     el.oncontextmenu = (e) => { e.preventDefault(); toggleFilter('owner', el.dataset.id); };
@@ -138,6 +141,8 @@ function tileHtml(c) {
     '<span class="grow"></span>' +
     (hasLink ? '<span class="t-ind" title="has link">📎</span>' : '') +
     (msgs ? '<span class="t-ind" title="' + msgs + ' messages">💬' + msgs + '</span>' : '') +
+    // 👁 peek: every Working card can be watched live (its worker's terminal)
+    (c.column === 'working' ? '<button class="t-peek" title="watch this worker\'s terminal live">👁</button>' : '') +
     agoSpanHtml(cardRecency(c), 't-ago') +
     '</div></div>';
 }
@@ -181,6 +186,7 @@ function wire() {
       if (pressFired) { pressFired = false; return; } // long-press already handled
       const t = e.target;
       if (t.closest('a')) return; // PR chip / link: let the anchor navigate, don't open detail
+      if (t.closest('.t-peek')) { openCardPane(el.dataset.id); return; }
       if (t.classList.contains('label')) { toggleFilter('label', t.dataset.label); return; }
       const own = t.closest('.t-owner');
       if (own) { toggleFilter('owner', own.dataset.owner); return; }

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -6,6 +6,7 @@ import { trackMessages } from './voice.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, closeOwnerMenu, ownerMenuOpen } from './detail.js';
+import { closePane, paneOpen } from './pane.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import './resize.js'; // draggable side-panel widths
@@ -103,6 +104,7 @@ document.addEventListener('keydown', (e) => {
   if (e.key === '/' && !inField) { e.preventDefault(); filterInput.focus(); return; }
   if (e.key === 'Escape') {
     if (artifactOpen()) closeArtifact();
+    else if (paneOpen()) closePane();
     else if (newCardOpen()) closeNewCard();
     else if (newLieutenantOpen()) closeNewLieutenant();
     else if (pickerIsOpen()) closeLabelPicker();

--- a/ui/js/pane.js
+++ b/ui/js/pane.js
@@ -1,0 +1,75 @@
+// pane.js — the 👁 peek drawer: watch a worker's / lieutenant's terminal LIVE.
+// Opens an EventSource on the target's /pane/stream (a dedicated per-target
+// SSE — never the board-wide /api/events). Every `frame` event carries the
+// pane's full rendered screen, so the <pre> is REPLACED, not appended to.
+// Closing the drawer closes the EventSource; the server releases the harness
+// pane by refcount. unsupported/no-pane/busy arrive as tidy inline messages.
+import { card, lieutenant } from './state.js';
+import { ansiToHtml } from './ansi.js';
+
+const overlay = document.getElementById('pane-overlay');
+const titleEl = document.getElementById('pane-title');
+const liveEl = document.getElementById('pane-live');
+const preEl = document.getElementById('pane-body');
+const msgEl = document.getElementById('pane-msg');
+let es = null;
+
+function stop() { if (es) { es.close(); es = null; } }
+function setLive(on) {
+  liveEl.classList.toggle('on', on);
+  liveEl.title = on ? 'live' : 'not streaming';
+}
+function showMsg(text) {
+  stop(); // a guard event ends the stream server-side too — don't let EventSource retry-loop
+  setLive(false);
+  preEl.hidden = true;
+  msgEl.hidden = false;
+  msgEl.textContent = text;
+}
+
+function open(url, title) {
+  stop();
+  titleEl.textContent = title;
+  preEl.hidden = false;
+  msgEl.hidden = true;
+  preEl.textContent = 'connecting…';
+  setLive(false);
+  overlay.hidden = false;
+  es = new EventSource(url);
+  es.addEventListener('frame', (e) => {
+    let frame;
+    try { frame = JSON.parse(e.data); } catch (err) { return; }
+    // Frames are whole-screen snapshots: replace, don't append. Stick to the
+    // bottom only when the user was already there — a scroll-up into the
+    // scrollback must survive the next frame.
+    const stick = preEl.scrollTop + preEl.clientHeight >= preEl.scrollHeight - 12;
+    preEl.innerHTML = ansiToHtml(String(frame));
+    if (stick) preEl.scrollTop = preEl.scrollHeight;
+    setLive(true);
+  });
+  es.addEventListener('unsupported', () => showMsg('this harness has no live pane view'));
+  es.addEventListener('busy', () => showMsg('too many live panes open — close one and try again'));
+  es.addEventListener('no-pane', (e) => {
+    let reason = '';
+    try { reason = (JSON.parse(e.data) || {}).reason || ''; } catch (err) { /* plain message */ }
+    showMsg('no live pane' + (reason ? ' — ' + reason : ''));
+  });
+  es.onerror = () => setLive(false); // EventSource reconnects on its own
+}
+
+export function openCardPane(cardId) {
+  const c = card(cardId);
+  const at = (c && c.attributes) || {};
+  open('/api/cards/' + encodeURIComponent(cardId) + '/pane/stream',
+    String(at.session || (c && c.title) || cardId));
+}
+export function openLieutenantPane(id) {
+  const l = lieutenant(id);
+  open('/api/lieutenants/' + encodeURIComponent(id) + '/pane/stream',
+    String((l && l.ref && l.ref.session) || (l && l.name) || id));
+}
+export function closePane() { stop(); overlay.hidden = true; }
+export function paneOpen() { return !overlay.hidden; }
+
+document.getElementById('pane-close').onclick = closePane;
+overlay.onclick = (e) => { if (e.target === overlay) closePane(); };


### PR DESCRIPTION
Ships the **👁 peek** feature: click a Working card (or a lieutenant chip) and watch that agent's terminal LIVE in the browser — a stalled/silent worker (`worker-stalled` bell) can now be inspected without `tmux attach`.

## The abstraction (hard requirement: decoupling)

Pane viewing goes through the harness port as an **optional capability verb** — `server/server.js` and `ui/` contain zero pane-related tmux/claude specifics (grep-proven; all pane tmux lives in `harness/claude-tmux.js`):

- `openPane(ref, {onFrame, intervalMs?, lines?}) → {close()}` — change-detected rendered-screen frames; `paneSnapshot(ref, {lines?})` one-shot companion.
- NOT added to the port's 7 REQUIRED verbs (would force every harness to implement it); the server capability-checks `typeof impl.openPane === 'function'` and degrades to `unsupported`. Documented in port.js header + harness/README + docs/api/overview.md.
- claude-tmux: polls `capture-pane -e` (~1s, 200-line scrollback) — deliberately rendered frames, not `pipe-pane` bytes: a repainting TUI needs the composed screen, not a client-side terminal emulator. `[pane gone]` terminal frame when the pane dies.
- fake: deterministic counter frames; file-backed open/close log for cross-process refcount assertions; `BC_FAKE_NO_PANE` simulates a pane-less harness.

## Server: PaneHub + scoped SSE

- `GET /api/cards/:id/pane/stream` and `GET /api/lieutenants/:id/pane/stream` — dedicated per-target SSE (never the board-wide `/api/events`); the connection's lifetime IS the subscription.
- Ref resolution in the server (card → worker ref, lieutenant → ref); PaneHub refcounts per pane key: first subscriber opens ONE harness feed, frames fan out, last disconnect `close()`s it.
- Guards as clean SSE events (never a 500/hang): `unsupported` / `no-pane` / `busy` (`BC_PANE_MAX`, default 8); initial paint via last-frame replay or `paneSnapshot`; 25s named ping shared with the board stream.

## UI

- 👁 on every Working tile + lieutenant chip (hover-revealed, matching the ⋯ affordance) → terminal drawer: dark surface, mono, pulsing **● live** dot, ✕ close; whole-frame `<pre>` replace with bottom-stick autoscroll that survives a scroll-up; tidy inline messages for the guard events; closing the drawer closes the EventSource (server releases by refcount).
- `ui/js/ansi.js`: zero-dep SGR→HTML (reset, bold/dim, 16/256-color + defensive truecolor fg/bg), HTML-escaped first, cursor-movement/OSC stripped.

## Tests & verification

- 15 new tests: PaneHub subscribe → frames → shared pane (1 open for 2 subscribers) → last-close teardown (1 close) → reopen; `unsupported`; `no-pane` (backlog card / unknown card / unknown lt / ref-less lt); `busy` cap with same-key sharing unaffected; 10 ansi.js units. Full suite green: 159 server + 25 harness.
- Verified end-to-end: real tmux pane (immediate frame, ANSI kept, change-detect, `[pane gone]`) and a real browser (drawer streams live frames, zero console errors, close → server logs the pane release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
