### PR TITLE
feat: artifact viewer renders images inline (not just text)

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -104,6 +104,18 @@ fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 // Upload size cap (decoded bytes). Over-cap uploads are rejected 413.
 const UPLOAD_MAX_BYTES = parseInt(process.env.BC_UPLOAD_MAX_BYTES, 10) > 0
   ? parseInt(process.env.BC_UPLOAD_MAX_BYTES, 10) : 10 * 1024 * 1024;
+// Raw-artifact byte serve cap. Images/binaries are delivered as bytes to an
+// <img>/download (not inlined as text), so this is far larger than the text
+// preview cap; over-cap → 413.
+const ARTIFACT_MAX_BYTES = parseInt(process.env.BC_ARTIFACT_MAX_BYTES, 10) > 0
+  ? parseInt(process.env.BC_ARTIFACT_MAX_BYTES, 10) : 25 * 1024 * 1024;
+// Extension → Content-Type for raw artifact byte serving. Images render inline
+// in the viewer; pdf may render inline; everything else downloads.
+const ARTIFACT_MIME = {
+  '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
+  '.webp': 'image/webp', '.svg': 'image/svg+xml', '.bmp': 'image/bmp', '.avif': 'image/avif',
+  '.pdf': 'application/pdf',
+};
 
 const DEFAULT_PORT = 4780;
 
