### PR TITLE
Notification settings: toast + sound, captain-configurable

### DIFF
--- a/test/notifypolicy.test.js
+++ b/test/notifypolicy.test.js
@@ -1,0 +1,82 @@
+'use strict';
+// ui/js/notifypolicy.js — pure toast+sound decision logic behind the
+// notifications settings panel. No DOM/WebAudio, so it's imported directly.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let defaultsFor, policyFor, selectNewEvents;
+test.before(async () => {
+  ({ defaultsFor, policyFor, selectNewEvents } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'notifypolicy.js')).href));
+});
+
+test('defaultsFor: red level-1 kinds get alert + toast', () => {
+  for (const kind of ['failed', 'needs-you', 'blocked', 'worker-died']) {
+    assert.deepStrictEqual(defaultsFor(kind, 1), { toast: true, sound: 'alert' });
+  }
+});
+
+test('defaultsFor: other level-1 kinds get a toast + non-none sound', () => {
+  for (const kind of ['done', 'handoff', 'question', 'worker-stalled', 'worker-stopped', 'something-new']) {
+    const d = defaultsFor(kind, 1);
+    assert.strictEqual(d.toast, true);
+    assert.notStrictEqual(d.sound, 'none');
+  }
+});
+
+test('defaultsFor: level-2 kinds are silent regardless of name', () => {
+  for (const kind of ['progress', 'pr-opened', 'worker-linked', 'failed']) {
+    assert.deepStrictEqual(defaultsFor(kind, 2), { toast: false, sound: 'none' });
+  }
+});
+
+test('policyFor: a saved per-kind override wins over the level default', () => {
+  const settings = { master: true, kinds: { done: { toast: false, sound: 'ding' } } };
+  assert.deepStrictEqual(policyFor('done', 1, settings), { toast: false, sound: 'ding' });
+});
+
+test('policyFor: a partial override only replaces the given field', () => {
+  const settings = { master: true, kinds: { done: { sound: 'blip' } } };
+  const p = policyFor('done', 1, settings);
+  assert.strictEqual(p.sound, 'blip');
+  assert.strictEqual(p.toast, true); // falls through to the level default
+});
+
+test('policyFor: master:false suppresses everything, override or not', () => {
+  const settings = { master: false, kinds: { failed: { toast: true, sound: 'alert' } } };
+  assert.deepStrictEqual(policyFor('failed', 1, settings), { toast: false, sound: 'none' });
+});
+
+test('policyFor: an unknown kind with no override falls through to its level default', () => {
+  const settings = { master: true, kinds: {} };
+  assert.deepStrictEqual(policyFor('brand-new-kind', 1, settings), defaultsFor('brand-new-kind', 1));
+  assert.deepStrictEqual(policyFor('brand-new-kind', 2, settings), { toast: false, sound: 'none' });
+});
+
+test('selectNewEvents: returns only unseen seqs ascending and mutates the seen set', () => {
+  const doc = { events: [{ seq: 3, kind: 'done' }, { seq: 1, kind: 'created' }], cards: [
+    { id: 'c1', title: 'Card 1', events: [{ seq: 2, kind: 'question' }] },
+  ] };
+  const seen = new Set();
+  const first = selectNewEvents(seen, doc);
+  assert.deepStrictEqual(first.map((e) => e.seq), [1, 2, 3]);
+  assert.deepStrictEqual([...seen].sort(), [1, 2, 3]);
+});
+
+test('selectNewEvents: a second call with the same doc returns nothing (dedup across SSE resends)', () => {
+  const doc = { events: [{ seq: 1, kind: 'created' }] };
+  const seen = new Set();
+  selectNewEvents(seen, doc);
+  const second = selectNewEvents(seen, doc);
+  assert.deepStrictEqual(second, []);
+});
+
+test('selectNewEvents: a doc with a brand-new higher-seq event returns just that one', () => {
+  const seen = new Set([1, 2]);
+  const doc = { events: [{ seq: 1 }, { seq: 2 }, { seq: 5, kind: 'done' }] };
+  const out = selectNewEvents(seen, doc);
+  assert.deepStrictEqual(out.map((e) => e.seq), [5]);
+  assert.ok(seen.has(5));
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -362,6 +362,50 @@ body.resizing { user-select: none; cursor: col-resize; }
 }
 #voice-test { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 8px; font-size: 12px; }
 #voice-select:hover, #voice-test:hover { border-color: var(--accent2); color: var(--accent); }
+#ns-body { display: flex; flex-direction: column; gap: 8px; transition: opacity .2s; }
+#ns-body.dim { opacity: .5; }
+#ns-master-btn { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#ns-master-btn.on { color: var(--accent); border-color: var(--accent2); }
+#ns-volume { flex: 1; min-width: 0; accent-color: var(--accent); cursor: pointer; }
+#ns-list { display: flex; flex-direction: column; gap: 4px; max-height: 40vh; overflow-y: auto; }
+.ns-row { display: flex; gap: 6px; align-items: center; font-size: 12px; }
+.ns-row .ns-em { flex: none; width: 16px; text-align: center; }
+.ns-row .ns-name { flex: 1; min-width: 0; color: var(--dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.ns-row input[type=checkbox] { accent-color: var(--accent); cursor: pointer; flex: none; }
+.ns-row select {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 6px; color: var(--dim);
+  font-size: 11px; padding: 2px 4px; flex: none; width: 76px; cursor: pointer; outline: none;
+}
+.ns-row select:hover { border-color: var(--accent2); color: var(--accent); }
+.ns-row .ns-prev { border: 1px solid var(--line); border-radius: 6px; color: var(--faint); font-size: 11px; padding: 1px 6px; flex: none; }
+.ns-row .ns-prev:hover { color: var(--accent); border-color: var(--accent2); }
+details.ns-quiet { margin-top: 2px; }
+details.ns-quiet summary { color: var(--faint); font-size: 10.5px; cursor: pointer; padding: 3px 0; user-select: none; }
+details.ns-quiet summary:hover { color: var(--dim); }
+details.ns-quiet .ns-row { margin-top: 4px; }
+
+/* ---------- notification toasts ---------- */
+#toast-stack {
+  position: fixed; top: 52px; right: 10px; z-index: 80; display: flex; flex-direction: column;
+  gap: 8px; width: min(320px, calc(100vw - 20px)); pointer-events: none;
+}
+.toast {
+  display: flex; gap: 9px; align-items: flex-start; padding: 10px 12px; border-radius: 10px;
+  background: var(--bg2); border: 1px solid var(--line2); box-shadow: var(--shadow);
+  pointer-events: auto; cursor: pointer; animation: toast-in .18s ease-out;
+}
+@keyframes toast-in { from { opacity: 0; transform: translateX(16px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) {
+  .toast { animation: toast-fade .18s ease-out; }
+  @keyframes toast-fade { from { opacity: 0; } to { opacity: 1; } }
+}
+.toast .em { flex: none; font-size: 15px; }
+.toast .bd { flex: 1; min-width: 0; }
+.toast .tx { font-size: 13px; line-height: 1.4; overflow-wrap: anywhere; }
+.toast .sub { color: var(--faint); font-size: 10.5px; margin-top: 2px; font-family: var(--mono); }
+.toast .x { flex: none; color: var(--faint); font-size: 12px; padding: 0 2px; }
+.toast .x:hover { color: var(--danger); }
+
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
 .lm-row input[type=color], #lm-color { width: 26px; height: 22px; padding: 0; border: 1px solid var(--line); border-radius: 5px; background: none; cursor: pointer; flex: none; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -49,6 +49,14 @@
       <button id="voice-test" title="test the selected voice">▶</button>
     </span>
   </div>
+  <div class="sp-title">notifications</div>
+  <div id="ns-body">
+    <div class="sp-row">
+      <button id="ns-master-btn" title="toast + sound for board events">🔔 on</button>
+      <input id="ns-volume" type="range" min="0" max="1" step="0.05" title="notification volume">
+    </div>
+    <div id="ns-list"></div>
+  </div>
   <div class="sp-title">labels</div>
   <div id="lm-list"></div>
   <form id="lm-new">

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -3,6 +3,8 @@ import { S, onRender, render, cards, lieutenants, cardUnread, lieutenantUnread, 
 import { api } from './api.js';
 import { refreshAgoLabels } from './util.js';
 import { trackMessages } from './voice.js';
+import { trackEvents, renderNotifSettings } from './notifysettings.js';
+import { onOpenCard as toastOnOpenCard } from './toast.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, closeOwnerMenu, ownerMenuOpen } from './detail.js';
@@ -13,6 +15,7 @@ import './resize.js'; // draggable side-panel widths
 
 chatOnOpenCard(openDetail);
 notifOnOpenCard(openDetail);
+toastOnOpenCard(openDetail);
 
 // ---------- header: filter ----------
 const filterInput = document.getElementById('filter');
@@ -67,7 +70,7 @@ gearBtn.onclick = (e) => {
   e.stopPropagation();
   spEl.hidden = !spEl.hidden;
   gearBtn.classList.toggle('on', !spEl.hidden);
-  if (!spEl.hidden) { S.notifOpen = false; renderLabelManager(); render(); }
+  if (!spEl.hidden) { S.notifOpen = false; renderLabelManager(); renderNotifSettings(); render(); }
 };
 document.addEventListener('click', (e) => {
   if (!spEl.hidden && !spEl.contains(e.target) && e.target !== gearBtn) {
@@ -131,7 +134,7 @@ onRender(() => {
   renderNotifications();
   renderTabs();
   if (pickerIsOpen()) renderPicker();
-  if (!spEl.hidden) renderLabelManager();
+  if (!spEl.hidden) { renderLabelManager(); renderNotifSettings(); }
   // fill the [data-ago] spans the panels above left empty (see util.js: time
   // text stays out of the compared markup so it never forces a rebuild)
   refreshAgoLabels();
@@ -155,6 +158,7 @@ function applyBoard(doc) {
   serverBoot = doc.boot || serverBoot;
   S.doc = doc;
   trackMessages(S.doc);
+  trackEvents(S.doc);
   render();
 }
 function refetchBoard() {

--- a/ui/js/notifypolicy.js
+++ b/ui/js/notifypolicy.js
@@ -1,0 +1,62 @@
+// notifypolicy.js — pure decision logic for toast+sound notifications.
+// NO DOM, NO WebAudio, NO side effects at import: safe for node --test to import
+// directly. Kept separate from state.js/sound.js/toast.js so the policy itself
+// stays trivially unit-testable.
+
+// Kinds that mean "the captain needs to act right now" get the loud alert tone,
+// regardless of what the server's built-in kinds map calls them today — this
+// list is deliberately name-based (not level-based) so it still applies if a
+// lieutenant later registers a custom kind under one of these names.
+const RED_KINDS = new Set(['failed', 'needs-you', 'needs-captain', 'blocked', 'worker-died']);
+// Level-1 kinds about a worker going quiet/away get a duller double-tap instead
+// of the bright chime used for ordinary good-news level-1 events.
+const KNOCK_KINDS = new Set(['worker-stalled', 'worker-stopped']);
+
+// Out-of-box behavior for a kind with no saved override.
+export function defaultsFor(kind, level) {
+  if (level === 2) return { toast: false, sound: 'none' };
+  if (RED_KINDS.has(kind)) return { toast: true, sound: 'alert' };
+  if (KNOCK_KINDS.has(kind)) return { toast: true, sound: 'knock' };
+  return { toast: true, sound: 'chime' };
+}
+
+// Resolve a kind's effective policy: saved per-kind override on top of the
+// level default, honoring the master on/off switch. A kind absent from
+// settings.kinds falls through to its level default, so newly registered
+// kinds behave sensibly with zero configuration.
+export function policyFor(kind, level, settings) {
+  if (!settings || settings.master === false) return { toast: false, sound: 'none' };
+  const base = defaultsFor(kind, level);
+  const override = settings.kinds && settings.kinds[kind];
+  if (!override) return base;
+  return {
+    toast: override.toast !== undefined ? override.toast : base.toast,
+    sound: override.sound !== undefined ? override.sound : base.sound,
+  };
+}
+
+// The unified event stream over a board doc: board-level events + every card's
+// events, ascending by seq. Mirrors state.js's allEvents() but takes a plain
+// `doc` argument so this module never depends on live UI state.
+function docEvents(doc) {
+  const out = [];
+  for (const e of (doc && doc.events) || []) out.push(e);
+  for (const c of (doc && doc.cards) || []) {
+    for (const e of c.events || []) out.push(Object.assign({ card: c.id, cardTitle: c.title }, e));
+  }
+  out.sort((a, b) => a.seq - b.seq);
+  return out;
+}
+
+// Returns the events in `doc` whose seq is not yet in `seenSet` (ascending),
+// and mutates `seenSet` to include them. Pair with a `firstLoad` flag in the
+// caller (not here) so the very first board never fires notifications.
+export function selectNewEvents(seenSet, doc) {
+  const out = [];
+  for (const e of docEvents(doc)) {
+    if (e.seq == null || seenSet.has(e.seq)) continue;
+    seenSet.add(e.seq);
+    out.push(e);
+  }
+  return out;
+}

--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -1,0 +1,142 @@
+// notifysettings.js — persisted notification settings, the "notifications"
+// section of the settings panel, and the driver that turns new board events
+// into toasts/sounds. Mirrors voice.js's localStorage + gesture-unlock pattern.
+import { kinds, kindEmoji } from './state.js';
+import { defaultsFor, policyFor, selectNewEvents } from './notifypolicy.js';
+import * as sound from './sound.js';
+import * as toast from './toast.js';
+
+const KEY = 'bc-notif-settings';
+
+function loadSettings() {
+  try {
+    const raw = JSON.parse(localStorage.getItem(KEY));
+    if (raw && typeof raw === 'object') {
+      return { master: raw.master !== false, volume: typeof raw.volume === 'number' ? raw.volume : 0.7, kinds: Object.assign({}, raw.kinds) };
+    }
+  } catch (e) {}
+  return { master: true, volume: 0.7, kinds: {} };
+}
+const settings = loadSettings();
+sound.setVolume(settings.volume);
+
+function saveSettings() {
+  try { localStorage.setItem(KEY, JSON.stringify(settings)); } catch (e) {}
+}
+
+function effective(kind, level) {
+  const ov = settings.kinds[kind] || {};
+  const base = defaultsFor(kind, level);
+  return {
+    toast: ov.toast !== undefined ? ov.toast : base.toast,
+    sound: ov.sound !== undefined ? ov.sound : base.sound,
+  };
+}
+function setOverride(kind, patch) {
+  settings.kinds[kind] = Object.assign({}, settings.kinds[kind], patch);
+  saveSettings();
+}
+
+// ---------- driver: new events -> toast/sound ----------
+// mirrors voice.js's trackMessages: first call just seeds the seen-set (no
+// firing), thereafter each genuinely-new event resolves its policy.
+let firstLoad = true;
+const seen = new Set();
+export function trackEvents(doc) {
+  if (!doc) return;
+  const events = selectNewEvents(seen, doc);
+  if (firstLoad) { firstLoad = false; return; }
+  for (const e of events) {
+    const p = policyFor(e.kind, e.level, settings);
+    if (p.toast) toast.push({ emoji: kindEmoji(e.kind), text: e.text, cardTitle: e.cardTitle, actor: e.actor, card: e.card });
+    if (p.sound && p.sound !== 'none') sound.play(p.sound);
+  }
+}
+
+// ---------- settings section (rendered inside #settings-panel while open) ----------
+const masterBtn = document.getElementById('ns-master-btn');
+const volumeInput = document.getElementById('ns-volume');
+const bodyEl = document.getElementById('ns-body');
+const listEl = document.getElementById('ns-list');
+
+function renderMaster() {
+  masterBtn.classList.toggle('on', settings.master);
+  masterBtn.textContent = settings.master ? '🔔 on' : '🔕 off';
+  bodyEl.classList.toggle('dim', !settings.master);
+  if (document.activeElement !== volumeInput) volumeInput.value = settings.volume;
+}
+masterBtn.onclick = () => { settings.master = !settings.master; saveSettings(); renderMaster(); };
+volumeInput.oninput = () => { settings.volume = parseFloat(volumeInput.value); sound.setVolume(settings.volume); saveSettings(); };
+
+function rowFor(kind, level) {
+  const row = document.createElement('div');
+  row.className = 'ns-row';
+
+  const em = document.createElement('span');
+  em.className = 'ns-em';
+  em.textContent = kindEmoji(kind) || '·';
+
+  const name = document.createElement('span');
+  name.className = 'ns-name';
+  name.textContent = kind;
+
+  const eff = effective(kind, level);
+
+  const cb = document.createElement('input');
+  cb.type = 'checkbox';
+  cb.title = 'show toast';
+  cb.checked = eff.toast;
+  cb.onchange = () => setOverride(kind, { toast: cb.checked });
+
+  const sel = document.createElement('select');
+  sel.title = 'sound';
+  for (const n of sound.SOUND_NAMES) {
+    const o = document.createElement('option');
+    o.value = n;
+    o.textContent = n;
+    sel.appendChild(o);
+  }
+  sel.value = eff.sound;
+  sel.onchange = () => setOverride(kind, { sound: sel.value });
+
+  const prev = document.createElement('button');
+  prev.type = 'button';
+  prev.className = 'ns-prev';
+  prev.title = 'preview this sound';
+  prev.textContent = '▶';
+  prev.onclick = () => sound.play(sel.value);
+
+  row.append(em, name, cb, sel, prev);
+  return row;
+}
+
+let lastListHtml = null;
+function renderList() {
+  if (listEl.contains(document.activeElement)) return; // don't clobber an in-progress edit
+  const km = kinds();
+  const entries = Object.keys(km).map((k) => ({ kind: k, level: km[k].level === 2 ? 2 : 1 }));
+  entries.sort((a, b) => a.kind.localeCompare(b.kind));
+  const lvl1 = entries.filter((e) => e.level === 1);
+  const lvl2 = entries.filter((e) => e.level === 2);
+
+  const tmp = document.createElement('div');
+  for (const e of lvl1) tmp.appendChild(rowFor(e.kind, e.level));
+  if (lvl2.length) {
+    const det = document.createElement('details');
+    det.className = 'ns-quiet';
+    const sum = document.createElement('summary');
+    sum.textContent = 'quiet events (' + lvl2.length + ')';
+    det.appendChild(sum);
+    for (const e of lvl2) det.appendChild(rowFor(e.kind, e.level));
+    tmp.appendChild(det);
+  }
+  if (lastListHtml === tmp.innerHTML) return; // same kinds set — leave live rows/interactions alone
+  lastListHtml = tmp.innerHTML;
+  listEl.textContent = '';
+  while (tmp.firstChild) listEl.appendChild(tmp.firstChild);
+}
+
+export function renderNotifSettings() {
+  renderMaster();
+  renderList();
+}

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -1,0 +1,101 @@
+// sound.js — zero-dependency WebAudio synth palette for notifications.
+// No audio files: every tone is oscillators + a short gain envelope. The
+// AudioContext is created lazily and resumed on the first real user gesture
+// anywhere on the page (the same autoplay-gate dance voice.js does for
+// speechSynthesis), so a later programmatic play() from an SSE event isn't
+// silently blocked by the browser.
+let ctx = null;
+let master = null;
+let volume = 0.7;
+
+function ensureCtx() {
+  if (ctx) return ctx;
+  const AC = window.AudioContext || window.webkitAudioContext;
+  if (!AC) return null;
+  try {
+    ctx = new AC();
+    master = ctx.createGain();
+    master.gain.value = volume;
+    master.connect(ctx.destination);
+  } catch (e) { ctx = null; master = null; }
+  return ctx;
+}
+
+export function setVolume(v) {
+  volume = Math.max(0, Math.min(1, Number(v)));
+  if (master) master.gain.value = volume;
+}
+
+// One short note: an oscillator through its own attack/decay gain envelope,
+// optionally sweeping frequency (freqTo), routed into the shared master gain.
+function note(t0, { freq, freqTo, dur = 0.15, type = 'sine', peak = 0.22 }) {
+  const osc = ctx.createOscillator();
+  const g = ctx.createGain();
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, t0);
+  if (freqTo) osc.frequency.exponentialRampToValueAtTime(freqTo, t0 + dur);
+  g.gain.setValueAtTime(0.0001, t0);
+  g.gain.linearRampToValueAtTime(peak, t0 + 0.012);
+  g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
+  osc.connect(g);
+  g.connect(master);
+  osc.start(t0);
+  osc.stop(t0 + dur + 0.03);
+}
+
+const PALETTE = {
+  // pleasant two-note rise
+  chime(t0) {
+    note(t0, { freq: 523.25, dur: 0.16, peak: 0.22 });      // C5
+    note(t0 + 0.11, { freq: 783.99, dur: 0.26, peak: 0.2 }); // G5
+  },
+  // single soft bell, with a quiet overtone for shimmer
+  ding(t0) {
+    note(t0, { freq: 880, dur: 0.5, peak: 0.2 });
+    note(t0, { freq: 1760, dur: 0.32, peak: 0.05 });
+  },
+  // short, unobtrusive
+  blip(t0) {
+    note(t0, { freq: 1200, dur: 0.07, type: 'square', peak: 0.14 });
+  },
+  // two low taps — "someone knocking"
+  knock(t0) {
+    note(t0, { freq: 130, dur: 0.09, peak: 0.3 });
+    note(t0 + 0.15, { freq: 112, dur: 0.1, peak: 0.3 });
+  },
+  // urgent triple beep
+  alert(t0) {
+    [0, 0.11, 0.22].forEach((d) => note(t0 + d, { freq: 988, dur: 0.09, type: 'square', peak: 0.26 }));
+  },
+  // classic two-note "coin" pickup
+  coin(t0) {
+    note(t0, { freq: 988, dur: 0.08, type: 'square', peak: 0.18 });
+    note(t0 + 0.08, { freq: 1319, dur: 0.28, type: 'square', peak: 0.16 });
+  },
+};
+
+export const SOUND_NAMES = Object.keys(PALETTE).concat('none');
+
+// Fail silently on any audio hazard (no context, suspended and can't resume,
+// unknown name) — this is called from the SSE event path and must never throw.
+export function play(name) {
+  if (!name || name === 'none') return;
+  const fn = PALETTE[name];
+  if (!fn) return;
+  const c = ensureCtx();
+  if (!c) return;
+  try {
+    if (c.state === 'suspended') c.resume().catch(() => {});
+    fn(c.currentTime + 0.01);
+  } catch (e) {}
+}
+
+// Global gesture primer: the first click/keydown anywhere unlocks the audio
+// context ahead of time, so the FIRST real notification (which rides no
+// gesture of its own) can still play instead of being silently dropped.
+function primeOnGesture() {
+  const c = ensureCtx();
+  if (c && c.state === 'suspended') c.resume().catch(() => {});
+}
+window.addEventListener('click', primeOnGesture, { once: true, passive: true });
+window.addEventListener('keydown', primeOnGesture, { once: true, passive: true });

--- a/ui/js/toast.js
+++ b/ui/js/toast.js
@@ -1,0 +1,58 @@
+// toast.js — fixed top-right toast stack for board notifications. The
+// container is created lazily (mirrors voice.js's floating "speaking" bubble)
+// so nothing exists in the DOM until the first toast is pushed.
+const MAX_VISIBLE = 4;
+const DISMISS_MS = 6000;
+
+let root = null;
+let openCard = null;
+export function onOpenCard(fn) { openCard = fn; }
+
+function ensureRoot() {
+  if (root) return root;
+  root = document.createElement('div');
+  root.id = 'toast-stack';
+  document.body.appendChild(root);
+  return root;
+}
+
+// e: { emoji, text, cardTitle, actor, card }
+export function push(e) {
+  const stack = ensureRoot();
+  const el = document.createElement('div');
+  el.className = 'toast';
+
+  const em = document.createElement('span');
+  em.className = 'em';
+  em.textContent = e.emoji || '';
+
+  const bd = document.createElement('div');
+  bd.className = 'bd';
+  const tx = document.createElement('div');
+  tx.className = 'tx';
+  tx.textContent = e.text || '';
+  const sub = document.createElement('div');
+  sub.className = 'sub';
+  sub.textContent = [e.cardTitle, e.actor].filter(Boolean).join(' · ');
+  bd.append(tx, sub);
+
+  const x = document.createElement('button');
+  x.type = 'button';
+  x.className = 'x';
+  x.title = 'dismiss';
+  x.textContent = '✕';
+
+  el.append(em, bd, x);
+
+  let timer = null;
+  const dismiss = () => { clearTimeout(timer); el.remove(); };
+  const arm = () => { timer = setTimeout(dismiss, DISMISS_MS); };
+  el.onmouseenter = () => clearTimeout(timer);
+  el.onmouseleave = arm;
+  x.onclick = (ev) => { ev.stopPropagation(); dismiss(); };
+  el.onclick = () => { if (e.card && openCard) openCard(e.card); dismiss(); };
+
+  stack.appendChild(el);
+  while (stack.children.length > MAX_VISIBLE) stack.firstChild.remove();
+  arm();
+}


### PR DESCRIPTION
## Summary
- New client-only Notifications settings section (⚙️ panel): master on/off, volume, and per-kind toast/sound overrides, grouped by level with a collapsible "quiet events" subsection for level-2 kinds.
- WebAudio-synthesized sound palette (`ui/js/sound.js`, zero deps, no audio files): chime, ding, blip, knock, alert, coin, none — gesture-unlocked like `voice.js`'s TTS.
- Toast stack (`ui/js/toast.js`): top-right, auto-dismiss ~6s, hover pauses, ✕ dismiss, click opens the card, respects `prefers-reduced-motion`.
- Pure policy module (`ui/js/notifypolicy.js`): `defaultsFor`, `policyFor`, `selectNewEvents` — no DOM/WebAudio, fully unit tested.
- Driver `trackEvents()` wired into `applyBoard()` in `main.js` right after `trackMessages()`, mirroring the voice.js firstLoad/seen-set dedup pattern so page load / SSE reconnect never replays the backlog.
- Settings persist in `localStorage` (`bc-notif-settings`), same pattern as `voice.js`'s `bc-voice-*` keys.
- `server/` and `harness/` are byte-for-byte unchanged — grep-verified, this is a pure client-side feature.

## Test plan
- [x] `node --test test/*.test.js` — 169/169 green (10 new in `notifypolicy.test.js`)
- [x] Manual E2E in a real browser against a throwaway server instance: opened ⚙️ → Notifications, confirmed master toggle + volume + per-kind rows render from the live `kinds` map, toggled a per-kind override and confirmed it persists in `localStorage` across reload
- [x] Fired a real `needs-captain` (level-1) event via `bc-axi notify` over SSE — toast appeared live with correct emoji/text; fired a level-2 `moved` event — confirmed it stayed silent
- [x] Confirmed backlog events on initial page load never produce a toast (no replay)
- [x] `grep -rl` for `bc-notif-settings`/`toast-stack`/`notifypolicy`/`notifysettings` across `server/` and `harness/` — no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)