### PR TITLE
feat: chat file upload — images inline, any file type, + promote-to-artifact

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -43,6 +43,7 @@ const opts = {
   level: null, kind: null, actor: null, reason: null, note: null, attrs: [], labels: [], json: false,
   worker: null, ttl: null, spawn: false, harness: null,
   mode: null, briefFile: null, resume: false, outcome: null, model: null, park: false,
+  uri: null,
 };
 const positional = [];
 for (let i = 0; i < argv.length; i++) {
@@ -79,10 +80,13 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--resume') opts.resume = true;
   else if (a === '--park') opts.park = true;
   else if (a === '--outcome') opts.outcome = argv[++i];
+  else if (a === '--uri') opts.uri = argv[++i];
   else positional.push(a);
 }
 // Two-word verbs mirror the DNA operation names: `card create`, `lieutenant list`, …
 if ((cmd === 'card' || cmd === 'lieutenant' || cmd === 'project' || cmd === 'worker') && positional.length) cmd = cmd + ' ' + positional.shift();
+// Three-word verb: `card artifact add|rm`.
+if (cmd === 'card artifact' && positional.length) cmd = cmd + ' ' + positional.shift();
 
 // ---------- workspace resolution ----------
 function findWorkspace(start) {
@@ -155,6 +159,13 @@ function parseAttrs(list) {
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function hhmm(iso) { try { return new Date(iso).toISOString().slice(5, 16).replace('T', ' '); } catch (e) { return ''; } }
 const TARGET_RE = /^(lieutenant:.+|card:.+)$/;
+// Agent-facing attachment lines: the ABSOLUTE local path per file, so the agent
+// can Read it. Images are flagged so the agent knows they're viewable inline.
+function attachmentLines(atts) {
+  if (!Array.isArray(atts) || !atts.length) return [];
+  return atts.map((a) => 'attachment: ' + (a.path || ('attachment://' + a.id)) +
+    (a.mime ? ' (' + a.mime + ')' : '') + (a.name && a.name !== (a.path || '').split('/').pop() ? ' — ' + a.name : ''));
+}
 
 // ---------- server ----------
 // ensureServer — boot the workspace server detached when down (idempotent).
@@ -382,7 +393,10 @@ async function cmdShow() {
   }
   if ((c.thread || []).length) {
     console.log('\n--- thread ---');
-    for (const m of c.thread) console.log(hhmm(m.ts) + '  ' + m.author + ': ' + m.text.replace(/\n/g, '\n    '));
+    for (const m of c.thread) {
+      console.log(hhmm(m.ts) + '  ' + m.author + ': ' + (m.text || '').replace(/\n/g, '\n    '));
+      for (const line of attachmentLines(m.attachments)) console.log('    ' + line);
+    }
   }
 }
 
@@ -402,7 +416,10 @@ async function cmdThread() {
     msgs = c.thread || [];
   }
   if (opts.json) return console.log(JSON.stringify(msgs, null, 2));
-  for (const m of msgs) console.log(hhmm(m.ts) + '  ' + m.author + ': ' + m.text.replace(/\n/g, '\n    '));
+  for (const m of msgs) {
+    console.log(hhmm(m.ts) + '  ' + m.author + ': ' + (m.text || '').replace(/\n/g, '\n    '));
+    for (const line of attachmentLines(m.attachments)) console.log('    ' + line);
+  }
 }
 
 async function cmdArchived() {
@@ -512,6 +529,27 @@ async function cmdRestore() {
   if (opts.kind) body.kind = opts.kind;
   const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/restore', body);
   console.log('restored ' + id + ' in ' + r.card.column);
+}
+
+// ---------- promote to artifact (the deliberate tool) ----------
+// A chat upload is NOT a card artifact — this is how a file becomes one, on the
+// lieutenant's judgment. Idempotent by uri.
+async function cmdArtifactAdd() {
+  const id = positional[0];
+  if (!id || !opts.uri) {
+    die('usage: bc-axi card artifact add <card-id> --uri <attachment://id | file://path | path> [--label L]\n' +
+      '  Promote a file to the card\'s curated artifacts list (deliberate — a chat upload alone never does this).');
+  }
+  const body = { uri: opts.uri, actor: opts.actor || 'agent' };
+  if (opts.labels.length) body.label = opts.labels[0]; // --label L
+  const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/artifacts', body);
+  console.log('artifact -> ' + id + ': ' + (r.artifact ? (r.artifact.label + ' (' + r.artifact.uri + ')') : opts.uri));
+}
+async function cmdArtifactRemove() {
+  const id = positional[0];
+  if (!id || !opts.uri) die('usage: bc-axi card artifact rm <card-id> --uri <attachment://id | file://path | path>');
+  const r = await request('DELETE', '/api/cards/' + encodeURIComponent(id) + '/artifacts', { uri: opts.uri, actor: opts.actor || 'agent' });
+  console.log((r.removed ? 'removed' : 'not present') + ' artifact -> ' + id + ': ' + opts.uri);
 }
 
 // ---------- card.start / workers (F5) ----------
@@ -736,6 +774,7 @@ async function cmdDrain() {
     }
     console.log('#' + it.seq + '  ' + head);
     if (it.text) console.log(indent(it.text));
+    for (const line of attachmentLines(it.attachments)) console.log(indent(line));
     if (hint) console.log('    -> ' + hint);
     console.log('');
   }
@@ -816,6 +855,7 @@ const commands = {
   'card create': cmdCreate, 'card move': cmdMove, 'card patch': cmdPatch,
   'card archive': cmdArchive, 'card restore': cmdRestore, 'card show': cmdShow,
   'card start': cmdStart, 'card park': cmdCardPark,
+  'card artifact add': cmdArtifactAdd, 'card artifact rm': cmdArtifactRemove,
   'worker signal': cmdWorkerSignal, 'worker done': cmdWorkerDone, 'worker send': cmdWorkerSend,
   'worker pause': cmdWorkerPause,
   show: cmdShow, // alias for card show
@@ -883,6 +923,10 @@ if (!commands[cmd]) {
     '  card park <card-id>                    move a Working card whose worker is absent or DEAD back\n' +
     '                                         to Backlog (liveness re-checked server-side; a live\n' +
     '                                         worker refuses — pause it instead). Timeline event\n' +
+    '  card artifact add <card-id> --uri <attachment://id | file://path | path> [--label L]\n' +
+    '                                         promote a file to the card\'s curated artifacts list\n' +
+    '                                         (deliberate — a chat upload alone never does this). Idempotent\n' +
+    '  card artifact rm <card-id> --uri <...>  remove an artifact entry by uri\n' +
     '  worker send <card-id> "<instructions>" [--text-file f|-]\n' +
     '                                         hand a LIVE worker new instructions: typed into its\n' +
     '                                         session with verified submission (run by the lieutenant)\n' +

--- a/server/server.js
+++ b/server/server.js
@@ -50,6 +50,7 @@
 const http = require('http');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
 // The harness port — the ONLY seam the server speaks to agent sessions through
 // (docs/api/overview.md, "harness port"). Lazy builtins: requiring port.js
 // drags in no tmux/claude machinery until a ref is actually dispatched.
@@ -84,6 +85,13 @@ const ARCHIVE_FILE = path.join(STATE_DIR, 'archive.jsonl');
 const CONFIG_FILE = path.join(STATE_DIR, 'config.json');
 const QUEUE_DIR = path.join(STATE_DIR, 'queue');
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
+// Chat file uploads. Lives under the workspace .bridge-command/ (already
+// git-ignored). NOTE: this dir grows unbounded — an upload is never garbage
+// collected here; a prune policy (age/size cap, orphan sweep) can come later.
+// Each file is stored as <id>__<safeName> with a sidecar <id>.json holding its
+// metadata (name/mime/size), so GET can serve the right Content-Type and the
+// stored name can never be spoofed by the request path.
+const UPLOADS_DIR = path.join(STATE_DIR, 'uploads');
 const UI_DIR = path.join(__dirname, '..', 'ui');
 // Harness working state (session ids, prompts, turn-end logs) lives in the
 // WORKSPACE, never in the harness's global last-resort dir — two boards on one
@@ -91,6 +99,11 @@ const UI_DIR = path.join(__dirname, '..', 'ui');
 const HARNESS_STATE_DIR = process.env.BC_HARNESS_STATE || path.join(STATE_DIR, 'harness');
 fs.mkdirSync(QUEUE_DIR, { recursive: true });
 fs.mkdirSync(HARNESS_STATE_DIR, { recursive: true });
+fs.mkdirSync(UPLOADS_DIR, { recursive: true });
+
+// Upload size cap (decoded bytes). Over-cap uploads are rejected 413.
+const UPLOAD_MAX_BYTES = parseInt(process.env.BC_UPLOAD_MAX_BYTES, 10) > 0
+  ? parseInt(process.env.BC_UPLOAD_MAX_BYTES, 10) : 10 * 1024 * 1024;
 
 const DEFAULT_PORT = 4780;
 
@@ -775,6 +788,90 @@ function readBody(req) {
     req.on('error', reject);
   });
 }
