### PR TITLE
fix: chat/thread messages now fire the chat notification category

### DIFF
--- a/test/notifypolicy.test.js
+++ b/test/notifypolicy.test.js
@@ -6,9 +6,9 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let categorize, defaultCategoryPolicy, policyFor, selectNewEvents;
+let categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages;
 test.before(async () => {
-  ({ categorize, defaultCategoryPolicy, policyFor, selectNewEvents } =
+  ({ categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'notifypolicy.js')).href));
 });
 
@@ -96,4 +96,41 @@ test('selectNewEvents: a doc with a brand-new higher-seq event returns just that
   const out = selectNewEvents(seen, doc);
   assert.deepStrictEqual(out.map((e) => e.seq), [5]);
   assert.ok(seen.has(5));
+});
+
+test('selectNewMessages: returns new messages from both lieutenant chat and card threads, ascending by ts, and mutates the seen set', () => {
+  const doc = {
+    lieutenants: [{ id: 'l1', chat: [{ ts: 3, author: 'l1', text: 'hey' }] }],
+    cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }, { ts: 2, author: 'l1', text: 'ok' }] }],
+  };
+  const seen = new Set();
+  const first = selectNewMessages(seen, doc);
+  assert.deepStrictEqual(first.map((m) => m.ts), [1, 2, 3]);
+  assert.strictEqual(first[0].card, 'c1');
+  assert.strictEqual(first[0].cardTitle, 'Card 1');
+  assert.strictEqual(first[2].card, undefined); // lieutenant chat has no card
+  assert.strictEqual(seen.size, 3);
+});
+
+test('selectNewMessages: a second call with the same doc returns nothing (dedup)', () => {
+  const doc = { cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }] }] };
+  const seen = new Set();
+  selectNewMessages(seen, doc);
+  const second = selectNewMessages(seen, doc);
+  assert.deepStrictEqual(second, []);
+});
+
+test('selectNewMessages: a brand-new message on the next doc returns just that one', () => {
+  const doc1 = { cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }] }] };
+  const seen = new Set();
+  selectNewMessages(seen, doc1);
+  const doc2 = { cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }, { ts: 2, author: 'l1', text: 'reply' }] }] };
+  const second = selectNewMessages(seen, doc2);
+  assert.deepStrictEqual(second.map((m) => m.text), ['reply']);
+});
+
+test('selectNewMessages: does not filter by author itself — that filtering is the driver\'s job', () => {
+  const doc = { cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }] }] };
+  const out = selectNewMessages(new Set(), doc);
+  assert.deepStrictEqual(out.map((m) => m.author), ['user']);
 });

--- a/ui/js/notifypolicy.js
+++ b/ui/js/notifypolicy.js
@@ -76,3 +76,33 @@ export function selectNewEvents(seenSet, doc) {
   }
   return out;
 }
+
+// The unified chat/thread stream over a board doc: lieutenant chat + every
+// card's thread, ascending by ts. Mirrors voice.js's trackMessages walk, but
+// as a plain-doc function so it can live here alongside selectNewEvents.
+function docMessages(doc) {
+  const out = [];
+  for (const l of (doc && doc.lieutenants) || []) {
+    for (const m of l.chat || []) out.push(Object.assign({ scope: 'lieutenant:' + l.id }, m));
+  }
+  for (const c of (doc && doc.cards) || []) {
+    for (const m of c.thread || []) out.push(Object.assign({ scope: 'card:' + c.id, card: c.id, cardTitle: c.title }, m));
+  }
+  out.sort((a, b) => a.ts - b.ts);
+  return out;
+}
+
+// Returns the chat/thread messages in `doc` not yet in `seenSet` (ascending
+// by ts), and mutates `seenSet` to include them. Symmetric with
+// selectNewEvents: a pure "what's new" diff that does NOT filter by author —
+// the driver decides whether the captain's own messages should notify.
+export function selectNewMessages(seenSet, doc) {
+  const out = [];
+  for (const m of docMessages(doc)) {
+    const k = m.scope + '|' + m.ts + '|' + m.author + '|' + m.text;
+    if (seenSet.has(k)) continue;
+    seenSet.add(k);
+    out.push({ scope: m.scope, author: m.author, text: m.text, ts: m.ts, card: m.card, cardTitle: m.cardTitle });
+  }
+  return out;
+}

--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -2,7 +2,7 @@
 // section of the settings panel, and the driver that turns new board events
 // into toasts/sounds. Mirrors voice.js's localStorage + gesture-unlock pattern.
 import { kindEmoji } from './state.js';
-import { defaultCategoryPolicy, policyFor, selectNewEvents } from './notifypolicy.js';
+import { defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages } from './notifypolicy.js';
 import * as sound from './sound.js';
 import * as toast from './toast.js';
 
@@ -48,18 +48,26 @@ function setOverride(cat, patch) {
   saveSettings();
 }
 
-// ---------- driver: new events -> toast/sound ----------
-// mirrors voice.js's trackMessages: first call just seeds the seen-set (no
-// firing), thereafter each genuinely-new event resolves its policy.
+// ---------- driver: new events + chat messages -> toast/sound ----------
+// mirrors voice.js's trackMessages: first call just seeds both seen-sets (no
+// firing), thereafter each genuinely-new event/message resolves its policy.
 let firstLoad = true;
 const seen = new Set();
+const seenMsgs = new Set();
 export function trackEvents(doc) {
   if (!doc) return;
   const events = selectNewEvents(seen, doc);
+  const messages = selectNewMessages(seenMsgs, doc);
   if (firstLoad) { firstLoad = false; return; }
   for (const e of events) {
     const p = policyFor(e.kind, e.level, settings);
     if (p.toast) toast.push({ emoji: kindEmoji(e.kind), text: e.text, cardTitle: e.cardTitle, actor: e.actor, card: e.card });
+    if (p.sound && p.sound !== 'none') sound.play(p.sound);
+  }
+  for (const m of messages) {
+    if (m.author === 'user') continue; // never notify the captain of his own messages
+    const p = policyFor('reply', 1, settings);
+    if (p.toast) toast.push({ emoji: '💬', text: m.text, cardTitle: m.cardTitle, actor: m.author, card: m.card });
     if (p.sound && p.sound !== 'none') sound.play(p.sound);
   }
 }


### PR DESCRIPTION
## Summary
- The notification driver (`trackEvents(doc)` in `ui/js/notifysettings.js`) only ever scanned `doc.events`/card `events` — chat/thread messages live in `doc.cards[].thread` and `doc.lieutenants[].chat` and are never recorded as events server-side, so the "💬 New chat message" category never fired.
- Added `selectNewMessages(seenSet, doc)` in `ui/js/notifypolicy.js`, mirroring `voice.js`'s `trackMessages` walk (lieutenant chat + card threads, keyed `scope|ts|author|text`, ascending by ts).
- `trackEvents` now also drains new messages through the same seen-set pattern (separate `seenMsgs` Set, same `firstLoad` seeding) and routes non-`user`-authored messages through the `reply`→`chat` policy, firing toast + sound exactly like an event.

## Test plan
- [x] `node --test test/*.test.js` — 176 tests, all green (added 4 new `selectNewMessages` cases: cross-source dedup/ordering, second-call dedup, incremental new-message detection, author-filtering-is-the-driver's-job)
- [x] Manual verify in a real browser against a throwaway workspace: incoming lieutenant-authored card-thread message fires a 💬 toast + Ding sound; a `user`-authored message does not notify; a hard reload does not replay old messages as new toasts
- [x] `grep -rl` confirms zero changes under `server/` or `harness/` — pure client-side fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)