### PR TITLE
fix: harden notification-audio unlock against suspended AudioContext

### DIFF
--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -64,24 +64,35 @@ export const SOUND_LABELS = { 'chime':'Chime','ding':'Ding','bell-tower':'Bell T
 
 // Fail silently on any audio hazard (no context, suspended and can't resume,
 // unknown name) — this is called from the SSE event path and must never throw.
+// Chrome starts (and re-suspends, e.g. on tab background) the AudioContext in
+// 'suspended' state; scheduling a tone into a suspended context is silently
+// dropped, so resume first and only schedule once it's actually running.
 export function play(name) {
   if (!name || name === 'none') return;
   const fn = PALETTE[name];
   if (!fn) return;
   const c = ensureCtx();
   if (!c) return;
-  try {
-    if (c.state === 'suspended') c.resume().catch(() => {});
-    fn(c.currentTime + 0.01);
-  } catch (e) {}
+  const run = () => { try { fn(c.currentTime + 0.02); } catch (e) {} };
+  if (c.state === 'suspended') { c.resume().then(run).catch(() => {}); }
+  else run();
 }
 
-// Global gesture primer: the first click/keydown anywhere unlocks the audio
-// context ahead of time, so the FIRST real notification (which rides no
-// gesture of its own) can still play instead of being silently dropped.
+// Global gesture primer: the first gesture anywhere unlocks the audio context
+// ahead of time, so the FIRST real notification (which rides no gesture of
+// its own) can still play instead of being silently dropped. Attached in the
+// capture phase (runs before target handlers) across several gesture types,
+// because the board's first click is often a control like the gear icon that
+// calls stopPropagation() — a bubble-phase window listener would miss it.
 function primeOnGesture() {
   const c = ensureCtx();
   if (c && c.state === 'suspended') c.resume().catch(() => {});
+  for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.removeEventListener(ev, primeOnGesture, true);
 }
-window.addEventListener('click', primeOnGesture, { once: true, passive: true });
-window.addEventListener('keydown', primeOnGesture, { once: true, passive: true });
+for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEventListener(ev, primeOnGesture, { capture: true, passive: true });
+
+// Re-resume proactively on refocus so the next notification after a
+// backgrounded tab isn't the one that eats the resume latency.
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden && ctx && ctx.state === 'suspended') ctx.resume().catch(() => {});
+});


### PR DESCRIPTION
## Summary
- `play()` now resumes a suspended AudioContext before scheduling the tone (previously it scheduled immediately, so the first sound after any suspend was silently lost).
- Gesture primer moved to the capture phase across `click`/`keydown`/`pointerdown`/`touchstart`, so it unlocks audio even when the first click is on a control that calls `stopPropagation()` (e.g. the gear button).
- Proactively resumes on `visibilitychange` when the tab regains focus, so the next notification doesn't eat the resume latency.
- Only `ui/js/sound.js` changed; `server/` and `harness/` untouched.

## Test plan
- [x] `node --test test/*.test.js` — 181/181 green
- [x] Verified in a real Chrome session: gear (stopPropagation button) clicked first, then preview button still plays (capture-phase primer worked); `ctx.state` reached `running`
- [x] Forced `ctx.suspend()`, triggered preview again — oscillators still scheduled and `ctx.state` returned to `running` (resume-then-schedule confirmed, no lost tone)
- [x] No console errors