+// Larger-capped body reader for the base64 upload transport: the 10 MB decoded
+// cap becomes ~13.4 MB of base64 + JSON overhead, well past readBody's 8 MB
+// guard. Rejects with .code 413 past the cap so the caller can answer correctly.
+function readBodyUpto(req, max) {
+  return new Promise((resolve, reject) => {
+    let len = 0; const chunks = [];
+    req.on('data', (c) => {
+      len += c.length;
+      if (len > max) { const e = new Error('body too large'); e.code = 413; reject(e); req.destroy(); return; }
+      chunks.push(c);
+    });
+    req.on('end', () => resolve(Buffer.concat(chunks).toString('utf8')));
+    req.on('error', reject);
+  });
+}
+
+// ---------- chat attachments (uploads) ----------
+// Filename sanitization: keep a readable tail but strip anything that could
+// escape the uploads dir or confuse a shell/browser — path separators, control
+// chars, leading dots. The <id> prefix guarantees uniqueness, so a collapsed or
+// empty name is harmless (falls back to "file").
+function safeUploadName(name) {
+  const base = String(name || '').split(/[\\/]/).pop() || '';
+  const cleaned = base.replace(/[\x00-\x1f\x7f]/g, '').replace(/[^A-Za-z0-9._-]/g, '_')
+    .replace(/^\.+/, '').slice(0, 120);
+  return cleaned || 'file';
+}
+function newAttachmentId() {
+  for (;;) {
+    const id = crypto.randomBytes(8).toString('hex');
+    if (!fs.existsSync(path.join(UPLOADS_DIR, id + '.json'))) return id;
+  }
+}
+function attachmentSidecar(id) { return path.join(UPLOADS_DIR, id + '.json'); }
+// Read the stored metadata for an id, or null. The id must be a bare token —
+// path traversal (slashes, dots) can never reach the filesystem.
+function readAttachmentMeta(id) {
+  if (!/^[a-f0-9]{8,}$/.test(String(id || ''))) return null;
+  try {
+    const meta = JSON.parse(fs.readFileSync(attachmentSidecar(id), 'utf8'));
+    if (!meta || typeof meta !== 'object' || meta.id !== id || typeof meta.stored !== 'string') return null;
+    // The absolute on-disk path, resolved strictly within the uploads dir.
+    const file = path.join(UPLOADS_DIR, meta.stored);
+    if (path.dirname(path.resolve(file)) !== path.resolve(UPLOADS_DIR)) return null;
+    meta.path = file;
+    return meta;
+  } catch (e) { return null; }
+}
+// Persist an uploaded file + sidecar; returns the public meta. `data` is the
+// decoded Buffer (size already enforced by the caller).
+function storeAttachment(name, mime, data) {
+  const id = newAttachmentId();
+  const stored = id + '__' + safeUploadName(name);
+  fs.writeFileSync(path.join(UPLOADS_DIR, stored), data);
+  const meta = {
+    id, name: safeUploadName(name), mime: String(mime || 'application/octet-stream').slice(0, 200),
+    size: data.length, stored, created: now(),
+  };
+  fs.writeFileSync(attachmentSidecar(id), JSON.stringify(meta));
+  return meta;
+}
+// Resolve a client-supplied attachment list to AUTHORITATIVE metas by id: the
+// client only names ids, the server reads name/mime/size/path from its own
+// sidecar so a message can never inject an arbitrary path or spoofed metadata.
+// Unknown ids are dropped. The stored form carries the absolute `path` so the
+// agent (drain/thread) and the UI (id → /api/attachments/:id) both resolve it.
+function resolveAttachments(list) {
+  if (!Array.isArray(list)) return [];
+  const out = [];
+  for (const a of list.slice(0, 20)) {
+    const id = a && (typeof a === 'string' ? a : a.id);
+    const meta = readAttachmentMeta(id);
+    if (meta) out.push({ id: meta.id, name: meta.name, mime: meta.mime, size: meta.size, path: meta.path });
+  }
+  return out;
+}
+// One-line agent-facing rendering of a message's attachments: absolute path +
+// mime per file. Without the PATH in the drain/thread text the agent can't Read
+// the file — this is the whole point of B.
+function attachmentsLine(atts) {
+  if (!Array.isArray(atts) || !atts.length) return '';
+  const parts = atts.map((a) => (a.path || '') + (a.mime ? ' (' + a.mime + ')' : ''));
+  return atts.length + ' attachment' + (atts.length > 1 ? 's' : '') + ': ' + parts.join(', ');
+}
 function findCard(id) { return board.cards.find((c) => c.id === id); }
 // Chat targets: lieutenant:<id> (main chat) | card:<id> (card thread).
 function threadFor(target) {
@@ -994,6 +1091,56 @@ function patchCard(card, body) {
   card.updated = now();
   registerCardLabels();
   return { ok: true };
+}
+
+// ---------- promote to artifact (the DELIBERATE tool — chat upload ≠ artifact) ----------
+// Add/remove a curated deliverable on card.attributes.artifacts [{uri, label}].
+// This is the ONLY path (besides the investigation auto-attach) that puts an
+// entry there — a chat upload alone never does. Idempotent by uri, mirroring the
+// investigation auto-attach shape. A bare filesystem path is normalized to a
+// file:// absolute uri; attachment:// and http(s):// / file:// uris pass through.
+function normalizeArtifactUri(raw) {
+  const s = String(raw || '').trim();
+  if (!s) return '';
+  if (/^(attachment|https?|file):\/\//.test(s)) return s;
+  return 'file://' + path.resolve(s);
+}
+function cardArtifactAdd(card, body) {
+  const uri = normalizeArtifactUri(body && body.uri);
+  if (!uri) return { error: 'uri required (attachment://id | file://path | path)' };
+  if (!Array.isArray(card.attributes.artifacts)) card.attributes.artifacts = [];
+  const label = String((body && body.label) || '').slice(0, 200);
+  const existing = card.attributes.artifacts.find((a) => a && a.uri === uri);
+  if (existing) {
+    if (label && existing.label !== label) { existing.label = label; card.updated = now(); }
+    return { ok: true, artifact: existing, unchanged: !label || existing.label === label };
+  }
+  // Default label: an attachment's stored name (nicer than its opaque id), else
+  // the uri's basename.
+  let defLabel = uriBasenameServer(uri);
+  const am = /^attachment:\/\/(.+)$/.exec(uri);
+  if (am) { const meta = readAttachmentMeta(am[1]); if (meta) defLabel = meta.name; }
+  const art = label ? { uri, label } : { uri, label: defLabel };
+  card.attributes.artifacts.push(art);
+  card.events.push(mkEvent({ text: 'artifact added: ' + (art.label || uri), actor: (body && body.actor) || 'agent', level: 2 }, {}));
+  card.updated = now();
+  return { ok: true, artifact: art };
+}
+function cardArtifactRemove(card, body) {
+  const uri = normalizeArtifactUri(body && body.uri);
+  if (!uri) return { error: 'uri required' };
+  const arts = Array.isArray(card.attributes.artifacts) ? card.attributes.artifacts : [];
+  const next = arts.filter((a) => !(a && a.uri === uri));
+  const removed = next.length !== arts.length;
+  card.attributes.artifacts = next;
+  if (removed) card.updated = now();
+  return { ok: true, removed };
+}
+// Server-side twin of ui/js/util.js uriBasename — the artifact's display name.
+function uriBasenameServer(uri) {
+  const s = String(uri).replace(/[?#].*$/, '').replace(/\/+$/, '');
+  const i = s.lastIndexOf('/');
+  return i >= 0 ? s.slice(i + 1) : s;
 }
 
 function readArchive() {
@@ -1698,13 +1845,59 @@ const server = http.createServer(async (req, res) => {
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
         c.attributes.artifacts.some((a) => a && a.uri === uri));
       if (!listed) return sendJson(res, 404, { error: 'unknown artifact' });
-      const file = uri.startsWith('file://') ? uri.slice('file://'.length) : uri;
+      // A promoted chat attachment (attachment://id) resolves to its stored file
+      // via the sidecar; file:// / bare paths read directly.
+      let file = uri.startsWith('file://') ? uri.slice('file://'.length) : uri;
+      let name = path.basename(file);
+      const am = /^attachment:\/\/(.+)$/.exec(uri);
+      if (am) {
+        const meta = readAttachmentMeta(am[1]);
+        if (!meta) return sendJson(res, 404, { error: 'unknown attachment' });
+        file = meta.path; name = meta.name;
+      }
       let data;
       try { data = fs.readFileSync(file); }
       catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
       if (data.length > 2e6) return sendJson(res, 413, { error: 'file too large to preview' });
       if (data.includes(0)) return sendJson(res, 415, { error: 'binary file' });
-      return sendJson(res, 200, { name: path.basename(file), content: data.toString('utf8') });
+      return sendJson(res, 200, { name, content: data.toString('utf8') });
+    }
+
+    // ----- chat attachments (uploads) -----
+    // POST: base64 upload transport (zero-dep). Decode, size-cap (413), sanitize,
+    // store under <STATE_DIR>/uploads with a sidecar; return {id, uri, ...}.
+    if (route === 'POST /api/attachments') {
+      let raw;
+      try { raw = await readBodyUpto(req, Math.ceil(UPLOAD_MAX_BYTES * 1.4) + 65536); }
+      catch (e) {
+        if (e.code === 413) return sendJson(res, 413, { error: 'upload too large (max ' + UPLOAD_MAX_BYTES + ' bytes)' });
+        throw e;
+      }
+      const body = JSON.parse(raw || '{}');
+      const b64 = String(body.dataBase64 || '');
+      if (!b64) return sendJson(res, 400, { error: 'dataBase64 required' });
+      let data;
+      try { data = Buffer.from(b64, 'base64'); } catch (e) { data = null; }
+      if (!data || !data.length) return sendJson(res, 400, { error: 'bad base64 data' });
+      if (data.length > UPLOAD_MAX_BYTES) return sendJson(res, 413, { error: 'upload too large (max ' + UPLOAD_MAX_BYTES + ' bytes)' });
+      const meta = storeAttachment(body.name, body.mime, data);
+      return sendJson(res, 200, { id: meta.id, uri: 'attachment://' + meta.id, name: meta.name, mime: meta.mime, size: meta.size });
+    }
+    // GET: stream the stored bytes with the stored Content-Type. Backs both the
+    // inline <img> and file downloads. Strictly within the uploads dir; unknown
+    // id → 404 (readAttachmentMeta rejects any traversal in the id).
+    const attRoute = /^\/api\/attachments\/([^/]+)$/.exec(p);
+    if (attRoute && req.method === 'GET') {
+      const meta = readAttachmentMeta(decodeURIComponent(attRoute[1]));
+      if (!meta) return sendJson(res, 404, { error: 'unknown attachment' });
+      let data;
+      try { data = fs.readFileSync(meta.path); } catch (e) { return sendJson(res, 404, { error: 'unreadable' }); }
+      res.writeHead(200, {
+        'Content-Type': meta.mime || 'application/octet-stream',
+        'Content-Length': data.length,
+        'Cache-Control': 'private, max-age=31536000, immutable',
+      });
+      return res.end(data);
     }
 
     // ----- lieutenants -----
@@ -1838,7 +2031,7 @@ const server = http.createServer(async (req, res) => {
       saveBoard(); broadcast();
       return sendJson(res, 200, { ok: true, card: publicCard(r.card, 'user'), event: r.event });
     }
-    const cardRoute = /^\/api\/cards\/([^/]+)(\/(move|events|archive|status|start|park|worker\/signal|worker\/done|worker\/send|worker\/pause))?$/.exec(p);
+    const cardRoute = /^\/api\/cards\/([^/]+)(\/(move|events|archive|status|start|park|artifacts|worker\/signal|worker\/done|worker\/send|worker\/pause))?$/.exec(p);
     if (cardRoute) {
       const card = findCard(decodeURIComponent(cardRoute[1]));
       if (!card) return sendJson(res, 404, { error: 'unknown card: ' + decodeURIComponent(cardRoute[1]) });
@@ -1914,6 +2107,20 @@ const server = http.createServer(async (req, res) => {
         saveBoard(); broadcast();
         return sendJson(res, 200, r);
       }
+      // promote-to-artifact — the deliberate tool. POST adds, DELETE removes an
+      // entry on card.attributes.artifacts. A chat upload alone never lands here.
+      if (sub === 'artifacts' && req.method === 'POST') {
+        const r = cardArtifactAdd(card, JSON.parse(await readBody(req) || '{}'));
+        if (r.error) return sendJson(res, r.code || 400, { error: r.error });
+        saveBoard(); broadcast();
+        return sendJson(res, 200, { ok: true, artifact: r.artifact, card: publicCard(card, 'user') });
+      }
+      if (sub === 'artifacts' && req.method === 'DELETE') {
+        const r = cardArtifactRemove(card, JSON.parse(await readBody(req) || '{}'));
+        if (r.error) return sendJson(res, r.code || 400, { error: r.error });
+        saveBoard(); broadcast();
+        return sendJson(res, 200, { ok: true, removed: r.removed, card: publicCard(card, 'user') });
+      }
       return sendJson(res, 405, { error: 'method not allowed' });
     }
 
@@ -1975,7 +2182,8 @@ const server = http.createServer(async (req, res) => {
       const thread = threadFor(target);
       if (!thread) return sendJson(res, 404, { error: 'unknown target: ' + target });
       const text = String(body.text_md || body.text || '');
-      if (!text.trim()) return sendJson(res, 400, { error: 'text required' });
+      const attachments = resolveAttachments(body.attachments);
+      if (!text.trim() && !attachments.length) return sendJson(res, 400, { error: 'text or attachments required' });
       // Default author, most-identified first: explicit body.author; then the
       // CALLER resolved from its tmux session (like drain/ack — so a lieutenant
       // posting to another's chat or card is stamped as itself, not the target);
@@ -1985,6 +2193,7 @@ const server = http.createServer(async (req, res) => {
       const sess = body.session ? String(body.session) : '';
       const caller = sess ? board.lieutenants.find((l) => l.ref && l.ref.session === sess) : null;
       const msg = { author: String(body.author || (caller && caller.name) || (lt && lt.name) || 'agent').slice(0, 60), text, ts: now() };
+      if (attachments.length) msg.attachments = attachments;
       thread.push(msg);
       const m = /^card:(.+)$/.exec(target);
       if (m) {
@@ -1999,7 +2208,8 @@ const server = http.createServer(async (req, res) => {
           // the owner's name). Captain messages ride /api/feedback, never here.
           const fromOwner = !!(caller && caller.id === card.owner);
           if (!fromOwner && msg.author !== 'user') {
-            queuePush(card.owner, { kind: 'worker-said', card: card.id, target, author: msg.author, text: text.slice(0, 2000) });
+            queuePush(card.owner, { kind: 'worker-said', card: card.id, target, author: msg.author,
+              text: text.slice(0, 2000), attachments });
           }
         }
       } else {
@@ -2016,13 +2226,17 @@ const server = http.createServer(async (req, res) => {
       const thread = threadFor(target);
       if (!thread) return sendJson(res, 404, { error: 'unknown target: ' + target });
       const text = String(body.text || '');
-      if (!text.trim()) return sendJson(res, 400, { error: 'text required' });
+      const attachments = resolveAttachments(body.attachments);
+      if (!text.trim() && !attachments.length) return sendJson(res, 400, { error: 'text or attachments required' });
       const lt = targetLieutenant(target);
       if (!lt) return sendJson(res, 404, { error: 'no lieutenant behind target: ' + target });
       // Write-ahead delivery: the QueueItem lands FIRST; the send-keys wake half
-      // of delivery arrives in a later phase. A dead session loses nothing.
-      const item = queuePush(lt.id, { kind: 'message', target, text });
+      // of delivery arrives in a later phase. A dead session loses nothing. The
+      // attachments (with absolute paths) ride the queue item so drain surfaces
+      // the file paths to the agent.
+      const item = queuePush(lt.id, { kind: 'message', target, text, attachments });
       const msg = { author: 'user', text, ts: now() };
+      if (attachments.length) msg.attachments = attachments;
       thread.push(msg);
       const m = /^card:(.+)$/.exec(target);
       if (m) {

--- a/server/server.js
+++ b/server/server.js
@@ -840,10 +840,11 @@ function readAttachmentMeta(id) {
 // decoded Buffer (size already enforced by the caller).
 function storeAttachment(name, mime, data) {
   const id = newAttachmentId();
-  const stored = id + '__' + safeUploadName(name);
+  const safe = safeUploadName(name);
+  const stored = id + '__' + safe;
   fs.writeFileSync(path.join(UPLOADS_DIR, stored), data);
   const meta = {
-    id, name: safeUploadName(name), mime: String(mime || 'application/octet-stream').slice(0, 200),
+    id, name: safe, mime: String(mime || 'application/octet-stream').slice(0, 200),
     size: data.length, stored, created: now(),
   };
   fs.writeFileSync(attachmentSidecar(id), JSON.stringify(meta));
@@ -863,14 +864,6 @@ function resolveAttachments(list) {
     if (meta) out.push({ id: meta.id, name: meta.name, mime: meta.mime, size: meta.size, path: meta.path });
   }
   return out;
-}
-// One-line agent-facing rendering of a message's attachments: absolute path +
-// mime per file. Without the PATH in the drain/thread text the agent can't Read
-// the file — this is the whole point of B.
-function attachmentsLine(atts) {
-  if (!Array.isArray(atts) || !atts.length) return '';
-  const parts = atts.map((a) => (a.path || '') + (a.mime ? ' (' + a.mime + ')' : ''));
-  return atts.length + ' attachment' + (atts.length > 1 ? 's' : '') + ': ' + parts.join(', ');
 }
 function findCard(id) { return board.cards.find((c) => c.id === id); }
 // Chat targets: lieutenant:<id> (main chat) | card:<id> (card thread).
@@ -1892,10 +1885,16 @@ const server = http.createServer(async (req, res) => {
       if (!meta) return sendJson(res, 404, { error: 'unknown attachment' });
       let data;
       try { data = fs.readFileSync(meta.path); } catch (e) { return sendJson(res, 404, { error: 'unreadable' }); }
+      // Uploaded bytes are untrusted content served from the board's own origin.
+      // nosniff pins the stored Content-Type (no MIME sniffing into executable
+      // types); the sandbox CSP neutralizes scripts if an HTML/SVG upload is
+      // navigated to as a document — inline <img> subresources are unaffected.
       res.writeHead(200, {
         'Content-Type': meta.mime || 'application/octet-stream',
         'Content-Length': data.length,
         'Cache-Control': 'private, max-age=31536000, immutable',
+        'X-Content-Type-Options': 'nosniff',
+        'Content-Security-Policy': 'sandbox',
       });
       return res.end(data);
     }

--- a/test/attachments.test.js
+++ b/test/attachments.test.js
@@ -31,6 +31,9 @@ test('upload → stored + served with the right Content-Type and correct size', 
     const res = await fetch(s.base + '/api/attachments/' + up.body.id);
     assert.strictEqual(res.status, 200);
     assert.strictEqual(res.headers.get('content-type'), 'text/plain');
+    // untrusted content served from our own origin: sniffing off + sandboxed
+    assert.strictEqual(res.headers.get('x-content-type-options'), 'nosniff');
+    assert.strictEqual(res.headers.get('content-security-policy'), 'sandbox');
     assert.strictEqual(await res.text(), payload);
   } finally {
     await s.stop();

--- a/test/attachments.test.js
+++ b/test/attachments.test.js
@@ -1,0 +1,230 @@
+'use strict';
+// Chat file uploads: the /api/attachments transport + serve, message attachments
+// with agent path delivery (drain/thread), and the DELIBERATE promote-to-artifact
+// tool. Uploading a file to chat must NEVER auto-add a card artifact.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { startServerWithLieutenant, withOwner, runCli, LT } = require('./helper');
+
+const b64 = (s) => Buffer.from(s).toString('base64');
+
+test('upload → stored + served with the right Content-Type and correct size', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const payload = 'hello attachment world';
+    const up = await s.api('POST', '/api/attachments', { name: 'note.txt', mime: 'text/plain', dataBase64: b64(payload) });
+    assert.strictEqual(up.status, 200);
+    assert.match(up.body.id, /^[a-f0-9]{16}$/);
+    assert.strictEqual(up.body.uri, 'attachment://' + up.body.id);
+    assert.strictEqual(up.body.name, 'note.txt');
+    assert.strictEqual(up.body.mime, 'text/plain');
+    assert.strictEqual(up.body.size, Buffer.byteLength(payload));
+
+    // stored on disk under .bridge-command/uploads with a sidecar
+    const up_dir = path.join(s.dir, '.bridge-command', 'uploads');
+    assert.ok(fs.existsSync(path.join(up_dir, up.body.id + '.json')), 'sidecar written');
+    assert.ok(fs.existsSync(path.join(up_dir, up.body.id + '__note.txt')), 'file written with id prefix');
+
+    // GET streams the bytes with the stored Content-Type
+    const res = await fetch(s.base + '/api/attachments/' + up.body.id);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'text/plain');
+    assert.strictEqual(await res.text(), payload);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('over-cap upload → 413', async () => {
+  const s = await startServerWithLieutenant({ env: { BC_UPLOAD_MAX_BYTES: '64' } });
+  try {
+    const ok = await s.api('POST', '/api/attachments', { name: 'small.bin', mime: 'application/octet-stream', dataBase64: b64('x'.repeat(64)) });
+    assert.strictEqual(ok.status, 200);
+    const over = await s.api('POST', '/api/attachments', { name: 'big.bin', mime: 'application/octet-stream', dataBase64: b64('x'.repeat(65)) });
+    assert.strictEqual(over.status, 413);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('unknown id → 404', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const res = await fetch(s.base + '/api/attachments/deadbeefdeadbeef');
+    assert.strictEqual(res.status, 404);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('path traversal in the id or the filename is blocked', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    // a bare ".." or an encoded traversal id never resolves to a file
+    for (const bad of ['..', '%2e%2e', '..%2f..%2fboard.json', 'not-hex-id']) {
+      const res = await fetch(s.base + '/api/attachments/' + bad);
+      assert.strictEqual(res.status, 404, 'traversal id blocked: ' + bad);
+    }
+    // a traversal filename is sanitized to a safe basename inside the uploads dir
+    const up = await s.api('POST', '/api/attachments', { name: '../../../etc/passwd', mime: 'text/plain', dataBase64: b64('x') });
+    assert.strictEqual(up.status, 200);
+    assert.strictEqual(up.body.name, 'passwd'); // stripped to the basename
+    const up_dir = path.join(s.dir, '.bridge-command', 'uploads');
+    const stored = fs.readdirSync(up_dir).filter((f) => f.startsWith(up.body.id + '__'));
+    assert.strictEqual(stored.length, 1);
+    assert.ok(!stored[0].includes('..') && !stored[0].includes('/'), 'stored name has no traversal');
+    // the file really lives inside the uploads dir
+    assert.ok(fs.existsSync(path.join(up_dir, stored[0])));
+  } finally {
+    await s.stop();
+  }
+});
+
+test('captain feedback with attachments persists them on the thread message and queues them with the absolute path', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Shots' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'shot.png', mime: 'image/png', dataBase64: b64('PNGDATA') });
+    const r = await s.api('POST', '/api/feedback', { target: 'card:shots', text: 'see this', attachments: [{ id: up.body.id }] });
+    assert.strictEqual(r.status, 200);
+
+    // persisted on the thread message with authoritative meta (server re-resolves by id)
+    const card = (await s.api('GET', '/api/cards/shots')).body;
+    const att = card.thread[0].attachments;
+    assert.strictEqual(att.length, 1);
+    assert.strictEqual(att[0].id, up.body.id);
+    assert.strictEqual(att[0].name, 'shot.png');
+    assert.strictEqual(att[0].mime, 'image/png');
+    const absPath = path.join(s.dir, '.bridge-command', 'uploads', up.body.id + '__shot.png');
+    assert.strictEqual(att[0].path, absPath);
+
+    // the queue item to the owner carries the same attachments (with path)
+    const item = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items[0];
+    assert.strictEqual(item.kind, 'message');
+    assert.strictEqual(item.attachments[0].path, absPath);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('a message may carry attachments with no text', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Nomsg' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'log.txt', mime: 'text/plain', dataBase64: b64('L') });
+    const r = await s.api('POST', '/api/feedback', { target: 'card:nomsg', text: '', attachments: [{ id: up.body.id }] });
+    assert.strictEqual(r.status, 200);
+    // but a message with neither text nor attachments is still rejected
+    const empty = await s.api('POST', '/api/feedback', { target: 'card:nomsg', text: '  ' });
+    assert.strictEqual(empty.status, 400);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('drain and thread output surface the absolute attachment path to the agent', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Paths' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'diag.log', mime: 'text/plain', dataBase64: b64('trace') });
+    await s.api('POST', '/api/feedback', { target: 'card:paths', text: 'look', attachments: [{ id: up.body.id }] });
+    const absPath = path.join(s.dir, '.bridge-command', 'uploads', up.body.id + '__diag.log');
+
+    const drain = await runCli(['drain', '--lieutenant', LT, '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(drain.code, 0, drain.stderr);
+    assert.ok(drain.stdout.includes(absPath), 'drain shows the absolute path:\n' + drain.stdout);
+
+    const thread = await runCli(['thread', 'card:paths', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(thread.code, 0, thread.stderr);
+    assert.ok(thread.stdout.includes(absPath), 'thread shows the absolute path:\n' + thread.stdout);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('uploading to chat does NOT auto-add a card artifact; promote add/rm is deliberate + idempotent', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Promote' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'design.png', mime: 'image/png', dataBase64: b64('IMG') });
+    await s.api('POST', '/api/feedback', { target: 'card:promote', text: 'here', attachments: [{ id: up.body.id }] });
+
+    // the upload alone leaves artifacts empty
+    let card = (await s.api('GET', '/api/cards/promote')).body;
+    assert.ok(!card.attributes.artifacts || !card.attributes.artifacts.length, 'no auto artifact from upload');
+
+    // deliberate promote appends {uri, label}
+    const uri = 'attachment://' + up.body.id;
+    const add = await s.api('POST', '/api/cards/promote/artifacts', { uri, label: 'the design' });
+    assert.strictEqual(add.status, 200);
+    card = (await s.api('GET', '/api/cards/promote')).body;
+    assert.deepStrictEqual(card.attributes.artifacts, [{ uri, label: 'the design' }]);
+
+    // idempotent — no duplicate on re-add
+    await s.api('POST', '/api/cards/promote/artifacts', { uri, label: 'the design' });
+    card = (await s.api('GET', '/api/cards/promote')).body;
+    assert.strictEqual(card.attributes.artifacts.length, 1);
+
+    // rm removes it
+    const rm = await s.api('DELETE', '/api/cards/promote/artifacts', { uri });
+    assert.strictEqual(rm.status, 200);
+    assert.strictEqual(rm.body.removed, true);
+    card = (await s.api('GET', '/api/cards/promote')).body;
+    assert.strictEqual((card.attributes.artifacts || []).length, 0);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('card artifact add defaults the label to the attachment name; promoted attachment previews via /api/artifact', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Deflabel' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'readme.md', mime: 'text/markdown', dataBase64: b64('# hi') });
+    const uri = 'attachment://' + up.body.id;
+    await s.api('POST', '/api/cards/deflabel/artifacts', { uri });
+    const card = (await s.api('GET', '/api/cards/deflabel')).body;
+    assert.deepStrictEqual(card.attributes.artifacts, [{ uri, label: 'readme.md' }]);
+
+    // the artifact preview endpoint resolves the attachment:// uri to its bytes
+    const prev = await s.api('GET', '/api/artifact?uri=' + encodeURIComponent(uri));
+    assert.strictEqual(prev.status, 200);
+    assert.strictEqual(prev.body.content, '# hi');
+  } finally {
+    await s.stop();
+  }
+});
+
+test('cli: card artifact add/rm on the currently-open card', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Cli art' }));
+    const up = await s.api('POST', '/api/attachments', { name: 'plot.png', mime: 'image/png', dataBase64: b64('P') });
+    const uri = 'attachment://' + up.body.id;
+    const add = await runCli(['card', 'artifact', 'add', 'cli-art', '--uri', uri, '--label', 'plot', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(add.code, 0, add.stderr);
+    let card = (await s.api('GET', '/api/cards/cli-art')).body;
+    assert.deepStrictEqual(card.attributes.artifacts, [{ uri, label: 'plot' }]);
+
+    const rm = await runCli(['card', 'artifact', 'rm', 'cli-art', '--uri', uri, '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(rm.code, 0, rm.stderr);
+    card = (await s.api('GET', '/api/cards/cli-art')).body;
+    assert.strictEqual((card.attributes.artifacts || []).length, 0);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('card artifact add normalizes a bare path to a file:// uri', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Filepath' }));
+    const r = await s.api('POST', '/api/cards/filepath/artifacts', { uri: '/tmp/report.md', label: 'report' });
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.body.artifact.uri, 'file:///tmp/report.md');
+  } finally {
+    await s.stop();
+  }
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -178,9 +178,54 @@ body.resizing { user-select: none; cursor: col-resize; }
 .composer button.sending { animation: send-pulse 1s ease-in-out infinite; }
 @keyframes send-pulse { 50% { opacity: .35; } }
 .composer textarea.send-fail { border-color: var(--danger); }
+.composer.drag { outline: 2px dashed var(--accent2); outline-offset: -4px; border-radius: 10px; }
+.composer-attach {
+  flex: none; width: 34px; height: 34px; border-radius: 50%; background: var(--panel2);
+  border: 1px solid var(--line); color: var(--dim); font-size: 15px;
+  display: flex; align-items: center; justify-content: center; transition: color .15s, border-color .15s, background .15s;
+}
+.composer-attach:hover { color: var(--accent); border-color: var(--accent2); }
+.composer-attach:disabled { opacity: .4; pointer-events: none; }
 #chat-send-err {
   flex: none; padding: 6px 12px 0; font-size: 12px; color: var(--danger);
 }
+/* pending-attachment chips (composer, before send) */
+#chat-atts { flex: none; display: flex; flex-wrap: wrap; gap: 6px; padding: 8px 12px 0; }
+.att-chip {
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 3px 6px 3px 9px; font-size: 12px;
+}
+.att-chip-nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 180px; }
+.att-chip-sz { color: var(--faint); font-size: 11px; font-family: var(--mono); flex: none; }
+.att-chip-x { flex: none; color: var(--dim); font-size: 12px; padding: 0 3px; line-height: 1; }
+.att-chip-x:hover { color: var(--danger); }
+
+/* message attachments (in the feed) */
+.atts { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 6px; }
+.att { position: relative; display: inline-flex; }
+.att-img { max-width: 100%; }
+.att-thumb {
+  max-width: 100%; max-height: 240px; border-radius: 10px; border: 1px solid var(--line);
+  cursor: pointer; display: block; object-fit: contain; background: var(--panel2);
+}
+.att-thumb:hover { border-color: var(--accent2); }
+.att-file .att-open {
+  display: inline-flex; align-items: center; gap: 7px; cursor: pointer;
+  background: var(--panel2); border: 1px solid var(--line); border-radius: 9px; padding: 6px 10px; max-width: 100%;
+}
+.att-file .att-open:hover { border-color: var(--accent2); }
+.att-ico { flex: none; font-size: 15px; }
+.att-nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 200px; font-size: 13px; }
+.att-sz { color: var(--faint); font-size: 11px; font-family: var(--mono); flex: none; }
+.att-pin {
+  position: absolute; top: 3px; right: 3px; width: 22px; height: 22px; border-radius: 6px;
+  background: rgba(4, 7, 11, .55); border: 1px solid var(--line); color: #fff; font-size: 12px;
+  display: flex; align-items: center; justify-content: center; opacity: 0; transition: opacity .12s;
+}
+.att:hover .att-pin, .att-pin:focus-visible { opacity: .9; }
+.att-pin:hover { opacity: 1; border-color: var(--accent2); }
+.att-file .att-pin { position: static; margin-left: 4px; align-self: center; background: var(--panel2); color: var(--dim); }
+@media (hover: none) { .att-pin { opacity: .7; } }
 
 /* ---------- lieutenant lane (above the columns) ---------- */
 #lane {
@@ -673,6 +718,11 @@ a.a-uri { color: var(--accent); }
 /* markdown artifacts render through the card-body renderer; drop the pre defaults
    so .md block styles (from the shared markdown section) apply as on a card body */
 #av-body.md { font-family: var(--sans); font-size: 15px; white-space: normal; }
+/* image attachment preview (shares the av-overlay) */
+#av-img-wrap { flex: 1; min-height: 60px; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
+#av-img { max-width: 100%; max-height: 76vh; object-fit: contain; border-radius: 6px; }
+#av-download { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; text-decoration: none; }
+#av-download:hover { color: var(--accent); }
 
 /* ---------- TTS speaking indicator ---------- */
 #tts-bubble {

--- a/ui/index.html
+++ b/ui/index.html
@@ -82,7 +82,10 @@
     </div>
     <div id="chat-feed"></div>
     <div id="chat-send-err" hidden></div>
+    <div id="chat-atts" hidden></div>
     <form id="chat-form" class="composer">
+      <input id="chat-file" type="file" multiple hidden>
+      <button type="button" id="chat-attach" class="composer-attach" title="attach files (images & any type)">📎</button>
       <textarea id="chat-input" rows="1" placeholder="message your lieutenant…" autocomplete="off"></textarea>
       <button type="submit" title="send">➤</button>
     </form>
@@ -193,8 +196,9 @@
 <!-- artifact viewer -->
 <div id="av-overlay" hidden>
   <div id="av-modal">
-    <div class="av-head"><span class="av-name" id="av-name"></span><button id="av-close" title="close">✕</button></div>
+    <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-close" title="close">✕</button></div>
     <pre id="av-body"></pre>
+    <div id="av-img-wrap" hidden><img id="av-img" alt=""></div>
   </div>
 </div>
 

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -24,7 +24,25 @@ export const api = {
     Object.assign({ column, actor: 'user' }, text ? { text } : {})),
   patchCard: (id, patch) => j('PATCH', '/api/cards/' + encodeURIComponent(id), patch),
   archiveCard: (id, reason) => j('POST', '/api/cards/' + encodeURIComponent(id) + '/archive', { actor: 'user', reason }),
-  feedback: (target, text) => j('POST', '/api/feedback', { target, text }),
+  feedback: (target, text, attachments) => j('POST', '/api/feedback',
+    Object.assign({ target, text }, attachments && attachments.length ? { attachments } : {})),
+  // upload a File → {id, uri, name, mime, size}. base64 is the zero-dep transport.
+  uploadAttachment: (file) => new Promise((resolve, reject) => {
+    const fr = new FileReader();
+    fr.onerror = () => reject(new Error('could not read ' + (file.name || 'file')));
+    fr.onload = () => {
+      const s = String(fr.result);
+      const i = s.indexOf(',');
+      const dataBase64 = i >= 0 ? s.slice(i + 1) : s; // strip the data:...;base64, prefix
+      j('POST', '/api/attachments', {
+        name: file.name || 'file', mime: file.type || 'application/octet-stream', dataBase64,
+      }).then(resolve, reject);
+    };
+    fr.readAsDataURL(file);
+  }),
+  addArtifact: (id, uri, label) => j('POST', '/api/cards/' + encodeURIComponent(id) + '/artifacts',
+    Object.assign({ uri, actor: 'user' }, label ? { label } : {})),
+  removeArtifact: (id, uri) => j('DELETE', '/api/cards/' + encodeURIComponent(id) + '/artifacts', { uri, actor: 'user' }),
   markNotifRead: (seqs) => j('POST', '/api/notifications/read', { user: 'user', seqs }),
   markAllNotifRead: () => j('POST', '/api/notifications/read', { user: 'user', all: true }),
   markThreadRead: (target) => j('POST', '/api/read', { user: 'user', target }),

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -4,9 +4,10 @@
 // premium composer.
 import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
-import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged } from './util.js';
+import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime } from './util.js';
 import { md } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
+import { openAttachment } from './detail.js';
 
 const feedEl = document.getElementById('chat-feed');
 const titleEl = document.getElementById('chat-title');
@@ -78,16 +79,42 @@ backBtn.onclick = backToMain;
 openBtn.onclick = () => { if (S.chatMode && S.chatMode.mode === 'card' && detailOpener) detailOpener(S.chatMode.id); };
 
 // ---------- feed rendering ----------
-function msgHtml(m) {
+// A message's attachments: images render inline (click → full-size viewer),
+// non-images render as a file chip (click → open/download). In a card thread a
+// small 📌 promotes the file to the open card's artifacts (deliberate — the
+// upload itself never did). All handlers are delegated on the feed (see below),
+// so the markup only carries data-* ids; nothing is interpolated into a handler.
+function attachmentsHtml(atts, promote) {
+  if (!Array.isArray(atts) || !atts.length) return '';
+  return '<div class="atts">' + atts.map((a) => {
+    const url = '/api/attachments/' + encodeURIComponent(a.id);
+    const meta = 'data-att-id="' + esc(a.id) + '" data-att-mime="' + esc(a.mime || '') + '" data-att-name="' + esc(a.name || '') + '"';
+    const pin = promote ? '<button type="button" class="att-pin" ' + meta + ' title="add to card artifacts" aria-label="add to card artifacts">📌</button>' : '';
+    if (isImageMime(a.mime)) {
+      return '<div class="att att-img">' +
+        '<img class="att-thumb" src="' + esc(url) + '" alt="' + esc(a.name || '') + '" loading="lazy" data-att-open ' + meta + '>' +
+        pin + '</div>';
+    }
+    return '<div class="att att-file">' +
+      '<span class="att-open" data-att-open ' + meta + ' title="' + esc(a.name || '') + '">' +
+      '<span class="att-ico">📄</span>' +
+      '<span class="att-nm">' + esc(a.name || 'file') + '</span>' +
+      '<span class="att-sz">' + esc(fmtSize(a.size)) + '</span>' +
+      '</span>' + pin + '</div>';
+  }).join('') + '</div>';
+}
+function msgHtml(m, promote) {
   const mine = m.author === USER;
-  const body = mine
+  const hasText = !!(m.text && m.text.trim());
+  const body = !hasText ? '' : (mine
     ? '<div class="md pre">' + esc(m.text) + '</div>'
-    : '<div class="md">' + md(m.text) + '</div>';
+    : '<div class="md">' + md(m.text) + '</div>');
+  const atts = attachmentsHtml(m.attachments, promote);
   const who = mine ? '' : esc(m.author) + ' · ';
   // speak button only on lieutenant bubbles; 🔊 icon, no message text in markup
   const speakBtn = mine ? '' :
     '<button class="msg-speak" type="button" data-speak title="read this message aloud" aria-label="read this message aloud">🔊</button>';
-  return '<div class="msg ' + (mine ? 'user' : 'agent') + '">' + body +
+  return '<div class="msg ' + (mine ? 'user' : 'agent') + '">' + body + atts +
     '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
 }
 function typingHtml(state, name) {
@@ -172,11 +199,13 @@ export function renderChat() {
     setHtmlIfChanged(titleEl, '💬 chat');
     inputEl.placeholder = 'create a lieutenant to start…';
     inputEl.disabled = true;
+    attachBtn.disabled = true;
     if (feed.key !== '') feedEl.innerHTML = '<div class="empty">no lieutenants yet — add one above the board to start commanding</div>';
     feed = { key: '', blocks: [], tail: '' };
     return;
   }
   inputEl.disabled = false;
+  attachBtn.disabled = false;
   const isCard = S.chatMode.mode === 'card';
   const c = isCard ? card(S.chatMode.id) : null;
   const lt = currentLieutenant();
@@ -204,7 +233,7 @@ export function renderChat() {
     const day = m.ts ? dayLabel(m.ts) : '';
     let h = '';
     if (day && day !== lastDay) { h += '<div class="feed-day">' + esc(day) + '</div>'; lastDay = day; }
-    blocks.push({ html: h + msgHtml(m), msg: m.author === USER ? null : m });
+    blocks.push({ html: h + msgHtml(m, isCard), msg: m.author === USER ? null : m });
   };
   if (isCard) {
     for (const m of c.thread || []) push(m);
@@ -276,12 +305,105 @@ function maybeMarkRead(c, target) {
   api.markThreadRead(target).catch(() => { lastMarked = { target: '', ts: '' }; });
 }
 
+// ---------- attachment interaction (delegated on the feed) ----------
+// One listener for every rendered message: open a file/image, or promote it to
+// the open card's artifacts. Delegation survives the append/rebuild fast-path
+// without any per-message re-wiring.
+feedEl.addEventListener('click', (e) => {
+  const pin = e.target.closest('.att-pin');
+  if (pin) {
+    e.stopPropagation();
+    promoteAttachment({ id: pin.dataset.attId, name: pin.dataset.attName, mime: pin.dataset.attMime }, pin);
+    return;
+  }
+  const open = e.target.closest('[data-att-open]');
+  if (open) {
+    e.stopPropagation();
+    openAttachment({ id: open.dataset.attId, name: open.dataset.attName, mime: open.dataset.attMime });
+  }
+});
+// 📌 promote — card threads only. The action is only rendered in a card thread,
+// but re-check S.chatMode so a stale click can never promote to the wrong place.
+async function promoteAttachment(att, btn) {
+  if (!(S.chatMode && S.chatMode.mode === 'card')) return;
+  const cardId = S.chatMode.id;
+  btn.disabled = true;
+  try {
+    await api.addArtifact(cardId, 'attachment://' + att.id, att.name || '');
+    btn.textContent = '✅';
+    btn.title = 'added to card artifacts';
+    setTimeout(() => { btn.textContent = '📌'; btn.disabled = false; btn.title = 'add to card artifacts'; }, 1400);
+  } catch (err) {
+    btn.disabled = false;
+    btn.title = 'failed: ' + err.message;
+  }
+}
+
 // ---------- composer ----------
 // The input clears ONLY once the message is confirmed delivered AND visible in
 // the chat timeline; until then the text is the captain's only copy. On failure
 // it stays in the composer with an error indication — never silently eaten.
 const sendBtn = document.querySelector('#chat-form button[type=submit]');
 const sendErrEl = document.getElementById('chat-send-err');
+const fileInput = document.getElementById('chat-file');
+const attachBtn = document.getElementById('chat-attach');
+const attsEl = document.getElementById('chat-atts');
+
+// Pending (not-yet-uploaded) files staged in the composer. Each is uploaded on
+// send; until then they show as removable chips and are the captain's only copy.
+let pendingAtts = []; // { file, key }
+let attSeq = 0;
+function addPendingFiles(files) {
+  for (const f of files) { if (f) pendingAtts.push({ file: f, key: ++attSeq }); }
+  renderPendingAtts();
+}
+function renderPendingAtts() {
+  if (!pendingAtts.length) { attsEl.hidden = true; attsEl.textContent = ''; return; }
+  attsEl.hidden = false;
+  attsEl.textContent = '';
+  for (const p of pendingAtts) {
+    const chip = document.createElement('span');
+    chip.className = 'att-chip';
+    const isImg = isImageMime(p.file.type);
+    const nm = document.createElement('span');
+    nm.className = 'att-chip-nm';
+    nm.textContent = (isImg ? '🖼 ' : '📄 ') + (p.file.name || 'file');
+    const sz = document.createElement('span');
+    sz.className = 'att-chip-sz';
+    sz.textContent = fmtSize(p.file.size);
+    const x = document.createElement('button');
+    x.type = 'button'; x.className = 'att-chip-x'; x.textContent = '✕'; x.title = 'remove';
+    x.onclick = () => { pendingAtts = pendingAtts.filter((q) => q !== p); renderPendingAtts(); };
+    chip.append(nm, sz, x);
+    attsEl.appendChild(chip);
+  }
+}
+attachBtn.onclick = () => fileInput.click();
+fileInput.onchange = () => { if (fileInput.files && fileInput.files.length) addPendingFiles([...fileInput.files]); fileInput.value = ''; };
+// drag-and-drop onto the composer
+const composerEl = document.getElementById('chat-form');
+['dragenter', 'dragover'].forEach((ev) => composerEl.addEventListener(ev, (e) => {
+  if (inputEl.disabled) return;
+  e.preventDefault(); composerEl.classList.add('drag');
+}));
+['dragleave', 'drop'].forEach((ev) => composerEl.addEventListener(ev, (e) => {
+  e.preventDefault();
+  if (ev === 'dragleave' && composerEl.contains(e.relatedTarget)) return;
+  composerEl.classList.remove('drag');
+}));
+composerEl.addEventListener('drop', (e) => {
+  if (inputEl.disabled) return;
+  const files = e.dataTransfer && e.dataTransfer.files;
+  if (files && files.length) addPendingFiles([...files]);
+});
+// paste-image from the clipboard (screenshots)
+inputEl.addEventListener('paste', (e) => {
+  const items = e.clipboardData && e.clipboardData.items;
+  if (!items) return;
+  const files = [];
+  for (const it of items) { if (it.kind === 'file') { const f = it.getAsFile(); if (f) files.push(f); } }
+  if (files.length) { e.preventDefault(); addPendingFiles(files); }
+});
 
 function autoGrow(t) { t.style.height = 'auto'; t.style.height = Math.min(t.scrollHeight, 132) + 'px'; }
 
@@ -319,16 +441,25 @@ async function send() {
   const target = currentTarget();
   if (!target) return;
   const text = inputEl.value.trim();
-  if (!text) return;
+  const atts = pendingAtts.slice();
+  if (!text && !atts.length) return; // nothing to send
   sending = true;
   clearSendError();
   sendBtn.disabled = true;
   sendBtn.classList.add('sending');
   inputEl.readOnly = true; // the pending text must stay exactly what was sent
   try {
-    await api.feedback(target, text);
-    if (!(await waitForEcho(target, text))) throw new Error('sent, but no echo from the server');
+    // Upload each staged file first (A), then post the message with the returned
+    // attachment metas (the server re-resolves them authoritatively by id).
+    const metas = [];
+    for (const p of atts) metas.push(await api.uploadAttachment(p.file));
+    await api.feedback(target, text, metas);
+    // With text, wait for its echo; attachments-only has no text to match, so the
+    // 200 is the confirmation (the SSE board push renders the bubble a beat later).
+    if (text && !(await waitForEcho(target, text))) throw new Error('sent, but no echo from the server');
     inputEl.value = '';
+    pendingAtts = [];
+    renderPendingAtts();
   } catch (e) {
     setSendError(e.message);
   } finally {

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -449,10 +449,10 @@ async function send() {
   sendBtn.classList.add('sending');
   inputEl.readOnly = true; // the pending text must stay exactly what was sent
   try {
-    // Upload each staged file first (A), then post the message with the returned
-    // attachment metas (the server re-resolves them authoritatively by id).
-    const metas = [];
-    for (const p of atts) metas.push(await api.uploadAttachment(p.file));
+    // Upload the staged files first (A) — concurrently, since they're
+    // independent — then post the message with the returned attachment metas
+    // (the server re-resolves them authoritatively by id).
+    const metas = await Promise.all(atts.map((p) => api.uploadAttachment(p.file)));
     await api.feedback(target, text, metas);
     // With text, wait for its echo; attachments-only has no text to match, so the
     // 200 is the confirmation (the SSE board push renders the bubble a beat later).

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -223,35 +223,46 @@ async function openArtifact(uri) {
 // content, everything else downloads. Served straight from /api/attachments/:id
 // (never /api/artifact — an attachment need not be a promoted card artifact).
 const TEXTY_MIME = /^(text\/|application\/(json|xml|javascript|x-sh|x-yaml|yaml|csv|x-www-form-urlencoded)|image\/svg)/;
+const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i;
+const TEXT_EXT = /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i;
 export async function openAttachment(att) {
   const url = '/api/attachments/' + encodeURIComponent(att.id);
-  avReset(att.name || att.id, att.name);
+  const name = att.name || '';
+  avReset(name || att.id, name);
   avDownload.href = url;
-  avDownload.setAttribute('download', att.name || 'file');
+  avDownload.setAttribute('download', name || 'file');
   avDownload.hidden = false;
-  const isImg = isImageMime(att.mime) || /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(att.name || '');
-  if (isImg) {
-    avBody.hidden = true;
-    avImgWrap.hidden = false;
-    avImg.src = url;
-    avImg.alt = att.name || '';
-    return;
-  }
-  if (TEXTY_MIME.test(String(att.mime || '')) || /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i.test(att.name || '')) {
+  const showImage = () => { avBody.hidden = true; avImgWrap.hidden = false; avImg.src = url; avImg.alt = name; };
+  const showText = (text) => {
+    if (MD_EXT.test(name)) { avBody.className = 'md'; avBody.innerHTML = md(text); }
+    else { avBody.className = ''; avBody.textContent = text; }
+  };
+  const mime = String(att.mime || '');
+  // Decide from mime/extension when possible; a promoted artifact carries only
+  // {uri, label}, so its mime may be unknown — then consult the served
+  // Content-Type before falling back to a download.
+  if (isImageMime(mime) || (!mime && IMG_EXT.test(name))) return showImage();
+  if (TEXTY_MIME.test(mime) || (!mime && TEXT_EXT.test(name))) {
     avBody.textContent = 'loading…';
     try {
       const r = await fetch(url);
       if (!r.ok) throw new Error('HTTP ' + r.status);
-      const text = await r.text();
-      if (MD_EXT.test(att.name || '')) { avBody.className = 'md'; avBody.innerHTML = md(text); }
-      else { avBody.className = ''; avBody.textContent = text; }
-    } catch (e) {
-      avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)';
-    }
+      showText(await r.text());
+    } catch (e) { avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)'; }
     return;
   }
-  // binary: no inline preview — offer the download and say so
-  avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
+  if (mime) { avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.'; return; }
+  // Unknown mime AND an undecided name (e.g. a promoted image with a custom
+  // label): ask the server what it is, then render accordingly.
+  avBody.textContent = 'loading…';
+  try {
+    const r = await fetch(url);
+    if (!r.ok) throw new Error('HTTP ' + r.status);
+    const ct = (r.headers.get('content-type') || '').split(';')[0];
+    if (isImageMime(ct)) return showImage();
+    if (TEXTY_MIME.test(ct)) return showText(await r.text());
+    avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
+  } catch (e) { avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)'; }
 }
 export function closeArtifact() { avOverlay.hidden = true; }
 export function artifactOpen() { return !avOverlay.hidden; }

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -1,6 +1,6 @@
 // card detail: attributes header + markdown body + event timeline (chat lives in the chat panel)
 import { S, card, lieutenant, lieutenants, lieutenantColor, cardStatus, cardActivityTs, cardRecency, kindEmoji, render, toggleFilter, filterSelected } from './state.js';
-import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename, setHtmlIfChanged } from './util.js';
+import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename, setHtmlIfChanged, isImageMime } from './util.js';
 import { md } from './md.js';
 import { api } from './api.js';
 import { labelChipHtml, openLabelPicker, saveCardLabels } from './labels.js';
@@ -176,14 +176,34 @@ bodyInput.onkeydown = (e) => {
 const avOverlay = document.getElementById('av-overlay');
 const avName = document.getElementById('av-name');
 const avBody = document.getElementById('av-body');
+const avImgWrap = document.getElementById('av-img-wrap');
+const avImg = document.getElementById('av-img');
+const avDownload = document.getElementById('av-download');
 const MD_EXT = /\.(md|markdown)$/i;
+// Reset the shared overlay to a clean text-mode state (used by both openers).
+function avReset(name, uri) {
+  avName.textContent = name;
+  avName.title = uri || name;
+  avImgWrap.hidden = true;
+  avImg.removeAttribute('src');
+  avBody.hidden = false;
+  avBody.className = '';
+  avDownload.hidden = true;
+  avOverlay.hidden = false;
+}
 async function openArtifact(uri) {
   const name = uriBasename(uri) || uri;
-  avName.textContent = name;
-  avName.title = uri;
-  avBody.className = ''; // plain until content lands
+  avReset(name, uri);
   avBody.textContent = 'loading…';
-  avOverlay.hidden = false;
+  // A promoted chat attachment resolves through the attachment viewer (images
+  // preview inline, text shows content, binary downloads) rather than the
+  // text-only /api/artifact path.
+  const am = /^attachment:\/\/(.+)$/.exec(uri);
+  if (am) {
+    const c = card(S.openCardId);
+    const at = c && (c.attributes || {}).artifacts && (c.attributes.artifacts.find((a) => a && a.uri === uri));
+    return openAttachment({ id: am[1], name: (at && at.label) || name, mime: '' });
+  }
   try {
     const r = await api.artifact(uri);
     if (MD_EXT.test(name)) {
@@ -198,6 +218,40 @@ async function openArtifact(uri) {
     avBody.className = '';
     avBody.textContent = '⚠ no preview — ' + e.message; // binary / too large / unreadable
   }
+}
+// Open a chat attachment: images preview inline, text-ish types show their
+// content, everything else downloads. Served straight from /api/attachments/:id
+// (never /api/artifact — an attachment need not be a promoted card artifact).
+const TEXTY_MIME = /^(text\/|application\/(json|xml|javascript|x-sh|x-yaml|yaml|csv|x-www-form-urlencoded)|image\/svg)/;
+export async function openAttachment(att) {
+  const url = '/api/attachments/' + encodeURIComponent(att.id);
+  avReset(att.name || att.id, att.name);
+  avDownload.href = url;
+  avDownload.setAttribute('download', att.name || 'file');
+  avDownload.hidden = false;
+  const isImg = isImageMime(att.mime) || /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i.test(att.name || '');
+  if (isImg) {
+    avBody.hidden = true;
+    avImgWrap.hidden = false;
+    avImg.src = url;
+    avImg.alt = att.name || '';
+    return;
+  }
+  if (TEXTY_MIME.test(String(att.mime || '')) || /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i.test(att.name || '')) {
+    avBody.textContent = 'loading…';
+    try {
+      const r = await fetch(url);
+      if (!r.ok) throw new Error('HTTP ' + r.status);
+      const text = await r.text();
+      if (MD_EXT.test(att.name || '')) { avBody.className = 'md'; avBody.innerHTML = md(text); }
+      else { avBody.className = ''; avBody.textContent = text; }
+    } catch (e) {
+      avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)';
+    }
+    return;
+  }
+  // binary: no inline preview — offer the download and say so
+  avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
 }
 export function closeArtifact() { avOverlay.hidden = true; }
 export function artifactOpen() { return !avOverlay.hidden; }

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -77,6 +77,15 @@ export function prChipHtml(pr, withState) {
     ' title="' + esc(pr.url) + ' (' + state + ')">' + esc(label) + '</a>';
 }
 
+// human file size (chat attachment chips)
+export function fmtSize(n) {
+  n = Number(n) || 0;
+  if (n < 1024) return n + ' B';
+  if (n < 1024 * 1024) return (n / 1024).toFixed(n < 10240 ? 1 : 0) + ' KB';
+  return (n / (1024 * 1024)).toFixed(n < 10485760 ? 1 : 0) + ' MB';
+}
+export function isImageMime(m) { return /^image\//.test(String(m || '')); }
+
 // last path segment of a uri/path (query/hash stripped) — the artifact display name
 export function uriBasename(uri) {
   const s = String(uri).replace(/[?#].*$/, '').replace(/\/+$/, '');


### PR DESCRIPTION
Lets the captain and lieutenants attach files to chat. **Images render inline; any other type is stored and delivered to the agent as an absolute filesystem path.** Uploading a file to chat does **not** make it a card artifact — that stays a separate, deliberate action.

## Server (zero-dep, harness-agnostic)
- `POST /api/attachments` — JSON `{name, mime, dataBase64}` (base64 = zero-dep transport). Size cap `BC_UPLOAD_MAX_BYTES` (default 10 MB → **413** over-cap), filename sanitized, stored at `<STATE_DIR>/uploads/<id>__<safeName>` with an `<id>.json` sidecar. Returns `{id, uri, name, mime, size}`, `uri = attachment://<id>`.
- `GET /api/attachments/:id` — streams bytes with the stored `Content-Type`; strictly within the uploads dir, **path traversal blocked**, unknown id → **404**. Backs both inline `<img>` and downloads.
- Card-thread + lieutenant-chat messages carry optional `attachments`; the server **re-resolves them authoritatively by id** (name/mime/size + absolute path) so a message can never inject an arbitrary path.
- **Promote-to-artifact:** `POST`/`DELETE /api/cards/:id/artifacts` (idempotent by uri). `/api/artifact` resolves `attachment://` uris for preview. The existing investigation auto-attach is unchanged; nothing else auto-promotes.
- Uploads dir lives under the git-ignored `.bridge-command/`; noted in a comment that it grows unbounded (prune policy later).

## Agent delivery
`bc-axi drain` / `thread` / `show` surface each attachment's **absolute local path** (+ mime) so the Claude agent can `Read` the file.

## CLI
`bc-axi card artifact add|rm <card-id> --uri <attachment://id | file://path | path> [--label L]` — the lieutenant's deliberate promote tool.

## UI (mobile-first)
- Composer 📎 attach button + **drag-and-drop** + **paste-image**, removable pending chips.
- Inline image rendering (click → lightbox), non-image file chips (click → text preview or download), and a 📌 **"add to card artifacts"** action on chat attachments in card threads.
- Reuses the existing `av-` artifact viewer; matches `app.css`.

## Security / decoupling
Filename sanitization, path-traversal guard on serve, size cap (413). No auth (loopback board, consistent with the rest). **`harness/` untouched** (grep-proven); the agent side is purely a path in the drain/thread text.

## Tests
11 new tests in `test/attachments.test.js` (upload/serve/Content-Type/size, over-cap 413, unknown id 404, traversal blocked, message attachments persisted + absolute path in drain/thread, promote add/rm idempotent, chat upload alone adds no artifact, path→file:// normalization). **Full suite green: 192 pass.** Verified end-to-end live in Chrome (inline images load, lightbox, text preview, composer upload+send, promote) with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)