@@ -1830,11 +1842,13 @@ const server = http.createServer(async (req, res) => {
       const items = notificationItems(url.searchParams.get('user'));
       return sendJson(res, 200, { items, unread: items.filter((e) => !e.read).length });
     }
-    // Artifact preview: text content of a local artifact, for the UI's popup
-    // viewer. Only a uri listed verbatim in some live card's attributes.artifacts
-    // is servable — never an arbitrary file read.
+    // Artifact serve, for the UI's popup viewer. Only a uri listed verbatim in
+    // some live card's attributes.artifacts is servable — never an arbitrary
+    // file read. Default (no raw): TEXT content of the file. raw=1: the raw
+    // bytes with a real Content-Type, backing the inline <img> and downloads.
     if (route === 'GET /api/artifact') {
       const uri = url.searchParams.get('uri') || '';
+      const raw = url.searchParams.get('raw') === '1' || url.searchParams.get('raw') === 'true';
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
         c.attributes.artifacts.some((a) => a && a.uri === uri));
       if (!listed) return sendJson(res, 404, { error: 'unknown artifact' });
@@ -1842,11 +1856,47 @@ const server = http.createServer(async (req, res) => {
       // via the sidecar; file:// / bare paths read directly.
       let file = uri.startsWith('file://') ? uri.slice('file://'.length) : uri;
       let name = path.basename(file);
+      let attMime = '';
       const am = /^attachment:\/\/(.+)$/.exec(uri);
       if (am) {
         const meta = readAttachmentMeta(am[1]);
         if (!meta) return sendJson(res, 404, { error: 'unknown attachment' });
-        file = meta.path; name = meta.name;
+        file = meta.path; name = meta.name; attMime = meta.mime || '';
+      }
+      if (raw) {
+        // Byte mode. Only a real local file is servable: an attachment path is
+        // already vetted by readAttachmentMeta; a plain artifact must be a
+        // file:// absolute path with no traversal escaping it (path.resolve is
+        // idempotent on a clean absolute path — a `..` segment or a relative
+        // path changes it, so it is rejected).
+        if (!am) {
+          if (!uri.startsWith('file://')) return sendJson(res, 400, { error: 'not a file artifact' });
+          if (path.resolve(file) !== file) return sendJson(res, 400, { error: 'unsafe artifact path' });
+        }
+        let st;
+        try { st = fs.statSync(file); }
+        catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
+        if (!st.isFile()) return sendJson(res, 404, { error: 'not a file' });
+        if (st.size > ARTIFACT_MAX_BYTES) return sendJson(res, 413, { error: 'artifact too large (max ' + ARTIFACT_MAX_BYTES + ' bytes)' });
+        const ext = path.extname(name).toLowerCase();
+        const ctype = am ? (attMime || 'application/octet-stream') : (ARTIFACT_MIME[ext] || 'application/octet-stream');
+        // Images and pdf may render inline in the browser; other binaries
+        // download. Same hardening as the attachments serve: nosniff pins the
+        // Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
+        // is navigated to as a document (inline <img> subresources unaffected).
+        const inline = /^image\//.test(ctype) || ctype === 'application/pdf';
+        let data;
+        try { data = fs.readFileSync(file); }
+        catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
+        res.writeHead(200, {
+          'Content-Type': ctype,
+          'Content-Length': data.length,
+          'Cache-Control': 'private, max-age=31536000, immutable',
+          'X-Content-Type-Options': 'nosniff',
+          'Content-Security-Policy': 'sandbox',
+          'Content-Disposition': (inline ? 'inline' : 'attachment') + '; filename="' + name.replace(/["\\\r\n]/g, '_') + '"',
+        });
+        return res.end(data);
       }
       let data;
       try { data = fs.readFileSync(file); }

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -1,0 +1,122 @@
+'use strict';
+// Artifact viewer serve: the text preview (default) AND the raw byte mode
+// (raw=1) that backs the inline <img> and file downloads. The auth guard (uri
+// must be listed verbatim on a live card), the path/file:// guard, the size cap,
+// and the attachments-grade hardening all hold for raw mode too.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { startServerWithLieutenant, withOwner } = require('./helper');
+
+// A minimal but valid 1x1 PNG.
+const PNG = Buffer.from(
+  '89504e470d0a1a0a0000000d49484452000000010000000108060000001f15c4890000000d4944415478' +
+  '9c6200010000050001' + '0d0a2db400000000' + '49454e44ae426082',
+  'hex'
+);
+
+// Create a card and promote a file at `filePath` (bare path or file:// uri) to
+// its artifacts; returns the stored artifact uri (normalized by the server).
+async function cardWithArtifact(s, uri, label) {
+  const cr = await s.api('POST', '/api/cards', withOwner({ title: 'Deliverable' }));
+  assert.strictEqual(cr.status, 200, JSON.stringify(cr.body));
+  const id = cr.body.card.id;
+  const add = await s.api('POST', '/api/cards/' + id + '/artifacts', { uri, label });
+  assert.strictEqual(add.status, 200, JSON.stringify(add.body));
+  return { id, uri: add.body.artifact.uri };
+}
+
+test('raw=1 for a listed image → 200, image Content-Type, hardening headers, exact bytes', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const img = path.join(s.dir, 'lunch.png');
+    fs.writeFileSync(img, PNG);
+    const { uri } = await cardWithArtifact(s, img, 'almoço do captain');
+
+    const res = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1');
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'image/png');
+    assert.strictEqual(res.headers.get('x-content-type-options'), 'nosniff');
+    assert.strictEqual(res.headers.get('content-security-policy'), 'sandbox');
+    assert.match(res.headers.get('content-disposition') || '', /^inline/);
+    const got = Buffer.from(await res.arrayBuffer());
+    assert.ok(got.equals(PNG), 'served bytes match the file');
+  } finally {
+    await s.stop();
+  }
+});
+
+test('raw=1 for a uri NOT listed on any card → 404 (auth guard holds for raw too)', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const img = path.join(s.dir, 'secret.png');
+    fs.writeFileSync(img, PNG);
+    // never promoted to a card
+    const res = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent('file://' + img) + '&raw=1');
+    assert.strictEqual(res.status, 404);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('raw=1 over BC_ARTIFACT_MAX_BYTES → 413', async () => {
+  const s = await startServerWithLieutenant({ env: { BC_ARTIFACT_MAX_BYTES: '64' } });
+  try {
+    const big = path.join(s.dir, 'big.png');
+    fs.writeFileSync(big, Buffer.alloc(65, 1));
+    const { uri } = await cardWithArtifact(s, big);
+    const res = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1');
+    assert.strictEqual(res.status, 413);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('raw=1 rejects a traversal file:// uri and a non-file:// uri', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    // A file:// uri with a `..` segment passes through the promote normalizer
+    // verbatim; the raw serve must reject it (resolves away from the given path).
+    const trav = await cardWithArtifact(s, 'file:///tmp/../etc/passwd');
+    const r1 = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(trav.uri) + '&raw=1');
+    assert.strictEqual(r1.status, 400);
+
+    // A non-file artifact (http) is not servable as local bytes.
+    const web = await cardWithArtifact(s, 'https://example.com/x.png');
+    const r2 = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(web.uri) + '&raw=1');
+    assert.strictEqual(r2.status, 400);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('non-image binary served as bytes with attachment disposition', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const zip = path.join(s.dir, 'bundle.zip');
+    fs.writeFileSync(zip, Buffer.from('PKrest-of-zip'));
+    const { uri } = await cardWithArtifact(s, zip);
+    const res = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1');
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'application/octet-stream');
+    assert.match(res.headers.get('content-disposition') || '', /^attachment/);
+  } finally {
+    await s.stop();
+  }
+});
+
+test('text artifact still returns the text preview (no raw)', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const md = path.join(s.dir, 'report.md');
+    fs.writeFileSync(md, '# Findings\n\nall good');
+    const { uri } = await cardWithArtifact(s, md, 'report');
+    const res = await s.api('GET', '/api/artifact?uri=' + encodeURIComponent(uri));
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.body.name, 'report.md');
+    assert.match(res.body.content, /# Findings/);
+  } finally {
+    await s.stop();
+  }
+});

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -198,12 +198,32 @@ async function openArtifact(uri) {
   // A promoted chat attachment resolves through the attachment viewer (images
   // preview inline, text shows content, binary downloads) rather than the
   // text-only /api/artifact path.
+  const c = card(S.openCardId);
+  const at = c && (c.attributes || {}).artifacts && (c.attributes.artifacts.find((a) => a && a.uri === uri));
+  const title = (at && at.label) || name; // the curated label shows as the viewer title
+  avName.textContent = title;
   const am = /^attachment:\/\/(.+)$/.exec(uri);
   if (am) {
-    const c = card(S.openCardId);
-    const at = c && (c.attributes || {}).artifacts && (c.attributes.artifacts.find((a) => a && a.uri === uri));
     return openAttachment({ id: am[1], name: (at && at.label) || name, mime: '' });
   }
+  // Non-attachment artifact (file:// / bare path). Dispatch by extension: an
+  // image renders inline from the raw byte serve; text/markdown keeps the text
+  // preview; a known binary offers a download instead of "no preview".
+  const rawUrl = '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1';
+  const offerDownload = (msg) => {
+    avBody.hidden = false; avImgWrap.hidden = true; avImg.removeAttribute('src');
+    avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
+    avBody.className = ''; avBody.textContent = msg;
+  };
+  if (IMG_EXT.test(name)) {
+    avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
+    avBody.hidden = true; avImgWrap.hidden = false; avImg.src = rawUrl; avImg.alt = title;
+    return;
+  }
+  if (BIN_EXT.test(name)) return offerDownload('No inline preview for this file type. Use ⬇ to download.');
+  // Text / markdown (or unknown) → the existing text preview. A genuine binary
+  // (null bytes → 415) or over-cap text (413, "too large") falls through to a
+  // download offer, carrying the server's message.
   try {
     const r = await api.artifact(uri);
     if (MD_EXT.test(name)) {
@@ -215,8 +235,7 @@ async function openArtifact(uri) {
       avBody.textContent = r.content; // non-markdown: plain preformatted text
     }
   } catch (e) {
-    avBody.className = '';
-    avBody.textContent = '⚠ no preview — ' + e.message; // binary / too large / unreadable
+    offerDownload('⚠ no preview — ' + e.message + ' (use ⬇ to download)'); // binary / too large / unreadable
   }
 }
 // Open a chat attachment: images preview inline, text-ish types show their
@@ -225,6 +244,8 @@ async function openArtifact(uri) {
 const TEXTY_MIME = /^(text\/|application\/(json|xml|javascript|x-sh|x-yaml|yaml|csv|x-www-form-urlencoded)|image\/svg)/;
 const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i;
 const TEXT_EXT = /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i;
+// Known binaries — never worth a text preview; offer a download straight away.
+const BIN_EXT = /\.(pdf|zip|gz|tgz|tar|xlsx?|docx?|pptx?|bin|exe|dmg|iso|mp4|mov|webm|mp3|wav|ogg|flac|woff2?|ttf|otf|parquet|pkl|npz|so|dll|wasm|class|jar)$/i;
 export async function openAttachment(att) {
   const url = '/api/attachments/' + encodeURIComponent(att.id);
   const name = att.name || '';


### PR DESCRIPTION
## Problem
Promoting an image to a card's artifacts (PR #21) works and the chip shows, but clicking it opened the **text-only** artifact viewer (built for investigation `.md` reports) → "⚠ no preview — file too large" for a JPEG/PNG.

## Fix
**Server** (`GET /api/artifact`):
- `raw=1` streams the artifact **bytes** with a real `Content-Type` (extension→mime for images/pdf; stored mime for promoted attachments) — backs the inline `<img>` and downloads.
- Same auth guard (uri listed verbatim on a live card) + attachments-grade hardening: `X-Content-Type-Options: nosniff`, `Content-Security-Policy: sandbox`.
- `Content-Disposition: inline` for images/pdf, `attachment` otherwise.
- `file://`-only + path-traversal guard for raw mode.
- `BC_ARTIFACT_MAX_BYTES` (default 25 MB) → 413. Text preview path unchanged.

**UI** (`ui/js/detail.js`):
- **Image** → inline `<img src=…&raw=1>` (reuses the existing `av-img` lightbox slot + CSS).
- **Text/markdown** → existing `<pre>`/md preview (size cap + "too large" message kept).
- **Other binary** (zip/pdf/xlsx/…) → filename + **Download** link (`?raw=1`), not "no preview".
- The curated **label** shows as the viewer title.

## Tests
`test/artifact.test.js`: raw image → 200 + `image/png` + nosniff/CSP + exact bytes; unlisted uri → 404; over-cap → 413; traversal/non-`file://` → rejected; binary disposition; text preview unchanged. **Full suite green (198).** `harness/` untouched.

## Manual verify (real browser)
Image renders inline (title = label "almoço do captain", ⬇ present); `.md` → markdown text preview; `.zip` → download link. No "no preview" for images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)