### PR TITLE
Suppress chat toast (not sound) when that conversation is on screen

### DIFF
--- a/test/notifypolicy.test.js
+++ b/test/notifypolicy.test.js
@@ -6,9 +6,9 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages;
+let categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages, shouldSuppressChat;
 test.before(async () => {
-  ({ categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages } =
+  ({ categorize, defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages, shouldSuppressChat } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'notifypolicy.js')).href));
 });
 
@@ -133,4 +133,29 @@ test('selectNewMessages: does not filter by author itself — that filtering is 
   const doc = { cards: [{ id: 'c1', title: 'Card 1', thread: [{ ts: 1, author: 'user', text: 'hi' }] }] };
   const out = selectNewMessages(new Set(), doc);
   assert.deepStrictEqual(out.map((m) => m.author), ['user']);
+});
+
+test('shouldSuppressChat: focused + chatVisible + matching openTarget suppresses', () => {
+  const ctx = { focused: true, chatVisible: true, openTarget: 'card:c1' };
+  assert.strictEqual(shouldSuppressChat('card:c1', ctx), true);
+});
+
+test('shouldSuppressChat: a different open conversation does not suppress', () => {
+  const ctx = { focused: true, chatVisible: true, openTarget: 'card:c2' };
+  assert.strictEqual(shouldSuppressChat('card:c1', ctx), false);
+});
+
+test('shouldSuppressChat: chat not visible (mobile on board tab) does not suppress', () => {
+  const ctx = { focused: true, chatVisible: false, openTarget: 'card:c1' };
+  assert.strictEqual(shouldSuppressChat('card:c1', ctx), false);
+});
+
+test('shouldSuppressChat: tab not focused does not suppress, even with a matching target', () => {
+  const ctx = { focused: false, chatVisible: true, openTarget: 'card:c1' };
+  assert.strictEqual(shouldSuppressChat('card:c1', ctx), false);
+});
+
+test('shouldSuppressChat: null openTarget does not suppress', () => {
+  const ctx = { focused: true, chatVisible: true, openTarget: null };
+  assert.strictEqual(shouldSuppressChat('card:c1', ctx), false);
 });

--- a/ui/js/notifypolicy.js
+++ b/ui/js/notifypolicy.js
@@ -106,3 +106,9 @@ export function selectNewMessages(seenSet, doc) {
   }
   return out;
 }
+
+// True when a chat message for `scope` should NOT notify because the captain is
+// already looking at that exact conversation. ctx: { focused, openTarget, chatVisible }.
+export function shouldSuppressChat(scope, ctx) {
+  return !!(ctx && ctx.focused && ctx.chatVisible && ctx.openTarget && ctx.openTarget === scope);
+}

--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -1,10 +1,18 @@
 // notifysettings.js — persisted notification settings, the "notifications"
 // section of the settings panel, and the driver that turns new board events
 // into toasts/sounds. Mirrors voice.js's localStorage + gesture-unlock pattern.
-import { kindEmoji } from './state.js';
-import { defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages } from './notifypolicy.js';
+import { S, kindEmoji } from './state.js';
+import { defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages, shouldSuppressChat } from './notifypolicy.js';
 import * as sound from './sound.js';
 import * as toast from './toast.js';
+
+// Mirrors ui/app.css's mobile breakpoint (`@media (max-width: 760px)`) that
+// collapses the board/chat columns into tabs. Below it, the chat panel is only
+// on screen when the captain has the chat tab selected.
+const DESKTOP_MQ = '(min-width: 761px)';
+function isChatVisible() {
+  return (typeof window !== 'undefined' && window.matchMedia && window.matchMedia(DESKTOP_MQ).matches) || S.view === 'chat';
+}
 
 // New key: the old per-kind blob (bc-notif-settings) is simply ignored, no
 // migration — the settings shape changed too much to translate meaningfully.
@@ -66,9 +74,14 @@ export function trackEvents(doc) {
   }
   for (const m of messages) {
     if (m.author === 'user') continue; // never notify the captain of his own messages
+    const ctx = {
+      focused: (typeof document !== 'undefined') && (document.hasFocus ? document.hasFocus() : !document.hidden),
+      openTarget: S.chatMode ? S.chatMode.mode + ':' + S.chatMode.id : null,
+      chatVisible: isChatVisible(),
+    };
     const p = policyFor('reply', 1, settings);
-    if (p.toast) toast.push({ emoji: '💬', text: m.text, cardTitle: m.cardTitle, actor: m.author, card: m.card });
-    if (p.sound && p.sound !== 'none') sound.play(p.sound);
+    if (p.toast && !shouldSuppressChat(m.scope, ctx)) toast.push({ emoji: '💬', text: m.text, cardTitle: m.cardTitle, actor: m.author, card: m.card });
+    if (p.sound && p.sound !== 'none') sound.play(p.sound); // ALWAYS — captain: "mantém o som"
   }
 }
 


### PR DESCRIPTION
## Summary
- Chat toasts are now suppressed when the tab is focused AND the exact conversation (card thread or lieutenant chat) is already open in the chat panel — the redundant visual is gone.
- The **sound always plays**, unconditionally, per the captain's explicit "mantém o som" — suppression is toast-only, never gated on `sound.play`.
- Scoped to the chat category only (`selectNewMessages` path); the typed-events path (done/error/other) is untouched.

## Changes
- `ui/js/notifypolicy.js`: new pure helper `shouldSuppressChat(scope, ctx)`.
- `ui/js/notifysettings.js`: driver computes `{focused, openTarget, chatVisible}` from live state (`document.hasFocus()`, `S.chatMode`, desktop/mobile via the same 760px breakpoint as `ui/app.css`) and gates only the toast push on it.
- `test/notifypolicy.test.js`: 5 new unit tests for `shouldSuppressChat`.

## Test plan
- [x] `node --test test/*.test.js` — 180/181 pass (1 pre-existing unrelated flaky network test in `supervise.test.js`, passes in isolation)
- [x] Manual verify in the live board (chrome-devtools-axi): open a card's thread, focused tab, post a lieutenant message to that card → no toast, sound still plays
- [x] Post to a different (not open) card → both toast and sound fire
- [x] Blur the tab, post to the open card → both fire
- [x] Mobile board tab (chat not on screen), post to the open card → both fire
- [x] Grepped: `server/` and `harness/` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)