### PR TITLE
feat: port captain's 17 chosen notification sounds into the board

### DIFF
--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -104,7 +104,7 @@ function rowFor(cat) {
   for (const n of sound.SOUND_NAMES) {
     const o = document.createElement('option');
     o.value = n;
-    o.textContent = n;
+    o.textContent = sound.SOUND_LABELS[n] || n;
     sel.appendChild(o);
   }
   sel.value = eff.sound;

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -4,77 +4,63 @@
 // anywhere on the page (the same autoplay-gate dance voice.js does for
 // speechSynthesis), so a later programmatic play() from an SSE event isn't
 // silently blocked by the browser.
-let ctx = null;
-let master = null;
-let volume = 0.7;
-
+let ctx = null, master = null, comp = null, volume = 0.85;
 function ensureCtx() {
   if (ctx) return ctx;
   const AC = window.AudioContext || window.webkitAudioContext;
   if (!AC) return null;
   try {
     ctx = new AC();
-    master = ctx.createGain();
-    master.gain.value = volume;
-    master.connect(ctx.destination);
+    master = ctx.createGain(); master.gain.value = volume;
+    comp = ctx.createDynamicsCompressor();
+    comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
+    comp.attack.value = 0.003; comp.release.value = 0.25;
+    master.connect(comp); comp.connect(ctx.destination);
   } catch (e) { ctx = null; master = null; }
   return ctx;
 }
-
 export function setVolume(v) {
   volume = Math.max(0, Math.min(1, Number(v)));
   if (master) master.gain.value = volume;
 }
-
-// One short note: an oscillator through its own attack/decay gain envelope,
-// optionally sweeping frequency (freqTo), routed into the shared master gain.
-function note(t0, { freq, freqTo, dur = 0.15, type = 'sine', peak = 0.22 }) {
-  const osc = ctx.createOscillator();
-  const g = ctx.createGain();
-  osc.type = type;
-  osc.frequency.setValueAtTime(freq, t0);
-  if (freqTo) osc.frequency.exponentialRampToValueAtTime(freqTo, t0 + dur);
+// one voice: oscillator through an attack/decay gain envelope, optional pitch glide
+function voice(t0, { freq, freqTo, type = 'sine', dur = 0.3, peak = 0.3, attack = 0.006 }) {
+  const o = ctx.createOscillator(), g = ctx.createGain();
+  o.type = type; o.frequency.setValueAtTime(freq, t0);
+  if (freqTo) o.frequency.exponentialRampToValueAtTime(Math.max(1, freqTo), t0 + dur);
   g.gain.setValueAtTime(0.0001, t0);
-  g.gain.linearRampToValueAtTime(peak, t0 + 0.012);
+  g.gain.linearRampToValueAtTime(peak, t0 + attack);
   g.gain.exponentialRampToValueAtTime(0.0001, t0 + dur);
-  osc.connect(g);
-  g.connect(master);
-  osc.start(t0);
-  osc.stop(t0 + dur + 0.03);
+  o.connect(g); g.connect(master);
+  o.start(t0); o.stop(t0 + dur + 0.04);
 }
+// a bell = fundamental + inharmonic partials decaying together
+function bell(t0, { freq, dur = 0.8, peak = 0.32, partials = [[1,1],[2.0,0.5],[2.76,0.28],[5.4,0.12]], type = 'sine' }) {
+  partials.forEach(([mult, amp]) => voice(t0, { freq: freq * mult, type, dur: dur * (0.6 + 0.4/mult), peak: peak * amp }));
+}
+const N = { C4:261.63,D4:293.66,E4:329.63,F4:349.23,G4:392,A4:440,B4:493.88,C5:523.25,D5:587.33,E5:659.25,F5:698.46,G5:783.99,A5:880,B5:987.77,C6:1046.5,D6:1174.7,E6:1318.5,G6:1568 };
 
 const PALETTE = {
-  // pleasant two-note rise
-  chime(t0) {
-    note(t0, { freq: 523.25, dur: 0.16, peak: 0.22 });      // C5
-    note(t0 + 0.11, { freq: 783.99, dur: 0.26, peak: 0.2 }); // G5
-  },
-  // single soft bell, with a quiet overtone for shimmer
-  ding(t0) {
-    note(t0, { freq: 880, dur: 0.5, peak: 0.2 });
-    note(t0, { freq: 1760, dur: 0.32, peak: 0.05 });
-  },
-  // short, unobtrusive
-  blip(t0) {
-    note(t0, { freq: 1200, dur: 0.07, type: 'square', peak: 0.14 });
-  },
-  // two low taps — "someone knocking"
-  knock(t0) {
-    note(t0, { freq: 130, dur: 0.09, peak: 0.3 });
-    note(t0 + 0.15, { freq: 112, dur: 0.1, peak: 0.3 });
-  },
-  // urgent triple beep
-  alert(t0) {
-    [0, 0.11, 0.22].forEach((d) => note(t0 + d, { freq: 988, dur: 0.09, type: 'square', peak: 0.26 }));
-  },
-  // classic two-note "coin" pickup
-  coin(t0) {
-    note(t0, { freq: 988, dur: 0.08, type: 'square', peak: 0.18 });
-    note(t0 + 0.08, { freq: 1319, dur: 0.28, type: 'square', peak: 0.16 });
-  },
+  'chime':      t => { bell(t,{freq:N.C5,dur:.5,peak:.3}); bell(t+.1,{freq:N.G5,dur:.66,peak:.28}); },
+  'ding':       t => bell(t,{freq:N.A5,dur:.9,peak:.34,partials:[[1,1],[2.76,0.3],[5.2,0.12]]}),
+  'bell-tower': t => bell(t,{freq:N.G4,dur:1.1,peak:.34,partials:[[1,1],[2.0,0.5],[2.94,0.3],[4.2,0.16],[5.4,0.1]]}),
+  'crystal':    t => { bell(t,{freq:N.E6,dur:.7,peak:.22,partials:[[1,1],[2.76,0.4],[5.4,0.2]],type:'triangle'}); voice(t,{freq:N.E6*4,type:'sine',dur:.4,peak:.04}); },
+  'glass':      t => bell(t,{freq:N.B5,dur:.55,peak:.26,partials:[[1,1],[3.1,0.35],[6.2,0.12]],type:'triangle'}),
+  'harp':       t => [N.C5,N.E5,N.G5].forEach((f,i)=>voice(t+i*.055,{freq:f,type:'triangle',dur:.5,peak:.24,attack:.004})),
+  'bloom':      t => { voice(t,{freq:N.C5,type:'sine',dur:.5,peak:.26,attack:.06}); voice(t,{freq:N.G5,type:'sine',dur:.5,peak:.16,attack:.09}); },
+  'halo':       t => { voice(t,{freq:N.E5,type:'triangle',dur:.6,peak:.2,attack:.08}); voice(t,{freq:N.B5,type:'sine',dur:.6,peak:.1,attack:.12}); },
+  'modem':      t => { voice(t,{freq:N.C5,type:'square',dur:.06,peak:.16}); voice(t+.07,{freq:N.G5,type:'square',dur:.06,peak:.16}); voice(t+.14,{freq:N.E5,type:'square',dur:.08,peak:.16}); },
+  'tri-tap':    t => [0,.1,.2].forEach(d=>voice(t+d,{freq:N.E6,type:'sine',dur:.05,peak:.28,attack:.001})),
+  'rise':       t => [N.C5,N.E5,N.G5].forEach((f,i)=>voice(t+i*.08,{freq:f,type:'sine',dur:.24,peak:.28})),
+  'descend':    t => [N.G5,N.E5,N.C5].forEach((f,i)=>voice(t+i*.08,{freq:f,type:'sine',dur:.24,peak:.28})),
+  'coin':       t => { voice(t,{freq:N.B5,type:'square',dur:.07,peak:.2}); voice(t+.08,{freq:N.E6,type:'square',dur:.3,peak:.18}); },
+  'fanfare':    t => { [N.C5,N.G5].forEach(f=>voice(t,{freq:f,type:'triangle',dur:.5,peak:.2})); voice(t+.12,{freq:N.C6,type:'triangle',dur:.5,peak:.22}); },
+  'success':    t => { voice(t,{freq:N.E5,type:'sine',dur:.14,peak:.3}); voice(t+.11,{freq:N.A5,type:'sine',dur:.3,peak:.3}); },
+  'alert':      t => [0,.12,.24].forEach(d=>voice(t+d,{freq:N.B5,type:'square',dur:.09,peak:.24})),
+  'alarm':      t => [0,.16,.32].forEach(d=>{voice(t+d,{freq:N.A5,type:'sawtooth',dur:.13,peak:.2}); voice(t+d,{freq:N.A5*1.5,type:'sawtooth',dur:.13,peak:.08});}),
 };
-
 export const SOUND_NAMES = Object.keys(PALETTE).concat('none');
+export const SOUND_LABELS = { 'chime':'Chime','ding':'Ding','bell-tower':'Bell Tower','crystal':'Crystal','glass':'Glass','harp':'Harp','bloom':'Bloom','halo':'Halo','modem':'Modem','tri-tap':'Tri-tap','rise':'Rise','descend':'Descend','coin':'Coin','fanfare':'Fanfare','success':'Success','alert':'Alert','alarm':'Alarm','none':'Off' };
 
 // Fail silently on any audio hazard (no context, suspended and can't resume,
 // unknown name) — this is called from the SSE event path and must never throw.


### PR DESCRIPTION
## Summary
- Replace the board's 6-tone WebAudio palette in `ui/js/sound.js` with the captain's 17 approved recipes (chime, ding, bell-tower, crystal, glass, harp, bloom, halo, modem, tri-tap, rise, descend, coin, fanfare, success, alert, alarm)
- Raise default volume 0.7 → 0.85 and add a `DynamicsCompressor` between master gain and destination for louder, clip-free layering
- Public API stays stable (`play`, `setVolume`, `SOUND_NAMES`); adds `SOUND_LABELS` export
- `ui/js/notifysettings.js`: sound `<select>` options now show `SOUND_LABELS[name]` as friendly text while keeping the slug as the value

## Test plan
- [x] `node --test test/*.test.js` — 172/172 green
- [x] `git diff --stat origin/main -- server/ harness/` — empty (untouched)
- [x] Loaded the board in a browser, opened ⚙️ → Notifications: all 17 friendly names + Off appear per category, defaults (chime/ding/alert) still resolve
- [x] `sound.play(name)` exercised for all 17 tones + `none` via in-page eval — no errors thrown

🤖 Generated with [Claude Code](https://claude.com/claude-code)