### PR TITLE
Simplify notification settings: 4 semantic categories, not per-kind

### DIFF
--- a/test/notifypolicy.test.js
+++ b/test/notifypolicy.test.js
@@ -6,53 +6,70 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let defaultsFor, policyFor, selectNewEvents;
+let categorize, defaultCategoryPolicy, policyFor, selectNewEvents;
 test.before(async () => {
-  ({ defaultsFor, policyFor, selectNewEvents } =
+  ({ categorize, defaultCategoryPolicy, policyFor, selectNewEvents } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'notifypolicy.js')).href));
 });
 
-test('defaultsFor: red level-1 kinds get alert + toast', () => {
-  for (const kind of ['failed', 'needs-you', 'blocked', 'worker-died']) {
-    assert.deepStrictEqual(defaultsFor(kind, 1), { toast: true, sound: 'alert' });
+test('categorize: work-finished kinds map to done', () => {
+  for (const kind of ['worker-done', 'landed', 'handoff', 'done']) {
+    assert.strictEqual(categorize(kind, 1), 'done');
   }
 });
 
-test('defaultsFor: other level-1 kinds get a toast + non-none sound', () => {
-  for (const kind of ['done', 'handoff', 'question', 'worker-stalled', 'worker-stopped', 'something-new']) {
-    const d = defaultsFor(kind, 1);
-    assert.strictEqual(d.toast, true);
-    assert.notStrictEqual(d.sound, 'none');
+test('categorize: lieutenant-message kinds map to chat', () => {
+  for (const kind of ['reply', 'question', 'message']) {
+    assert.strictEqual(categorize(kind, 1), 'chat');
   }
 });
 
-test('defaultsFor: level-2 kinds are silent regardless of name', () => {
-  for (const kind of ['progress', 'pr-opened', 'worker-linked', 'failed']) {
-    assert.deepStrictEqual(defaultsFor(kind, 2), { toast: false, sound: 'none' });
+test('categorize: needs-captain-now kinds map to error', () => {
+  for (const kind of ['needs-captain', 'needs-you', 'failed', 'blocked', 'worker-died', 'worker-stalled']) {
+    assert.strictEqual(categorize(kind, 1), 'error');
   }
 });
 
-test('policyFor: a saved per-kind override wins over the level default', () => {
-  const settings = { master: true, kinds: { done: { toast: false, sound: 'ding' } } };
-  assert.deepStrictEqual(policyFor('done', 1, settings), { toast: false, sound: 'ding' });
+test('categorize: everything else, including unknown kinds, maps to other', () => {
+  for (const kind of ['created', 'moved', 'started', 'brand-new-kind']) {
+    assert.strictEqual(categorize(kind, 2), 'other');
+  }
+});
+
+test('defaultCategoryPolicy: done/chat/error toast on with non-none sounds', () => {
+  const d = defaultCategoryPolicy();
+  for (const cat of ['done', 'chat', 'error']) {
+    assert.strictEqual(d[cat].toast, true);
+    assert.notStrictEqual(d[cat].sound, 'none');
+  }
+});
+
+test('defaultCategoryPolicy: other is toast off + no sound', () => {
+  const d = defaultCategoryPolicy();
+  assert.deepStrictEqual(d.other, { toast: false, sound: 'none' });
+});
+
+test('policyFor: a saved category override wins over its default', () => {
+  const settings = { master: true, categories: { done: { toast: false, sound: 'ding' } } };
+  assert.deepStrictEqual(policyFor('worker-done', 1, settings), { toast: false, sound: 'ding' });
 });
 
 test('policyFor: a partial override only replaces the given field', () => {
-  const settings = { master: true, kinds: { done: { sound: 'blip' } } };
-  const p = policyFor('done', 1, settings);
+  const settings = { master: true, categories: { done: { sound: 'blip' } } };
+  const p = policyFor('landed', 1, settings);
   assert.strictEqual(p.sound, 'blip');
-  assert.strictEqual(p.toast, true); // falls through to the level default
+  assert.strictEqual(p.toast, true); // falls through to the category default
 });
 
 test('policyFor: master:false suppresses everything, override or not', () => {
-  const settings = { master: false, kinds: { failed: { toast: true, sound: 'alert' } } };
+  const settings = { master: false, categories: { error: { toast: true, sound: 'alert' } } };
   assert.deepStrictEqual(policyFor('failed', 1, settings), { toast: false, sound: 'none' });
 });
 
-test('policyFor: an unknown kind with no override falls through to its level default', () => {
-  const settings = { master: true, kinds: {} };
-  assert.deepStrictEqual(policyFor('brand-new-kind', 1, settings), defaultsFor('brand-new-kind', 1));
-  assert.deepStrictEqual(policyFor('brand-new-kind', 2, settings), { toast: false, sound: 'none' });
+test('policyFor: an event whose category has no override uses that category default', () => {
+  const settings = { master: true, categories: {} };
+  assert.deepStrictEqual(policyFor('question', 1, settings), defaultCategoryPolicy().chat);
+  assert.deepStrictEqual(policyFor('created', 2, settings), defaultCategoryPolicy().other);
 });
 
 test('selectNewEvents: returns only unseen seqs ascending and mutates the seen set', () => {

--- a/ui/app.css
+++ b/ui/app.css
@@ -379,10 +379,6 @@ body.resizing { user-select: none; cursor: col-resize; }
 .ns-row select:hover { border-color: var(--accent2); color: var(--accent); }
 .ns-row .ns-prev { border: 1px solid var(--line); border-radius: 6px; color: var(--faint); font-size: 11px; padding: 1px 6px; flex: none; }
 .ns-row .ns-prev:hover { color: var(--accent); border-color: var(--accent2); }
-details.ns-quiet { margin-top: 2px; }
-details.ns-quiet summary { color: var(--faint); font-size: 10.5px; cursor: pointer; padding: 3px 0; user-select: none; }
-details.ns-quiet summary:hover { color: var(--dim); }
-details.ns-quiet .ns-row { margin-top: 4px; }
 
 /* ---------- notification toasts ---------- */
 #toast-stack {

--- a/ui/js/notifypolicy.js
+++ b/ui/js/notifypolicy.js
@@ -2,32 +2,48 @@
 // NO DOM, NO WebAudio, NO side effects at import: safe for node --test to import
 // directly. Kept separate from state.js/sound.js/toast.js so the policy itself
 // stays trivially unit-testable.
+//
+// The captain asked for 4 semantic buckets instead of one row per event kind
+// (server/server.js's BUILTIN_KINDS is a couple dozen entries and growing —
+// too many toggles to reason about). categorize() is the single place that
+// maps a kind name to a bucket; everything downstream only ever deals with
+// the 4 buckets.
 
-// Kinds that mean "the captain needs to act right now" get the loud alert tone,
-// regardless of what the server's built-in kinds map calls them today — this
-// list is deliberately name-based (not level-based) so it still applies if a
-// lieutenant later registers a custom kind under one of these names.
-const RED_KINDS = new Set(['failed', 'needs-you', 'needs-captain', 'blocked', 'worker-died']);
-// Level-1 kinds about a worker going quiet/away get a duller double-tap instead
-// of the bright chime used for ordinary good-news level-1 events.
-const KNOCK_KINDS = new Set(['worker-stalled', 'worker-stopped']);
+const DONE_KINDS = new Set(['worker-done', 'landed', 'handoff', 'done']);
+const CHAT_KINDS = new Set(['reply', 'question', 'message']);
+const ERROR_KINDS = new Set(['needs-captain', 'needs-you', 'failed', 'blocked', 'worker-died', 'worker-stalled']);
 
-// Out-of-box behavior for a kind with no saved override.
-export function defaultsFor(kind, level) {
-  if (level === 2) return { toast: false, sound: 'none' };
-  if (RED_KINDS.has(kind)) return { toast: true, sound: 'alert' };
-  if (KNOCK_KINDS.has(kind)) return { toast: true, sound: 'knock' };
-  return { toast: true, sound: 'chime' };
+// Maps a kind (+ level, currently unused but kept for symmetry with the old
+// per-kind API and in case a future kind needs level to disambiguate) to one
+// of the 4 semantic categories. Anything not explicitly listed — including
+// level-2 chatter like created/moved/ordered/started/signal — falls into
+// 'other', which is OFF by default: the captain said this bucket "não deve
+// ser importante".
+export function categorize(kind, level) {
+  if (DONE_KINDS.has(kind)) return 'done';
+  if (CHAT_KINDS.has(kind)) return 'chat';
+  if (ERROR_KINDS.has(kind)) return 'error';
+  return 'other';
 }
 
-// Resolve a kind's effective policy: saved per-kind override on top of the
-// level default, honoring the master on/off switch. A kind absent from
-// settings.kinds falls through to its level default, so newly registered
-// kinds behave sensibly with zero configuration.
+// Out-of-box behavior per category.
+export function defaultCategoryPolicy() {
+  return {
+    done: { toast: true, sound: 'chime' },
+    chat: { toast: true, sound: 'ding' },
+    error: { toast: true, sound: 'alert' },
+    other: { toast: false, sound: 'none' },
+  };
+}
+
+// Resolve a kind's effective policy: categorize it, then apply the saved
+// per-category override on top of that category's default, honoring the
+// master on/off switch.
 export function policyFor(kind, level, settings) {
   if (!settings || settings.master === false) return { toast: false, sound: 'none' };
-  const base = defaultsFor(kind, level);
-  const override = settings.kinds && settings.kinds[kind];
+  const cat = categorize(kind, level);
+  const base = defaultCategoryPolicy()[cat];
+  const override = settings.categories && settings.categories[cat];
   if (!override) return base;
   return {
     toast: override.toast !== undefined ? override.toast : base.toast,

--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -1,21 +1,32 @@
 // notifysettings.js — persisted notification settings, the "notifications"
 // section of the settings panel, and the driver that turns new board events
 // into toasts/sounds. Mirrors voice.js's localStorage + gesture-unlock pattern.
-import { kinds, kindEmoji } from './state.js';
-import { defaultsFor, policyFor, selectNewEvents } from './notifypolicy.js';
+import { kindEmoji } from './state.js';
+import { defaultCategoryPolicy, policyFor, selectNewEvents } from './notifypolicy.js';
 import * as sound from './sound.js';
 import * as toast from './toast.js';
 
-const KEY = 'bc-notif-settings';
+// New key: the old per-kind blob (bc-notif-settings) is simply ignored, no
+// migration — the settings shape changed too much to translate meaningfully.
+const KEY = 'bc-notify2';
+
+// One row per category, not per kind — the captain said per-kind was too
+// many options. Order here is render order.
+const CATEGORIES = [
+  { key: 'done', emoji: '✅', label: 'Card finished' },
+  { key: 'chat', emoji: '💬', label: 'New chat message' },
+  { key: 'error', emoji: '💥', label: 'Something went wrong' },
+  { key: 'other', emoji: '🔔', label: 'Everything else' },
+];
 
 function loadSettings() {
   try {
     const raw = JSON.parse(localStorage.getItem(KEY));
     if (raw && typeof raw === 'object') {
-      return { master: raw.master !== false, volume: typeof raw.volume === 'number' ? raw.volume : 0.7, kinds: Object.assign({}, raw.kinds) };
+      return { master: raw.master !== false, volume: typeof raw.volume === 'number' ? raw.volume : 0.7, categories: Object.assign({}, raw.categories) };
     }
   } catch (e) {}
-  return { master: true, volume: 0.7, kinds: {} };
+  return { master: true, volume: 0.7, categories: {} };
 }
 const settings = loadSettings();
 sound.setVolume(settings.volume);
@@ -24,16 +35,16 @@ function saveSettings() {
   try { localStorage.setItem(KEY, JSON.stringify(settings)); } catch (e) {}
 }
 
-function effective(kind, level) {
-  const ov = settings.kinds[kind] || {};
-  const base = defaultsFor(kind, level);
+function effective(cat) {
+  const ov = settings.categories[cat] || {};
+  const base = defaultCategoryPolicy()[cat];
   return {
     toast: ov.toast !== undefined ? ov.toast : base.toast,
     sound: ov.sound !== undefined ? ov.sound : base.sound,
   };
 }
-function setOverride(kind, patch) {
-  settings.kinds[kind] = Object.assign({}, settings.kinds[kind], patch);
+function setOverride(cat, patch) {
+  settings.categories[cat] = Object.assign({}, settings.categories[cat], patch);
   saveSettings();
 }
 
@@ -68,25 +79,25 @@ function renderMaster() {
 masterBtn.onclick = () => { settings.master = !settings.master; saveSettings(); renderMaster(); };
 volumeInput.oninput = () => { settings.volume = parseFloat(volumeInput.value); sound.setVolume(settings.volume); saveSettings(); };
 
-function rowFor(kind, level) {
+function rowFor(cat) {
   const row = document.createElement('div');
   row.className = 'ns-row';
 
   const em = document.createElement('span');
   em.className = 'ns-em';
-  em.textContent = kindEmoji(kind) || '·';
+  em.textContent = cat.emoji;
 
   const name = document.createElement('span');
   name.className = 'ns-name';
-  name.textContent = kind;
+  name.textContent = cat.label;
 
-  const eff = effective(kind, level);
+  const eff = effective(cat.key);
 
   const cb = document.createElement('input');
   cb.type = 'checkbox';
   cb.title = 'show toast';
   cb.checked = eff.toast;
-  cb.onchange = () => setOverride(kind, { toast: cb.checked });
+  cb.onchange = () => setOverride(cat.key, { toast: cb.checked });
 
   const sel = document.createElement('select');
   sel.title = 'sound';
@@ -97,7 +108,7 @@ function rowFor(kind, level) {
     sel.appendChild(o);
   }
   sel.value = eff.sound;
-  sel.onchange = () => setOverride(kind, { sound: sel.value });
+  sel.onchange = () => setOverride(cat.key, { sound: sel.value });
 
   const prev = document.createElement('button');
   prev.type = 'button';
@@ -110,30 +121,10 @@ function rowFor(kind, level) {
   return row;
 }
 
-let lastListHtml = null;
 function renderList() {
   if (listEl.contains(document.activeElement)) return; // don't clobber an in-progress edit
-  const km = kinds();
-  const entries = Object.keys(km).map((k) => ({ kind: k, level: km[k].level === 2 ? 2 : 1 }));
-  entries.sort((a, b) => a.kind.localeCompare(b.kind));
-  const lvl1 = entries.filter((e) => e.level === 1);
-  const lvl2 = entries.filter((e) => e.level === 2);
-
-  const tmp = document.createElement('div');
-  for (const e of lvl1) tmp.appendChild(rowFor(e.kind, e.level));
-  if (lvl2.length) {
-    const det = document.createElement('details');
-    det.className = 'ns-quiet';
-    const sum = document.createElement('summary');
-    sum.textContent = 'quiet events (' + lvl2.length + ')';
-    det.appendChild(sum);
-    for (const e of lvl2) det.appendChild(rowFor(e.kind, e.level));
-    tmp.appendChild(det);
-  }
-  if (lastListHtml === tmp.innerHTML) return; // same kinds set — leave live rows/interactions alone
-  lastListHtml = tmp.innerHTML;
   listEl.textContent = '';
-  while (tmp.firstChild) listEl.appendChild(tmp.firstChild);
+  for (const cat of CATEGORIES) listEl.appendChild(rowFor(cat));
 }
 
 export function renderNotifSettings() {


### PR DESCRIPTION
## Summary
- Collapses the per-kind notification settings from #15 (one row per `BUILTIN_KINDS` entry) into exactly 4 semantic categories: **done**, **chat**, **error**, **other**.
- New pure `categorize(kind, level)` in `ui/js/notifypolicy.js` maps every kind to a bucket; unlisted/unknown kinds fall into `other`, which defaults to OFF (toast off, sound none) per the captain's call that this bucket "não deve ser importante".
- `defaultCategoryPolicy()` + reworked `policyFor(kind, level, settings)` resolve a per-category override on top of category defaults, honoring `settings.master === false`.
- Settings now persist under a new `bc-notify2` localStorage key — the old per-kind blob is simply ignored, no migration needed.
- `ui/js/notifysettings.js` renders exactly 4 rows (✅ Card finished / 💬 New chat message / 💥 Something went wrong / 🔔 Everything else), each with a toast checkbox, sound `<select>`, and ▶ preview — no more per-kind list.
- `selectNewEvents(seenSet, doc)` and the SSE/dedup/decoupling machinery are unchanged. `ui/js/sound.js` and `ui/js/toast.js` are unchanged.
- `server/` and `harness/` are byte-for-byte untouched (verified via `git diff --stat origin/main -- server/ harness/`).

## Test plan
- [x] `node --test test/*.test.js` — full suite green (172/172), including rewritten `test/notifypolicy.test.js` covering `categorize`, `defaultCategoryPolicy`, `policyFor`, and unchanged `selectNewEvents` behavior.
- [x] Manual e2e in a throwaway workspace: opened the board, confirmed the settings panel shows master toggle + volume + exactly 4 category rows with correct defaults (done=chime, chat=ding, error=alert, other=none/off).
- [x] Toggled a category override, reloaded the page, confirmed it persisted via `bc-notify2`.
- [x] Fired real board events via the CLI (`question` -> chat toast, `needs-captain` -> error toast, `started` -> other, no toast) and confirmed each resolves to its category's policy.