### PR TITLE
feat: codex harness — run OpenAI Codex CLI workers and lieutenants

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -42,7 +42,7 @@ const opts = {
   name: null, color: null,
   level: null, kind: null, actor: null, reason: null, note: null, attrs: [], labels: [], json: false,
   worker: null, ttl: null, spawn: false, harness: null,
-  mode: null, briefFile: null, resume: false, outcome: null, model: null, park: false,
+  mode: null, briefFile: null, resume: false, outcome: null, model: null, effort: null, park: false,
   uri: null,
 };
 const positional = [];
@@ -75,6 +75,7 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--spawn') opts.spawn = true;
   else if (a === '--harness') opts.harness = argv[++i];
   else if (a === '--model') opts.model = argv[++i];
+  else if (a === '--effort') opts.effort = argv[++i];
   else if (a === '--mode') opts.mode = argv[++i];
   else if (a === '--brief-file') opts.briefFile = argv[++i];
   else if (a === '--resume') opts.resume = true;
@@ -556,12 +557,13 @@ async function cmdArtifactRemove() {
 async function cmdStart() {
   const id = positional[0];
   if (!id) {
-    die('usage: bc-axi card start <card-id> [--brief-file f|-] [--resume] [--harness h] [--model m]\n' +
+    die('usage: bc-axi card start <card-id> [--brief-file f|-] [--resume] [--harness h] [--model m] [--effort l]\n' +
       '  ONE atomic op: provision an isolated worktree, spawn the worker session with the brief\n' +
       '  as launch prompt, bind session/worktree/branch to the card, move it to Working.\n' +
       '  --brief-file adds/overrides the task text (default: the card body).\n' +
       '  --resume reincarnates the card\'s recorded (dead) worker in the same worktree.\n' +
-      '  --model overrides the spawned worker\'s model (e.g. claude-fable-5); ignored with --resume.');
+      '  --model overrides the spawned worker\'s model (e.g. claude-fable-5); ignored with --resume.\n' +
+      '  --effort sets reasoning effort (low|medium|high|xhigh|max) for a claude worker; ignored with --resume.');
   }
   if (opts.resume && opts.briefFile) {
     die('--resume does not deliver briefs: the reincarnated worker keeps its own context and the\n' +
@@ -573,6 +575,7 @@ async function cmdStart() {
   if (opts.resume) body.resume = true;
   if (opts.harness) body.harness = opts.harness;
   if (opts.model) body.model = opts.model;
+  if (opts.effort) body.effort = opts.effort;
   console.log((opts.resume ? 'resuming' : 'starting') + ' a worker for ' + id + ' (worktree + real session — can take a minute)...');
   const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/start', body, 180000);
   const w = r.worker;

--- a/harness/README.md
+++ b/harness/README.md
@@ -60,13 +60,18 @@ is the captain's escape hatch). `resumeId` is the harness-native conversation id
 
 - `port.js` — the contract: `getHarness(name)`, `registerHarness(name, impl)`, `harnessFor(ref)`, `isHarnessRef(ref)`
 - `claude-tmux.js` — the claude implementation over tmux (v0's real harness)
+- `codex-tmux.js` — the OpenAI Codex CLI implementation over tmux
+- `tmux-session.js` — session/window/pane plumbing shared by the tmux adapters
+  (pane lifecycle, naming, launch-and-settle skeleton, turn-end tail, pane viewing)
 - `tmux.js` — shared tmux primitives (composer state, ghost-text stripping, verified submit)
 - `turnend-hook.js` — the Stop-hook relay claude runs at every turn boundary
+- `codex-notify.js` — the notify relay codex runs at every turn boundary
 - `fake.js` — in-memory implementation for unit-testing server code; set
   `BC_FAKE_STATE=<dir>` for file-backed mode (cross-process: spawn writes a
   `<session>.json` marker, sends append to `<session>.sends.jsonl`, and a
   marker on disk counts as a live session)
 - `smoke.js` — real end-to-end smoke (spawns actual claude sessions)
+- `smoke-codex.js` — the codex twin (skips cleanly when codex is not on PATH)
 - `test/` — unit tests (`node --test harness/test/*.test.js`)
 
 ## The claude implementation
@@ -111,14 +116,64 @@ workspace's `.bridge-command/harness/` (`BC_HARNESS_STATE` overrides; the
 global `~/.bridge-command/harness/` is a last-resort for bare embedders only):
 `<session>.prompt`, `<session>.session-id`, `<session>.turnend.jsonl`.
 
+## The codex implementation
+
+Same tmux plumbing as claude (shared `tmux-session.js`); what differs is the
+launch line, the screen signatures, and where the turn-end relay rides
+(command line, not settings file). Verified against codex 0.144.1.
+
+- **spawn** — launches
+  `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust -c notify='[...]' "$(cat <promptfile>)"`.
+  - `--dangerously-bypass-approvals-and-sandbox` is codex's analog of claude's
+    `--dangerously-skip-permissions` (YOLO mode: no sandbox, no approval
+    prompts — the port's full-autonomy rule).
+  - `--dangerously-bypass-hook-trust` suppresses the "Hooks need review"
+    picker a global `~/.codex/hooks.json` otherwise raises at launch; without
+    it spawn hangs on that screen.
+  - a fresh cwd still shows codex's **directory-trust** prompt ("Do you trust
+    the contents of this directory?", accept preselected) even with both
+    bypass flags; launch-settle auto-accepts it with Enter, exactly like
+    claude's folder trust. codex renders inline in the primary screen (no
+    alternate screen), so the settle signatures are matched against the pane
+    TAIL — the accepted trust prompt lingers in scrollback.
+  - `--model <m>` is accepted, so the server's existing `extraArgs` model
+    plumbing works unchanged; the default model comes from
+    `~/.codex/config.toml`.
+- **turn ends + resume id** — one mechanism gives both: `-c notify=[...]`
+  makes codex run `codex-notify.js` at every turn boundary with its payload
+  JSON appended as the LAST argv (`type: "agent-turn-complete"`, `thread-id`,
+  `cwd`, ...). The relay normalizes it into the exact event shape
+  `turnend-hook.js` emits, appends to `<key>.turnend.jsonl` (so `onTurnEnd()`
+  is the shared tail), records the thread-id at `<key>.session-id`, and
+  best-effort POSTs the callback URL. Nothing is written into the worktree —
+  the never-dirty rule holds for free.
+- **resumeId** — the codex thread-id. Unlike claude there is no `--session-id`
+  flag: the ref is born WITHOUT `resumeId` and adopts it from the first
+  turn-end (the server writes it back into the ref; the `.session-id` file is
+  the ground truth either way).
+- **resume** — `codex resume <thread-id>` with the same bypass + notify flags,
+  in a fresh pane under the same name. Resuming continues the SAME thread-id
+  (verified empirically — `smoke-codex.js --resume` asserts it), so refs
+  survive any number of death/resume cycles. Without any id: fresh launch,
+  memory lost.
+- **composer** — codex's prompt glyph is `›` (U+203A), in `tmux.js`
+  `PROMPT_GLYPHS` so verified submit gets its positive ack when the composer
+  clears; codex's busy footer matches the shared `BUSY_RE`
+  ("esc to interrupt").
+
 ## Adding a new harness
 
-Implement the seven verbs in one module and register it:
+Implement the seven verbs in one module and register it (claude and codex are
+already builtins — `getHarness('codex')` just works):
 
 ```js
 const { registerHarness } = require('./port.js');
-registerHarness('codex', require('./codex-tmux.js'));
+registerHarness('goose', require('./goose-tmux.js'));
 ```
+
+For a tmux-TUI harness, start from `tmux-session.js` — codex-tmux.js shows the
+shape: the adapter supplies only its launch line, trust/UI-ready signatures,
+resume semantics, and turn-end relay wiring.
 
 Rules of the road, learned the hard way (from firstmate's verified adapters):
 
@@ -141,6 +196,8 @@ node --test harness/test/*.test.js   # unit: registry, ref shape, fake, ANSI str
 node harness/smoke.js                # REAL e2e: spawn → hook turn-end → reply →
                                      # send → reply → alive/kill (needs tmux + claude)
 node harness/smoke.js --resume       # + kill → resume → memory-recall leg
+node harness/smoke-codex.js          # the codex twin (+ --resume adds the
+                                     # thread-id-continuity leg); skips without codex
 ```
 
 The smoke prints `SMOKE OK` and exits 0 on success; on failure it dumps the

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -16,6 +16,10 @@
 //              id (no fork by default), so the ref survives any number of
 //              death/resume cycles.
 //
+// Session/window/pane plumbing is shared with the other tmux adapters —
+// see tmux-session.js. This module owns only what is claude-specific:
+// launch line, screen signatures, the Stop-hook install, and resume.
+//
 // Verified launch template (mined from firstmate's fm-spawn.sh):
 //   CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions \
 //     --session-id <uuid> "$(cat <promptfile>)"
@@ -31,100 +35,19 @@
 // (and optionally POSTs to a callback URL). onTurnEnd() tails that file.
 
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const crypto = require('node:crypto');
 const { execFile } = require('node:child_process');
 const t = require('./tmux.js');
+const s = require('./tmux-session.js');
 
 const HOOK_SCRIPT = path.join(__dirname, 'turnend-hook.js');
-const SHELLS = new Set(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh']);
 const TRUST_RE = /Yes, I trust this folder|Quick safety check/;
 
-// State dir resolution: opts.stateDir (the server/CLI always pass the
-// workspace's .bridge-command/harness), then BC_HARNESS_STATE, then a global
-// last-resort for bare embedders only — shared across workspaces, so never
-// rely on it from workspace-aware callers.
-function stateDirOf(opts = {}) {
-  const dir = opts.stateDir || process.env.BC_HARNESS_STATE
-    || path.join(os.homedir(), '.bridge-command', 'harness');
-  fs.mkdirSync(dir, { recursive: true });
-  return dir;
-}
-
-function shellQuote(s) {
-  return `'` + String(s).replace(/'/g, `'\\''`) + `'`;
-}
-
-function newSessionName() {
-  return 'bc-' + crypto.randomBytes(3).toString('hex');
-}
-
-// stateKey — the per-agent key for prompt/turnend/session-id state files and
-// the Stop-hook `session` argument. Window-granular agents share their tmux
-// session name with the lieutenant (and sibling workers), so the bare session
-// would collide; the `session:window` form is unique — tmux session names can
-// never contain ':'.
-function stateKey(session, window) {
-  return window ? `${session}:${window}` : session;
-}
-
-// paneTarget — exact-match tmux target for an agent's pane.
-// Session-granular: the bare `=name` exact-match form resolves for
-// session-level commands but NOT for pane-level ones (verified tmux 3.4:
-// `send-keys -t =name` fails with "can't find pane"); the trailing colon
-// (`=name:`) resolves for both. Window-granular: `=session:=window`, exact on
-// both halves, so tmux never pattern-matches or reads the window as an index.
-function paneTarget(session, window) {
-  return window ? `=${session}:=${window}` : `=${session}:`;
-}
-
-async function paneCommand(target) {
-  const out = await t.tryTmux('display-message', '-p', '-t', target, '#{pane_current_command}');
-  return out === null ? null : out.trim();
-}
-
-async function hasSession(session) {
-  return (await t.tryTmux('has-session', '-t', `=${session}:`)) !== null;
-}
-
-// hasWindow — strict window existence. `display-message -t =ses:=missing`
-// does NOT error — tmux silently falls back to another pane (verified tmux
-// 3.4) — so existence is checked against the session's actual window list.
-async function hasWindow(session, window) {
-  const out = await t.tryTmux('list-windows', '-t', `=${session}:`, '-F', '#{window_name}');
-  return out !== null && out.split('\n').includes(window);
-}
-
-function paneExists(session, window) {
-  return window ? hasWindow(session, window) : hasSession(session);
-}
-
-// createPane — bring the agent's pane into existence. Session-granular: a
-// fresh detached session. Window-granular: a new window appended to the
-// session, created with -d so a worker spawn never steals the lieutenant's
-// focus; when the session is not up yet it is created with this window as its
-// first (the accepted lifecycle coupling — no separate fleet session).
-async function createPane(session, window, cwd) {
-  if (!window) {
-    await t.tmux('new-session', '-d', '-s', session, '-c', cwd);
-  } else if (await hasSession(session)) {
-    await t.tmux('new-window', '-d', '-t', `=${session}:`, '-n', window, '-c', cwd);
-  } else {
-    await t.tmux('new-session', '-d', '-s', session, '-n', window, '-c', cwd);
-  }
-}
-
-// killPane — session-granular kills the session; window-granular kills ONLY
-// the window (the lieutenant and sibling workers cohabit the session).
-// Killing a session's last window ends the session — tmux's own semantics.
-async function killPane(session, window) {
-  if (window) {
-    if (await hasWindow(session, window)) await t.tryTmux('kill-window', '-t', paneTarget(session, window));
-  } else if (await hasSession(session)) {
-    await t.tryTmux('kill-session', '-t', paneTarget(session));
-  }
-}
+// UI_READY_RE matches signatures only the main UI renders (composer prompt,
+// busy footer, permission-mode footer) and the trust screen does not.
+const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
+const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'claude' };
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
 // Idempotent; preserves any existing settings/hooks. Also hides the file from
@@ -139,8 +62,8 @@ async function installHooks(cwd, session, stateDir, callbackUrl) {
   } catch {
     settings = {};
   }
-  const command = ['node', shellQuote(HOOK_SCRIPT), shellQuote(stateDir), shellQuote(session)]
-    .concat(callbackUrl ? [shellQuote(callbackUrl)] : [])
+  const command = ['node', s.shellQuote(HOOK_SCRIPT), s.shellQuote(stateDir), s.shellQuote(session)]
+    .concat(callbackUrl ? [s.shellQuote(callbackUrl)] : [])
     .join(' ');
   if (!settings.hooks || typeof settings.hooks !== 'object') settings.hooks = {};
   if (!Array.isArray(settings.hooks.Stop)) settings.hooks.Stop = [];
@@ -170,37 +93,6 @@ async function installHooks(cwd, session, stateDir, callbackUrl) {
   }
 }
 
-// launchAndSettle — send the launch command into the pane, wait for the claude
-// process and its main UI, auto-accepting the folder-trust dialog if it appears
-// (a fresh cwd shows it even with --dangerously-skip-permissions; option
-// "1. Yes, I trust this folder" is preselected, so Enter accepts).
-// UI_READY_RE matches signatures only the main UI renders (composer prompt,
-// busy footer, permission-mode footer) and the trust screen does not.
-const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
-
-async function launchAndSettle(target, launchCmd) {
-  await t.sendLiteral(target, launchCmd);
-  await t.sleep(300);
-  await t.sendKey(target, 'Enter');
-
-  const deadline = Date.now() + 45000;
-  while (Date.now() < deadline) {
-    await t.sleep(500);
-    const cmd = await paneCommand(target);
-    if (cmd === null) throw new Error(`tmux pane ${target} vanished during launch`);
-    if (SHELLS.has(cmd)) continue; // claude not up yet (or it already exited — captured by timeout)
-    const pane = await t.capture(target, 40);
-    if (TRUST_RE.test(pane)) {
-      await t.sendKey(target, 'Enter');
-      await t.sleep(1000);
-      continue;
-    }
-    if (UI_READY_RE.test(pane)) return;
-  }
-  const tail = await t.capture(target, 20);
-  throw new Error(`claude did not start at ${target} within 45s; pane tail:\n${tail}`);
-}
-
 // spawn(cwd, prompt, opts?) -> HarnessRef
 // opts: { session?, window?, stateDir?, callbackUrl?, extraArgs?: string[], installHooks?: boolean }
 // window: birth the agent as a named window inside `session` (which must then
@@ -212,22 +104,10 @@ async function launchAndSettle(target, launchCmd) {
 async function spawn(cwd, prompt, opts = {}) {
   const cwdAbs = path.resolve(cwd);
   if (!fs.existsSync(cwdAbs)) throw new Error(`spawn cwd does not exist: ${cwdAbs}`);
-  const session = opts.session || newSessionName();
-  if (!/^bc-[A-Za-z0-9_-]+$/.test(session)) {
-    throw new Error(`invalid session name "${session}" (must match bc-<id>)`);
-  }
-  const window = opts.window === undefined || opts.window === null ? undefined : String(opts.window);
-  if (window !== undefined && !/^[A-Za-z][A-Za-z0-9_-]*$/.test(window)) {
-    throw new Error(`invalid window name "${window}" (must start with a letter — tmux parses numeric names as window indexes)`);
-  }
-  if (window) {
-    if (await hasWindow(session, window)) throw new Error(`tmux window ${session}:${window} already exists`);
-  } else if (await hasSession(session)) {
-    throw new Error(`tmux session ${session} already exists`);
-  }
-  const stateDir = stateDirOf(opts);
+  const { session, window } = await s.claimPaneNames(opts);
+  const stateDir = s.stateDirOf(opts);
   const resumeId = crypto.randomUUID();
-  const key = stateKey(session, window);
+  const key = s.stateKey(session, window);
 
   if (opts.installHooks !== false) {
     await installHooks(cwdAbs, key, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
@@ -236,16 +116,16 @@ async function spawn(cwd, prompt, opts = {}) {
   const promptFile = path.join(stateDir, `${key}.prompt`);
   fs.writeFileSync(promptFile, prompt);
 
-  await createPane(session, window, cwdAbs);
+  await s.createPane(session, window, cwdAbs);
   try {
-    const extra = (opts.extraArgs || []).map(shellQuote).join(' ');
+    const extra = (opts.extraArgs || []).map(s.shellQuote).join(' ');
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + `claude --dangerously-skip-permissions --session-id ${resumeId} `
       + (extra ? extra + ' ' : '')
-      + `"$(cat ${shellQuote(promptFile)})"`;
-    await launchAndSettle(paneTarget(session, window), launchCmd);
+      + `"$(cat ${s.shellQuote(promptFile)})"`;
+    await s.launchAndSettle(s.paneTarget(session, window), launchCmd, SETTLE);
   } catch (err) {
-    await killPane(session, window);
+    await s.killPane(session, window);
     try { fs.unlinkSync(promptFile); } catch { /* best-effort */ }
     throw err;
   }
@@ -258,9 +138,9 @@ async function spawn(cwd, prompt, opts = {}) {
 // send(ref, text) — type into the session with verified submission.
 // Enter is retried, never the text. Throws when the submit provably failed.
 async function send(ref, text) {
-  const name = stateKey(ref.session, ref.window);
+  const name = s.stateKey(ref.session, ref.window);
   if (!(await alive(ref))) throw new Error(`session ${name} is not alive`);
-  const verdict = await t.submit(paneTarget(ref.session, ref.window), text, {
+  const verdict = await t.submit(s.paneTarget(ref.session, ref.window), text, {
     retries: Number(process.env.BC_SEND_RETRIES || 3),
     enterSleep: Number(process.env.BC_SEND_SLEEP_MS || 400),
   });
@@ -279,9 +159,9 @@ async function send(ref, text) {
 // AND its pane is still running the agent (a pane sitting back at a bare shell
 // means claude exited).
 async function alive(ref) {
-  if (!(await paneExists(ref.session, ref.window))) return false;
-  const cmd = await paneCommand(paneTarget(ref.session, ref.window));
-  return cmd !== null && !SHELLS.has(cmd);
+  if (!(await s.paneExists(ref.session, ref.window))) return false;
+  const cmd = await s.paneCommand(s.paneTarget(ref.session, ref.window));
+  return cmd !== null && !s.SHELLS.has(cmd);
 }
 
 // resumable(ref, opts?) -> bool — would resume(ref) restore memory? True when a
@@ -291,7 +171,7 @@ async function alive(ref) {
 async function resumable(ref, opts = {}) {
   if (ref.resumeId) return true;
   try {
-    return !!fs.readFileSync(path.join(stateDirOf(opts), `${stateKey(ref.session, ref.window)}.session-id`), 'utf8').trim();
+    return !!fs.readFileSync(path.join(s.stateDirOf(opts), `${s.stateKey(ref.session, ref.window)}.session-id`), 'utf8').trim();
   } catch {
     return false;
   }
@@ -303,8 +183,8 @@ async function resumable(ref, opts = {}) {
 // session under the same name. Without any resume id, launches fresh (memory lost).
 async function resume(ref, opts = {}) {
   if (await alive(ref)) return { ...ref };
-  const stateDir = stateDirOf(opts);
-  const key = stateKey(ref.session, ref.window);
+  const stateDir = s.stateDirOf(opts);
+  const key = s.stateKey(ref.session, ref.window);
   let resumeId = ref.resumeId;
   try {
     const rec = fs.readFileSync(path.join(stateDir, `${key}.session-id`), 'utf8').trim();
@@ -312,19 +192,19 @@ async function resume(ref, opts = {}) {
   } catch {
     // no recorded id — fall back to the ref's
   }
-  await killPane(ref.session, ref.window); // clear any dead pane still holding the name
+  await s.killPane(ref.session, ref.window); // clear any dead pane still holding the name
 
   if (opts.installHooks !== false) {
     await installHooks(ref.cwd, key, stateDir, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
   }
-  await createPane(ref.session, ref.window, ref.cwd);
+  await s.createPane(ref.session, ref.window, ref.cwd);
   try {
     const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + 'claude --dangerously-skip-permissions '
       + (resumeId ? `--resume ${resumeId}` : '');
-    await launchAndSettle(paneTarget(ref.session, ref.window), launchCmd.trim());
+    await s.launchAndSettle(s.paneTarget(ref.session, ref.window), launchCmd.trim(), SETTLE);
   } catch (err) {
-    await killPane(ref.session, ref.window);
+    await s.killPane(ref.session, ref.window);
     throw err;
   }
   const out = { harness: 'claude', session: ref.session, cwd: ref.cwd, resumeId };
@@ -339,133 +219,17 @@ async function resume(ref, opts = {}) {
 // purpose — resumeId and the turn-end log are cheap, and a later resume(ref)
 // can still reincarnate the conversation if the kill turns out premature.
 async function kill(ref) {
-  await killPane(ref.session, ref.window);
+  await s.killPane(ref.session, ref.window);
 }
 
-// onTurnEnd(ref, hook) -> unsubscribe()
-// hook(event, ref) fires once per turn boundary; event is the JSON line the
-// Stop hook appended ({ ts, session, event, session_id, cwd }). Only events
-// appended AFTER registration are delivered. fs.watch push with a polling
-// backstop, so no boundary is missed on filesystems with flaky watch.
-function onTurnEnd(ref, hook, opts = {}) {
-  const stateDir = stateDirOf(opts);
-  const file = path.join(stateDir, `${stateKey(ref.session, ref.window)}.turnend.jsonl`);
-  let offset = 0;
-  try {
-    offset = fs.statSync(file).size;
-  } catch {
-    offset = 0;
-  }
-  let closed = false;
-
-  function drain() {
-    if (closed) return;
-    let size;
-    try {
-      size = fs.statSync(file).size;
-    } catch {
-      return;
-    }
-    if (size < offset) offset = 0; // truncated/rotated
-    if (size === offset) return;
-    const fd = fs.openSync(file, 'r');
-    try {
-      const buf = Buffer.alloc(size - offset);
-      fs.readSync(fd, buf, 0, buf.length, offset);
-      offset = size;
-      for (const line of buf.toString('utf8').split('\n')) {
-        if (!line.trim()) continue;
-        let event;
-        try {
-          event = JSON.parse(line);
-        } catch {
-          continue;
-        }
-        try {
-          hook(event, ref);
-        } catch {
-          // a throwing hook must not kill the watcher
-        }
-      }
-    } finally {
-      fs.closeSync(fd);
-    }
-  }
-
-  let watcher = null;
-  try {
-    watcher = fs.watch(stateDir, (_type, name) => {
-      if (name === path.basename(file)) drain();
-    });
-  } catch {
-    watcher = null;
-  }
-  const poll = setInterval(drain, 1000);
-  poll.unref?.();
-
-  return function unsubscribe() {
-    closed = true;
-    clearInterval(poll);
-    watcher?.close();
-  };
-}
-
-// ---------- pane viewing (OPTIONAL capability verbs — see port.js) ----------
-// openPane(ref, { onFrame, intervalMs?, lines? }) -> { close() }
-// Streams the pane's CURRENT RENDERED SCREEN as successive frames: every
-// intervalMs the pane is captured with ANSI styling and scrollback, and
-// onFrame(frame) fires only when the content changed since the last frame.
-// close() stops delivery and releases the interval.
-//
-// Deliberately rendered frames via capture-pane, NOT a pipe-pane byte stream:
-// the target (claude) is a full-screen TUI that repaints in place, so raw pty
-// bytes would need a client-side terminal emulator (xterm.js — a dependency we
-// will not add). capture-pane returns the already-composed screen, works for
-// any TUI, and keeps the client a plain <pre>.
-function openPane(ref, opts = {}) {
-  const onFrame = typeof opts.onFrame === 'function' ? opts.onFrame : () => {};
-  const intervalMs = opts.intervalMs > 0 ? opts.intervalMs : 1000;
-  const lines = opts.lines > 0 ? opts.lines : 200;
-  const target = paneTarget(ref.session, ref.window);
-  let last = null;
-  let closed = false;
-  let busy = false; // never overlap captures — a slow tmux must not stack children
-
-  async function tick() {
-    if (closed || busy) return;
-    busy = true;
-    try {
-      if (!(await paneExists(ref.session, ref.window))) {
-        close();
-        try { onFrame('\n[pane gone]'); } catch { /* subscriber's problem */ }
-        return;
-      }
-      const frame = await t.captureStyled(target, lines);
-      if (closed || frame === null || frame === last) return;
-      last = frame;
-      try { onFrame(frame); } catch { /* a throwing subscriber must not kill the feed */ }
-    } finally {
-      busy = false;
-    }
-  }
-
-  const timer = setInterval(tick, intervalMs);
-  timer.unref?.();
-  tick(); // immediate first frame — the subscriber paints without waiting a tick
-  function close() { closed = true; clearInterval(timer); }
-  return { close };
-}
-
-// paneSnapshot(ref, { lines? }) -> Promise<string> — one-shot styled capture
-// (initial paint / non-streaming fallback). Empty string when unreadable.
-async function paneSnapshot(ref, opts = {}) {
-  const lines = opts.lines > 0 ? opts.lines : 200;
-  const out = await t.captureStyled(paneTarget(ref.session, ref.window), lines);
-  return out === null ? '' : out;
-}
+// onTurnEnd / openPane / paneSnapshot — the shared implementations verbatim
+// (tmux-session.js): the Stop-hook relay writes the same turnend.jsonl shape
+// every tmux adapter tails, and pane viewing is pure capture-pane.
+const { onTurnEnd, openPane, paneSnapshot } = s;
 
 // installHooks is exported beyond the seven port verbs so `bc-axi init` can
 // install the workspace-level Stop hook (session-agnostic; the server dedupes
 // turn-end POSTs by session_id). openPane/paneSnapshot are OPTIONAL capability
-// verbs (port.js) — pane viewing; every tmux specific of the feature lives here.
+// verbs (port.js) — pane viewing; every tmux specific of the feature lives in
+// tmux-session.js.
 module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd, installHooks, openPane, paneSnapshot };

--- a/harness/codex-notify.js
+++ b/harness/codex-notify.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+'use strict';
+// codex-notify.js — the codex turn-end relay (analog of turnend-hook.js).
+//
+// Wired at launch by codex-tmux.js via
+//   -c notify='["node","<this script>","<stateDir>","<key>","<url>"]'
+// codex invokes the program at every turn boundary with its payload JSON
+// APPENDED AS THE FINAL ARGV (not stdin):
+//   { "type": "agent-turn-complete", "thread-id": "<uuid>", "turn-id": "...",
+//     "cwd": "/abs/worktree", "input-messages": [...], "last-assistant-message": "..." }
+//
+// It normalizes that payload into the EXACT event shape the claude Stop-hook
+// relay emits, so the server's /api/turn-end and the harness onTurnEnd() tail
+// consume codex turn boundaries unchanged:
+//   { ts, session: <key>, event: 'turn-end', session_id: <thread-id>, cwd, tmux_session }
+//
+// It does three things, all best-effort and always exiting 0 fast so it can
+// never wedge the agent:
+//   1. records the codex thread-id at <stateDir>/<key>.session-id
+//      (ground truth for harness.resume, refreshed on every turn)
+//   2. appends one JSON line to <stateDir>/<key>.turnend.jsonl —
+//      the marker file harness.onTurnEnd() watches
+//   3. optionally POSTs the event to a callback URL so a server can learn
+//      turn boundaries without polling
+//
+// Usage (as the notify program): node codex-notify.js <stateDir> <key> [url] <payloadJSON>
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+// The relay runs inside the agent's own pane, so its tmux session identifies
+// the session exactly (the server attributes lieutenant turn-ends by it).
+// Empty when not under tmux; never fails the relay when tmux is absent.
+function tmuxSession() {
+  if (!process.env.TMUX) return '';
+  try {
+    return execFileSync('tmux', ['display-message', '-p', '#S'], { encoding: 'utf8' }).trim();
+  } catch {
+    return '';
+  }
+}
+
+async function main() {
+  const argv = process.argv;
+  const stateDir = argv[2];
+  const key = argv[3];
+  // codex appends the payload as the LAST argv; with a url wired the argv is
+  // [node, script, stateDir, key, url, payload], without it one shorter.
+  if (!stateDir || !key || argv.length < 5) return;
+  const url = (argv.length >= 6 ? argv[4] : '') || process.env.BC_TURNEND_URL || '';
+
+  let payload = {};
+  try {
+    payload = JSON.parse(argv[argv.length - 1]);
+  } catch {
+    return; // junk payload: nothing to relay
+  }
+  if (!payload || payload.type !== 'agent-turn-complete') return; // other notify kinds are not turn boundaries
+
+  const event = {
+    ts: new Date().toISOString(),
+    session: key,
+    event: 'turn-end',
+    session_id: payload['thread-id'] || null,
+    cwd: payload.cwd || null,
+    tmux_session: tmuxSession(),
+  };
+
+  try {
+    fs.mkdirSync(stateDir, { recursive: true });
+    if (event.session_id) {
+      fs.writeFileSync(path.join(stateDir, `${key}.session-id`), event.session_id + '\n');
+    }
+    fs.appendFileSync(path.join(stateDir, `${key}.turnend.jsonl`), JSON.stringify(event) + '\n');
+  } catch {
+    // never fail the relay
+  }
+
+  if (url) {
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(event),
+        signal: AbortSignal.timeout(3000),
+      });
+    } catch {
+      // callback is best-effort; the marker file is the reliable channel
+    }
+  }
+}
+
+main().then(() => process.exit(0), () => process.exit(0));

--- a/harness/codex-tmux.js
+++ b/harness/codex-tmux.js
@@ -1,0 +1,199 @@
+'use strict';
+// codex-tmux — the OpenAI Codex CLI implementation of the harness port, over tmux.
+//
+// HarnessRef: { harness: 'codex', session: 'bc-<id>', window?, cwd, resumeId? }
+//   session/window — same tmux addressing as every tmux adapter (tmux-session.js):
+//              session-granular refs own a whole `bc-*` session, window-granular
+//              refs live as a named window inside a shared one (workers inside
+//              their lieutenant's session).
+//   resumeId — the codex THREAD-ID (a uuid). Unlike claude there is no
+//              --session-id flag: codex assigns the id itself, so the ref is
+//              born WITHOUT resumeId and adopts it from the first turn-end
+//              (the notify relay records it to <stateDir>/<key>.session-id and
+//              POSTs it to the server, which writes it back into the ref).
+//              `codex resume <thread-id>` continues the SAME thread (verified
+//              0.144.1 — see smoke-codex.js), so refs survive death/resume.
+//
+// Session/window/pane plumbing is shared with the other tmux adapters — see
+// tmux-session.js. This module owns only what is codex-specific: launch line,
+// screen signatures, the notify relay wiring, and resume.
+//
+// Verified launch template (codex 0.144.1):
+//   codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust \
+//     -c notify='["node","<relay>","<stateDir>","<key>","<url>"]' "$(cat <promptfile>)"
+//   - --dangerously-bypass-approvals-and-sandbox is codex's analog of claude's
+//     --dangerously-skip-permissions (YOLO mode: no sandbox, no approval
+//     prompts — port rule #4, full autonomy at launch).
+//   - --dangerously-bypass-hook-trust suppresses the "Hooks need review"
+//     picker that a global ~/.codex/hooks.json otherwise raises at launch —
+//     without it spawn hangs on that screen.
+//   - -c notify=[...] wires the turn-end relay (codex-notify.js): codex runs
+//     it at every turn boundary with the payload JSON appended as the LAST
+//     argv. One mechanism gives BOTH turn-end detection AND the thread-id for
+//     resume — nothing is written into the worktree (port rule #5 for free).
+//   - the prompt rides in a file, expanded by the pane's shell — no quoting
+//     hazards, no tmux argv length limits (same trick as claude).
+//   - a fresh cwd shows codex's directory-trust prompt even with the bypass
+//     flags ("Do you trust the contents of this directory?", "Yes, continue"
+//     preselected — Enter accepts); launch-settle auto-accepts it, exactly
+//     like claude's folder trust.
+//
+// Turn boundaries: the notify relay appends the SAME event shape the claude
+// Stop hook emits to <stateDir>/<key>.turnend.jsonl, so onTurnEnd() is the
+// shared tail and the server's /api/turn-end needs nothing codex-specific.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const t = require('./tmux.js');
+const s = require('./tmux-session.js');
+
+const NOTIFY_SCRIPT = path.join(__dirname, 'codex-notify.js');
+const TRUST_RE = /Do you trust the contents of this directory|Yes, continue/;
+
+// UI_READY_RE matches signatures only the codex main UI renders: the intro
+// box (">_ OpenAI Codex (vX.Y.Z)"), the YOLO-mode permissions line, or the
+// composer prompt glyph '›' at a line start. The directory-trust screen shows
+// none of these as a line of its own — and trustRe is checked first anyway.
+const UI_READY_RE = /OpenAI Codex \(v|YOLO mode|\n›/;
+const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'codex' };
+
+// The bypass + notify flags every codex launch (spawn AND resume) carries.
+function launchFlags(stateDir, key, callbackUrl) {
+  const notify = ['node', NOTIFY_SCRIPT, stateDir, key].concat(callbackUrl ? [callbackUrl] : []);
+  return '--dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust '
+    + `-c ${s.shellQuote('notify=' + JSON.stringify(notify))}`;
+}
+
+// spawn(cwd, prompt, opts?) -> HarnessRef
+// opts: { session?, window?, stateDir?, callbackUrl?, extraArgs?: string[], installHooks?: boolean }
+// Same opts contract as claude-tmux.js. installHooks is accepted and ignored:
+// codex has no settings-file hook — the notify relay rides the launch line, so
+// there is nothing to install (or clobber) in any cwd.
+// The returned ref carries NO resumeId: codex assigns the thread-id itself and
+// the first notify delivers it (the server adopts it from that turn-end).
+async function spawn(cwd, prompt, opts = {}) {
+  const cwdAbs = path.resolve(cwd);
+  if (!fs.existsSync(cwdAbs)) throw new Error(`spawn cwd does not exist: ${cwdAbs}`);
+  const { session, window } = await s.claimPaneNames(opts);
+  const stateDir = s.stateDirOf(opts);
+  const key = s.stateKey(session, window);
+
+  const promptFile = path.join(stateDir, `${key}.prompt`);
+  fs.writeFileSync(promptFile, prompt);
+
+  await s.createPane(session, window, cwdAbs);
+  try {
+    const extra = (opts.extraArgs || []).map(s.shellQuote).join(' ');
+    const launchCmd = 'codex '
+      + launchFlags(stateDir, key, opts.callbackUrl || process.env.BC_TURNEND_URL || '') + ' '
+      + (extra ? extra + ' ' : '')
+      + `"$(cat ${s.shellQuote(promptFile)})"`;
+    await s.launchAndSettle(s.paneTarget(session, window), launchCmd, SETTLE);
+  } catch (err) {
+    await s.killPane(session, window);
+    try { fs.unlinkSync(promptFile); } catch { /* best-effort */ }
+    throw err;
+  }
+
+  const ref = { harness: 'codex', session, cwd: cwdAbs };
+  if (window) ref.window = window;
+  return ref;
+}
+
+// send(ref, text) — type into the session with verified submission.
+// Enter is retried, never the text. Throws when the submit provably failed.
+// (The '›' composer glyph is in tmux.js PROMPT_GLYPHS so a cleared codex
+// composer reads 'empty' — the positive ack that the submit landed.)
+async function send(ref, text) {
+  const name = s.stateKey(ref.session, ref.window);
+  if (!(await alive(ref))) throw new Error(`session ${name} is not alive`);
+  const verdict = await t.submit(s.paneTarget(ref.session, ref.window), text, {
+    retries: Number(process.env.BC_SEND_RETRIES || 3),
+    enterSleep: Number(process.env.BC_SEND_SLEEP_MS || 400),
+  });
+  if (verdict === 'pending') {
+    throw new Error(`text not submitted to ${name} (Enter swallowed; text left in composer)`);
+  }
+  if (verdict === 'send-failed') {
+    throw new Error(`text not sent to ${name} (tmux send failed)`);
+  }
+  // 'empty' = confirmed; 'unknown' = pane unreadable, assume sent (lenient —
+  // an unreadable pane must not turn a normal send into a false error).
+  await t.sleep(1000); // let the turn spin up so an immediate capture sees it working
+}
+
+// alive(ref) — the ref's session (and window, for window-granular refs) exists
+// AND its pane is still running the agent — same rule as claude: a pane
+// sitting back at a bare shell means codex exited (pane_current_command reads
+// 'codex' while it runs, verified 0.144.1).
+async function alive(ref) {
+  if (!(await s.paneExists(ref.session, ref.window))) return false;
+  const cmd = await s.paneCommand(s.paneTarget(ref.session, ref.window));
+  return cmd !== null && !s.SHELLS.has(cmd);
+}
+
+// resumable(ref, opts?) -> bool — would resume(ref) restore memory? True when
+// a thread-id is recoverable: ref.resumeId, or the relay-recorded session-id
+// file in the state dir. Introspection only — the server uses it to pick
+// resume vs relaunch-with-charter.
+async function resumable(ref, opts = {}) {
+  if (ref.resumeId) return true;
+  try {
+    return !!fs.readFileSync(path.join(s.stateDirOf(opts), `${s.stateKey(ref.session, ref.window)}.session-id`), 'utf8').trim();
+  } catch {
+    return false;
+  }
+}
+
+// resume(ref) -> HarnessRef — reincarnate a dead session with memory when possible.
+// Prefers the relay-recorded thread-id (ground truth, refreshed every turn)
+// over ref.resumeId, kills any leftover dead pane, relaunches
+// `codex resume <thread-id>` with the same bypass + notify flags in a fresh
+// pane under the same name. Resuming continues the SAME thread-id (verified),
+// so the ref stays valid across death/resume cycles — and were codex ever to
+// fork, the next notify would deliver the new id and the server would adopt
+// it. Without any id: fresh `codex` launch (memory lost).
+async function resume(ref, opts = {}) {
+  if (await alive(ref)) return { ...ref };
+  const stateDir = s.stateDirOf(opts);
+  const key = s.stateKey(ref.session, ref.window);
+  let resumeId = ref.resumeId;
+  try {
+    const rec = fs.readFileSync(path.join(stateDir, `${key}.session-id`), 'utf8').trim();
+    if (rec) resumeId = rec;
+  } catch {
+    // no recorded id — fall back to the ref's
+  }
+  await s.killPane(ref.session, ref.window); // clear any dead pane still holding the name
+
+  await s.createPane(ref.session, ref.window, ref.cwd);
+  try {
+    const launchCmd = (resumeId ? `codex resume ${resumeId} ` : 'codex ')
+      + launchFlags(stateDir, key, opts.callbackUrl || process.env.BC_TURNEND_URL || '');
+    await s.launchAndSettle(s.paneTarget(ref.session, ref.window), launchCmd, SETTLE);
+  } catch (err) {
+    await s.killPane(ref.session, ref.window);
+    throw err;
+  }
+  const out = { harness: 'codex', session: ref.session, cwd: ref.cwd };
+  if (resumeId) out.resumeId = resumeId;
+  if (ref.window) out.window = ref.window;
+  return out;
+}
+
+// kill(ref) — end the agent's pane for good. Idempotent: killing a dead or
+// missing one is a no-op. Session-granular refs take the whole session;
+// window-granular refs take ONLY their window. Harness state files are left
+// behind on purpose — the thread-id and turn-end log are cheap, and a later
+// resume(ref) can still reincarnate the conversation if the kill turns out
+// premature.
+async function kill(ref) {
+  await s.killPane(ref.session, ref.window);
+}
+
+// onTurnEnd / openPane / paneSnapshot — the shared implementations verbatim
+// (tmux-session.js): codex-notify.js writes the same turnend.jsonl shape the
+// claude Stop hook does, and pane viewing is pure capture-pane.
+const { onTurnEnd, openPane, paneSnapshot } = s;
+
+module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd, openPane, paneSnapshot };

--- a/harness/port.js
+++ b/harness/port.js
@@ -43,6 +43,7 @@ const VERBS = ['spawn', 'send', 'alive', 'resumable', 'resume', 'kill', 'onTurnE
 // machinery for callers that only use the fake.
 const BUILTINS = {
   claude: './claude-tmux.js',
+  codex: './codex-tmux.js',
   fake: './fake.js',
 };
 

--- a/harness/smoke-codex.js
+++ b/harness/smoke-codex.js
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+'use strict';
+// smoke-codex.js — REAL end-to-end smoke for the codex-tmux harness.
+//
+// Requires: tmux + an authenticated `codex` CLI on PATH; SKIPS (exit 0, loud
+// message) when codex is absent so CI without codex stays green. Costs a few
+// real turns.
+//
+//   node harness/smoke-codex.js             # spawn, notify turn-end, reply, send, alive, kill
+//   node harness/smoke-codex.js --resume    # also exercise the resume-with-memory leg
+//
+// What it proves (the codex ground truth the adapter is built on):
+//   1. spawn() launches codex in a fresh tmux session with the bypass flags,
+//      auto-accepts the directory-trust prompt, settles on the codex UI, and
+//      returns a serializable ref born WITHOUT resumeId
+//   2. the `-c notify=[...]` relay fires at the turn boundary — onTurnEnd()
+//      delivers the normalized event, <key>.session-id records the thread-id
+//   3. the first prompt was processed (BC_CODEX_SMOKE_OK in the pane)
+//   4. send() submits reliably against the '›' composer and the follow-up
+//      gets a reply (BC_CODEX_SMOKE_2)
+//   5. alive() is true while running, false after kill
+//   6. (--resume) resume() reincarnates a killed session via
+//      `codex resume <thread-id>` with memory, and the thread-id stays THE
+//      SAME across the death/resume cycle (refs survive repeated cycles)
+//
+// State is fully isolated in a temp stateDir (passed via opts), so nothing
+// touches ~/.bridge-command or any workspace.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { getHarness } = require('./port.js');
+const t = require('./tmux.js');
+
+const WITH_RESUME = process.argv.includes('--resume');
+const TURN_TIMEOUT_MS = 180000;
+
+function step(msg) {
+  console.log(`[smoke-codex] ${msg}`);
+}
+
+function waitTurnEnd(h, ref, label, opts) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      unsub();
+      reject(new Error(`timed out waiting for turn end (${label})`));
+    }, TURN_TIMEOUT_MS);
+    const unsub = h.onTurnEnd(ref, (event) => {
+      clearTimeout(timer);
+      unsub();
+      resolve(event);
+    }, opts);
+  });
+}
+
+function assertContains(pane, needle, label) {
+  if (!pane.includes(needle)) {
+    throw new Error(`${label}: expected pane to contain "${needle}"; pane tail:\n${pane}`);
+  }
+  step(`${label}: found "${needle}"`);
+}
+
+async function main() {
+  try {
+    execFileSync('codex', ['--version'], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  } catch {
+    console.log('[smoke-codex] SKIP — codex CLI not on PATH');
+    return;
+  }
+
+  const h = getHarness('codex');
+  const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-smoke-codex-'));
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-smoke-codex-state-'));
+  const opts = { stateDir };
+  step(`workdir ${cwd}, stateDir ${stateDir}`);
+  let ref = null;
+  let ok = false;
+  try {
+    // 1. spawn + wait for the first turn end (arrives via the notify relay).
+    //    The fresh cwd exercises the directory-trust auto-accept.
+    step('spawning codex session...');
+    ref = await h.spawn(cwd, 'Reply with exactly: BC_CODEX_SMOKE_OK', opts);
+    step(`spawned ${ref.session} (resumeId at birth: ${ref.resumeId === undefined ? 'none — codex assigns the thread-id' : ref.resumeId})`);
+    if (ref.resumeId !== undefined) {
+      throw new Error('a codex ref must be born WITHOUT resumeId (the thread-id arrives with the first notify)');
+    }
+    if (JSON.stringify(ref) !== JSON.stringify(JSON.parse(JSON.stringify(ref)))) {
+      throw new Error('ref is not JSON-serializable');
+    }
+    const ev1 = await waitTurnEnd(h, ref, 'first turn', opts);
+    step(`turn end via notify relay: ${JSON.stringify(ev1)}`);
+    if (ev1.event !== 'turn-end') throw new Error(`event kind ${ev1.event} != turn-end`);
+    if (ev1.session !== ref.session) throw new Error(`event session ${ev1.session} != ${ref.session}`);
+    if (!ev1.session_id) throw new Error('notify event carries no thread-id (session_id)');
+    const threadId = ev1.session_id;
+
+    // 2. the relay recorded the thread-id — the resume ground truth
+    const recorded = fs.readFileSync(path.join(stateDir, `${ref.session}.session-id`), 'utf8').trim();
+    if (recorded !== threadId) throw new Error(`.session-id file "${recorded}" != notify thread-id "${threadId}"`);
+    step(`thread-id recorded: ${threadId}`);
+    if (!(await h.resumable(ref, opts))) throw new Error('resumable() false with a recorded thread-id');
+    step('resumable() true via the recorded thread-id (ref still carries none)');
+
+    // 3. the prompt was processed
+    assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_CODEX_SMOKE_OK', 'first reply');
+
+    // 4. alive while running (pane_current_command must be codex, not a shell)
+    if (!(await h.alive(ref))) throw new Error('alive() false while session is running');
+    const cmd = (await t.tryTmux('display-message', '-p', '-t', `=${ref.session}:`, '#{pane_current_command}') || '').trim();
+    step(`alive() true while running (pane_current_command=${cmd})`);
+
+    // 5. send a follow-up with verified submission against the '›' composer
+    const secondTurn = waitTurnEnd(h, ref, 'second turn', opts);
+    await h.send(ref, 'Now reply with exactly: BC_CODEX_SMOKE_2');
+    step('follow-up submitted (verified — composer cleared)');
+    await secondTurn;
+    assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_CODEX_SMOKE_2', 'second reply');
+
+    if (WITH_RESUME) {
+      // 6. kill, resume with memory via the thread-id, verify recall AND
+      //    thread-id continuity across the death/resume cycle.
+      step('killing session for the resume leg...');
+      await t.tmux('kill-session', '-t', `=${ref.session}:`);
+      if (await h.alive(ref)) throw new Error('alive() true after kill-session');
+      step('alive() false after kill');
+      ref = await h.resume(ref, opts);
+      step(`resumed ${ref.session} resumeId=${ref.resumeId}`);
+      if (ref.resumeId !== threadId) {
+        throw new Error(`resume() must adopt the recorded thread-id (${ref.resumeId} != ${threadId})`);
+      }
+      if (!(await h.alive(ref))) throw new Error('alive() false after resume');
+      const recallTurn = waitTurnEnd(h, ref, 'recall turn', opts);
+      await h.send(ref, 'What was the FIRST marker I asked you to reply with? Answer with just that marker.');
+      const evRecall = await recallTurn;
+      assertContains(await t.capture(`=${ref.session}:`, 80), 'BC_CODEX_SMOKE_OK', 'resume memory recall');
+      // The empirical continuity check: codex resume keeps the SAME thread-id
+      // (were it to fork, the relay would have refreshed .session-id and the
+      // server would adopt the new id from this very event — but the adapter
+      // is built on non-forking resume, so a fork fails the smoke loudly).
+      if (evRecall.session_id !== threadId) {
+        throw new Error(`codex resume FORKED the thread-id: ${threadId} -> ${evRecall.session_id} — `
+          + 'refs would drift; re-verify `codex resume` semantics');
+      }
+      step(`thread-id continuity confirmed across kill/resume: ${evRecall.session_id}`);
+    }
+
+    // 7. kill; alive flips false
+    await h.kill(ref);
+    if (await h.alive(ref)) throw new Error('alive() true after final kill');
+    step('alive() false after kill');
+
+    ok = true;
+    console.log(`\nSMOKE-CODEX OK${WITH_RESUME ? ' (with resume)' : ''}`);
+  } finally {
+    // cleanup: session, isolated state dir, workdir
+    if (ref) {
+      if (!ok) {
+        console.error(`[smoke-codex] FAILED — pane tail of ${ref.session} (if still up):`);
+        console.error(await t.capture(`=${ref.session}:`, 40));
+      }
+      await t.tryTmux('kill-session', '-t', `=${ref.session}:`);
+    }
+    fs.rmSync(stateDir, { recursive: true, force: true });
+    fs.rmSync(cwd, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error('[smoke-codex] FAILED:', err.message);
+  process.exit(1);
+});

--- a/harness/test/codex-notify.test.js
+++ b/harness/test/codex-notify.test.js
@@ -1,0 +1,133 @@
+'use strict';
+// Unit tests for harness/codex-notify.js — the codex turn-end relay.
+// The relay is exercised the way codex runs it: as a child process with the
+// payload JSON appended as the final argv.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const { execFile } = require('node:child_process');
+
+const RELAY = path.join(__dirname, '..', 'codex-notify.js');
+
+function runRelay(args, env = {}) {
+  return new Promise((resolve, reject) => {
+    execFile('node', [RELAY, ...args], { encoding: 'utf8', env: { ...process.env, ...env } },
+      (err, stdout, stderr) => (err ? reject(Object.assign(err, { stderr })) : resolve({ stdout, stderr })));
+  });
+}
+
+function payload(overrides = {}) {
+  return JSON.stringify({
+    type: 'agent-turn-complete',
+    'thread-id': '019f49a7-81f4-7ad3-822d-3acf8cf81ed6',
+    'turn-id': 'turn-1',
+    cwd: '/abs/worktree',
+    'input-messages': ['do the thing'],
+    'last-assistant-message': 'PONG',
+    ...overrides,
+  });
+}
+
+test('codex-notify normalizes agent-turn-complete into the claude-relay event shape', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  try {
+    await runRelay([dir, 'bc-x1', payload()]);
+    assert.strictEqual(
+      fs.readFileSync(path.join(dir, 'bc-x1.session-id'), 'utf8'),
+      '019f49a7-81f4-7ad3-822d-3acf8cf81ed6\n',
+      'thread-id recorded as the resume ground truth');
+    const lines = fs.readFileSync(path.join(dir, 'bc-x1.turnend.jsonl'), 'utf8').trim().split('\n');
+    assert.strictEqual(lines.length, 1);
+    const ev = JSON.parse(lines[0]);
+    assert.strictEqual(ev.session, 'bc-x1');
+    assert.strictEqual(ev.event, 'turn-end');
+    assert.strictEqual(ev.session_id, '019f49a7-81f4-7ad3-822d-3acf8cf81ed6');
+    assert.strictEqual(ev.cwd, '/abs/worktree');
+    assert.ok(typeof ev.ts === 'string' && !Number.isNaN(Date.parse(ev.ts)), 'ts is a timestamp');
+    assert.ok('tmux_session' in ev, 'tmux_session present (may be empty outside tmux)');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex-notify keys state files by the session:window form for window-granular agents', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  try {
+    await runRelay([dir, 'bc-lt-a:w-card-7', payload()]);
+    assert.ok(fs.existsSync(path.join(dir, 'bc-lt-a:w-card-7.session-id')));
+    const ev = JSON.parse(fs.readFileSync(path.join(dir, 'bc-lt-a:w-card-7.turnend.jsonl'), 'utf8').trim());
+    assert.strictEqual(ev.session, 'bc-lt-a:w-card-7');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex-notify ignores junk payloads and non-turn-complete kinds (still exits 0)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  try {
+    await runRelay([dir, 'bc-x2', 'not json {{{']);
+    await runRelay([dir, 'bc-x2', JSON.stringify({ type: 'something-else', 'thread-id': 'nope' })]);
+    await runRelay([dir, 'bc-x2']); // payload argv missing entirely
+    assert.ok(!fs.existsSync(path.join(dir, 'bc-x2.session-id')), 'no session-id from junk');
+    assert.ok(!fs.existsSync(path.join(dir, 'bc-x2.turnend.jsonl')), 'no event from junk');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex-notify appends (never truncates) and refreshes the session-id every turn', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  try {
+    await runRelay([dir, 'bc-x3', payload()]);
+    await runRelay([dir, 'bc-x3', payload({ 'thread-id': 'fresh-thread-id', 'turn-id': 'turn-2' })]);
+    const lines = fs.readFileSync(path.join(dir, 'bc-x3.turnend.jsonl'), 'utf8').trim().split('\n');
+    assert.strictEqual(lines.length, 2, 'one line per turn boundary');
+    assert.strictEqual(
+      fs.readFileSync(path.join(dir, 'bc-x3.session-id'), 'utf8'),
+      'fresh-thread-id\n',
+      'latest thread-id wins');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex-notify POSTs the event to the url argv (and still writes files)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  const got = [];
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      got.push({ url: req.url, body: JSON.parse(body) });
+      res.end('{"ok":true}');
+    });
+  });
+  try {
+    await new Promise((r) => server.listen(0, '127.0.0.1', r));
+    const url = `http://127.0.0.1:${server.address().port}/api/turn-end`;
+    await runRelay([dir, 'bc-x4', url, payload()]);
+    assert.strictEqual(got.length, 1, 'exactly one POST');
+    assert.strictEqual(got[0].url, '/api/turn-end');
+    assert.strictEqual(got[0].body.session, 'bc-x4');
+    assert.strictEqual(got[0].body.session_id, '019f49a7-81f4-7ad3-822d-3acf8cf81ed6');
+    assert.strictEqual(got[0].body.event, 'turn-end');
+    assert.ok(fs.existsSync(path.join(dir, 'bc-x4.turnend.jsonl')), 'marker file written too');
+  } finally {
+    server.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('codex-notify survives an unreachable callback url (files written, exit 0)', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-notify-'));
+  try {
+    await runRelay([dir, 'bc-x5', 'http://127.0.0.1:1/nope', payload()]);
+    assert.ok(fs.existsSync(path.join(dir, 'bc-x5.turnend.jsonl')));
+    assert.ok(fs.existsSync(path.join(dir, 'bc-x5.session-id')));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/harness/test/codex-tmux.test.js
+++ b/harness/test/codex-tmux.test.js
@@ -1,0 +1,59 @@
+'use strict';
+// Unit tests for the tmux-free parts of harness/codex-tmux.js.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const codex = require('../codex-tmux.js');
+const { isHarnessRef } = require('../port.js');
+
+test('a codex ref is a valid HarnessRef with and without the (late-adopted) resumeId', () => {
+  // Born WITHOUT resumeId — codex assigns the thread-id and the first notify
+  // delivers it — so the bare shape must already round-trip the board state.
+  const born = { harness: 'codex', session: 'bc-ab12cd', cwd: '/tmp/x' };
+  assert.ok(isHarnessRef(born));
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(born)), born);
+  const adopted = { ...born, resumeId: '019f49a7-81f4-7ad3-822d-3acf8cf81ed6', window: 'w-card-7' };
+  assert.ok(isHarnessRef(adopted));
+});
+
+test('resumable: ref.resumeId, else the relay-recorded session-id file, else false', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-state-'));
+  try {
+    const ref = { harness: 'codex', session: 'bc-x1', cwd: '/tmp' };
+    assert.strictEqual(await codex.resumable(ref, { stateDir: dir }), false, 'no id anywhere');
+    assert.strictEqual(await codex.resumable({ ...ref, resumeId: 'thread-1' }, { stateDir: dir }), true, 'ref carries the id');
+    fs.writeFileSync(path.join(dir, 'bc-x1.session-id'), 'thread-recorded\n');
+    assert.strictEqual(await codex.resumable(ref, { stateDir: dir }), true, 'recorded thread-id counts');
+    fs.writeFileSync(path.join(dir, 'bc-x1.session-id'), '\n');
+    assert.strictEqual(await codex.resumable(ref, { stateDir: dir }), false, 'blank record is no id');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('resumable for a window-granular ref reads the session:window keyed record', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-codex-state-'));
+  try {
+    const ref = { harness: 'codex', session: 'bc-lt-a', window: 'w-card-7', cwd: '/tmp' };
+    // a record under the bare session name belongs to the LIEUTENANT, not this worker
+    fs.writeFileSync(path.join(dir, 'bc-lt-a.session-id'), 'thread-lieutenant\n');
+    assert.strictEqual(await codex.resumable(ref, { stateDir: dir }), false, 'never reads the cohabited session record');
+    fs.writeFileSync(path.join(dir, 'bc-lt-a:w-card-7.session-id'), 'thread-worker\n');
+    assert.strictEqual(await codex.resumable(ref, { stateDir: dir }), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('spawn validates the window name before touching tmux: numeric or hostile names refused', async () => {
+  // Same rule as claude (shared tmux-session.js plumbing): tmux parses a
+  // numeric window "name" in a target as a window INDEX.
+  for (const window of ['123', '7', '-w', 'w:x', 'w.x', '']) {
+    await assert.rejects(
+      codex.spawn('/tmp', 'hi', { session: 'bc-t', window }),
+      /invalid window name/,
+      `window "${window}" must be refused`);
+  }
+});

--- a/harness/test/port.test.js
+++ b/harness/test/port.test.js
@@ -8,6 +8,13 @@ test('getHarness returns builtin fake with all seven verbs', () => {
   for (const verb of VERBS) assert.strictEqual(typeof h[verb], 'function', verb);
 });
 
+test('getHarness returns builtin codex with all seven verbs + the pane capability verbs', () => {
+  const h = getHarness('codex');
+  for (const verb of VERBS) assert.strictEqual(typeof h[verb], 'function', verb);
+  assert.strictEqual(typeof h.openPane, 'function', 'openPane (UI pane peek)');
+  assert.strictEqual(typeof h.paneSnapshot, 'function', 'paneSnapshot');
+});
+
 test('getHarness throws on unknown harness', () => {
   assert.throws(() => getHarness('nope'), /unknown harness "nope"/);
 });

--- a/harness/test/tmux.test.js
+++ b/harness/test/tmux.test.js
@@ -2,7 +2,7 @@
 // Unit tests for the pure parts of harness/tmux.js (no tmux server needed).
 const test = require('node:test');
 const assert = require('node:assert');
-const { stripGhost } = require('../tmux.js');
+const { stripGhost, classifyComposerLine } = require('../tmux.js');
 
 const ESC = '\x1b';
 
@@ -42,4 +42,22 @@ test('stripGhost strips non-SGR escape sequences', () => {
 test('stripGhost keeps multibyte glyphs intact', () => {
   assert.strictEqual(stripGhost('❯ café'), '❯ café');
   assert.strictEqual(stripGhost(`${ESC}[2m❯ ghost${ESC}[0m│real│`), '│real│');
+});
+
+test('classifyComposerLine: a cleared claude composer reads empty', () => {
+  assert.strictEqual(classifyComposerLine('❯ '), 'empty');
+  assert.strictEqual(classifyComposerLine('│ > │'), 'empty');
+  assert.strictEqual(classifyComposerLine(`> ${ESC}[2mtry "fix the bug"${ESC}[0m`), 'empty');
+  assert.strictEqual(classifyComposerLine('❯ real text'), 'pending');
+});
+
+test("classifyComposerLine: codex's '›' composer (U+203A) reads empty when cleared", () => {
+  // The bare codex prompt glyph — a submit's positive ack. Without '›' in
+  // PROMPT_GLYPHS this classified as pending and verified-submit saw every
+  // codex send as stuck.
+  assert.strictEqual(classifyComposerLine('› '), 'empty');
+  // codex ghost text renders dim after the glyph
+  assert.strictEqual(classifyComposerLine(`› ${ESC}[2mAsk Codex anything${ESC}[0m`), 'empty');
+  // real unsubmitted text must still read pending
+  assert.strictEqual(classifyComposerLine('› fix the flaky test'), 'pending');
 });

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -1,0 +1,313 @@
+'use strict';
+// tmux-session — session/window/pane plumbing SHARED by the tmux-TUI harness
+// adapters (claude-tmux.js, codex-tmux.js). Everything here is harness-agnostic:
+// pane lifecycle, naming/validation, state-dir resolution, the launch-and-settle
+// skeleton (the adapter supplies its trust-prompt and UI-ready signatures), the
+// turn-end file tail, and the optional pane-viewing verbs. An adapter differs
+// only in its launch line, screen signatures, resume semantics, and turn-end
+// relay wiring.
+//
+// Extracted verbatim from claude-tmux.js (the reference implementation) — the
+// comments below carry that provenance where behavior was learned the hard way.
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const t = require('./tmux.js');
+
+// A pane sitting back at a bare shell means the agent process exited.
+const SHELLS = new Set(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh']);
+
+// State dir resolution: opts.stateDir (the server/CLI always pass the
+// workspace's .bridge-command/harness), then BC_HARNESS_STATE, then a global
+// last-resort for bare embedders only — shared across workspaces, so never
+// rely on it from workspace-aware callers.
+function stateDirOf(opts = {}) {
+  const dir = opts.stateDir || process.env.BC_HARNESS_STATE
+    || path.join(os.homedir(), '.bridge-command', 'harness');
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function shellQuote(s) {
+  return `'` + String(s).replace(/'/g, `'\\''`) + `'`;
+}
+
+function newSessionName() {
+  return 'bc-' + crypto.randomBytes(3).toString('hex');
+}
+
+// stateKey — the per-agent key for prompt/turnend/session-id state files and
+// the turn-end relay's `session` argument. Window-granular agents share their
+// tmux session name with the lieutenant (and sibling workers), so the bare
+// session would collide; the `session:window` form is unique — tmux session
+// names can never contain ':'.
+function stateKey(session, window) {
+  return window ? `${session}:${window}` : session;
+}
+
+// paneTarget — exact-match tmux target for an agent's pane.
+// Session-granular: the bare `=name` exact-match form resolves for
+// session-level commands but NOT for pane-level ones (verified tmux 3.4:
+// `send-keys -t =name` fails with "can't find pane"); the trailing colon
+// (`=name:`) resolves for both. Window-granular: `=session:=window`, exact on
+// both halves, so tmux never pattern-matches or reads the window as an index.
+function paneTarget(session, window) {
+  return window ? `=${session}:=${window}` : `=${session}:`;
+}
+
+async function paneCommand(target) {
+  const out = await t.tryTmux('display-message', '-p', '-t', target, '#{pane_current_command}');
+  return out === null ? null : out.trim();
+}
+
+async function hasSession(session) {
+  return (await t.tryTmux('has-session', '-t', `=${session}:`)) !== null;
+}
+
+// hasWindow — strict window existence. `display-message -t =ses:=missing`
+// does NOT error — tmux silently falls back to another pane (verified tmux
+// 3.4) — so existence is checked against the session's actual window list.
+async function hasWindow(session, window) {
+  const out = await t.tryTmux('list-windows', '-t', `=${session}:`, '-F', '#{window_name}');
+  return out !== null && out.split('\n').includes(window);
+}
+
+function paneExists(session, window) {
+  return window ? hasWindow(session, window) : hasSession(session);
+}
+
+// claimPaneNames — resolve + validate the session/window names for a spawn and
+// refuse names already in use. Window names must start with a letter — a
+// numeric name would be parsed by tmux as a window INDEX (papercut #8).
+async function claimPaneNames(opts = {}) {
+  const session = opts.session || newSessionName();
+  if (!/^bc-[A-Za-z0-9_-]+$/.test(session)) {
+    throw new Error(`invalid session name "${session}" (must match bc-<id>)`);
+  }
+  const window = opts.window === undefined || opts.window === null ? undefined : String(opts.window);
+  if (window !== undefined && !/^[A-Za-z][A-Za-z0-9_-]*$/.test(window)) {
+    throw new Error(`invalid window name "${window}" (must start with a letter — tmux parses numeric names as window indexes)`);
+  }
+  if (window) {
+    if (await hasWindow(session, window)) throw new Error(`tmux window ${session}:${window} already exists`);
+  } else if (await hasSession(session)) {
+    throw new Error(`tmux session ${session} already exists`);
+  }
+  return { session, window };
+}
+
+// createPane — bring the agent's pane into existence. Session-granular: a
+// fresh detached session. Window-granular: a new window appended to the
+// session, created with -d so a worker spawn never steals the lieutenant's
+// focus; when the session is not up yet it is created with this window as its
+// first (the accepted lifecycle coupling — no separate fleet session).
+async function createPane(session, window, cwd) {
+  if (!window) {
+    await t.tmux('new-session', '-d', '-s', session, '-c', cwd);
+  } else if (await hasSession(session)) {
+    await t.tmux('new-window', '-d', '-t', `=${session}:`, '-n', window, '-c', cwd);
+  } else {
+    await t.tmux('new-session', '-d', '-s', session, '-n', window, '-c', cwd);
+  }
+}
+
+// killPane — session-granular kills the session; window-granular kills ONLY
+// the window (the lieutenant and sibling workers cohabit the session).
+// Killing a session's last window ends the session — tmux's own semantics.
+async function killPane(session, window) {
+  if (window) {
+    if (await hasWindow(session, window)) await t.tryTmux('kill-window', '-t', paneTarget(session, window));
+  } else if (await hasSession(session)) {
+    await t.tryTmux('kill-session', '-t', paneTarget(session));
+  }
+}
+
+// launchAndSettle — send the launch command into the pane, wait for the agent
+// process and its main UI, auto-accepting the harness's trust dialog if it
+// appears (a fresh cwd shows one even in bypass mode; the accept option is
+// preselected, so Enter accepts). The adapter supplies:
+//   sig.trustRe — matches the trust screen (checked FIRST: a trust screen may
+//                 contain composer-like glyphs, so it must win over readyRe)
+//   sig.readyRe — matches signatures only the main UI renders
+//   sig.label   — the agent name for error messages ('claude', 'codex')
+//
+// Both signatures are tested against the TAIL of the pane — the current
+// interaction always sits at the bottom. Matching the whole capture broke on
+// inline-scrolling TUIs (codex renders in the primary screen, not the
+// alternate one): the ACCEPTED trust prompt lingers in scrollback, so a
+// full-capture trustRe kept re-matching forever and starved readyRe. claude's
+// alternate-screen dialogs keep their signatures bottom-anchored anyway
+// (composer + footer are the screen's last rows), so the tail is behavior-
+// preserving there.
+const SETTLE_TAIL_LINES = 15;
+
+function paneTail(pane) {
+  return pane.replace(/\s+$/, '').split('\n').slice(-SETTLE_TAIL_LINES).join('\n');
+}
+
+async function launchAndSettle(target, launchCmd, sig) {
+  await t.sendLiteral(target, launchCmd);
+  await t.sleep(300);
+  await t.sendKey(target, 'Enter');
+
+  const deadline = Date.now() + 45000;
+  while (Date.now() < deadline) {
+    await t.sleep(500);
+    const cmd = await paneCommand(target);
+    if (cmd === null) throw new Error(`tmux pane ${target} vanished during launch`);
+    if (SHELLS.has(cmd)) continue; // agent not up yet (or it already exited — captured by timeout)
+    const tail = paneTail(await t.capture(target, 40));
+    if (sig.trustRe.test(tail)) {
+      await t.sendKey(target, 'Enter');
+      await t.sleep(1000);
+      continue;
+    }
+    if (sig.readyRe.test(tail)) return;
+  }
+  const tail = await t.capture(target, 20);
+  throw new Error(`${sig.label} did not start at ${target} within 45s; pane tail:\n${tail}`);
+}
+
+// onTurnEnd(ref, hook) -> unsubscribe()
+// hook(event, ref) fires once per turn boundary; event is the JSON line the
+// harness's relay appended ({ ts, session, event, session_id, cwd }). Only
+// events appended AFTER registration are delivered. fs.watch push with a
+// polling backstop, so no boundary is missed on filesystems with flaky watch.
+function onTurnEnd(ref, hook, opts = {}) {
+  const stateDir = stateDirOf(opts);
+  const file = path.join(stateDir, `${stateKey(ref.session, ref.window)}.turnend.jsonl`);
+  let offset = 0;
+  try {
+    offset = fs.statSync(file).size;
+  } catch {
+    offset = 0;
+  }
+  let closed = false;
+
+  function drain() {
+    if (closed) return;
+    let size;
+    try {
+      size = fs.statSync(file).size;
+    } catch {
+      return;
+    }
+    if (size < offset) offset = 0; // truncated/rotated
+    if (size === offset) return;
+    const fd = fs.openSync(file, 'r');
+    try {
+      const buf = Buffer.alloc(size - offset);
+      fs.readSync(fd, buf, 0, buf.length, offset);
+      offset = size;
+      for (const line of buf.toString('utf8').split('\n')) {
+        if (!line.trim()) continue;
+        let event;
+        try {
+          event = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        try {
+          hook(event, ref);
+        } catch {
+          // a throwing hook must not kill the watcher
+        }
+      }
+    } finally {
+      fs.closeSync(fd);
+    }
+  }
+
+  let watcher = null;
+  try {
+    watcher = fs.watch(stateDir, (_type, name) => {
+      if (name === path.basename(file)) drain();
+    });
+  } catch {
+    watcher = null;
+  }
+  const poll = setInterval(drain, 1000);
+  poll.unref?.();
+
+  return function unsubscribe() {
+    closed = true;
+    clearInterval(poll);
+    watcher?.close();
+  };
+}
+
+// ---------- pane viewing (OPTIONAL capability verbs — see port.js) ----------
+// openPane(ref, { onFrame, intervalMs?, lines? }) -> { close() }
+// Streams the pane's CURRENT RENDERED SCREEN as successive frames: every
+// intervalMs the pane is captured with ANSI styling and scrollback, and
+// onFrame(frame) fires only when the content changed since the last frame.
+// close() stops delivery and releases the interval.
+//
+// Deliberately rendered frames via capture-pane, NOT a pipe-pane byte stream:
+// the target is a full-screen TUI that repaints in place, so raw pty bytes
+// would need a client-side terminal emulator (xterm.js — a dependency we
+// will not add). capture-pane returns the already-composed screen, works for
+// any TUI, and keeps the client a plain <pre>.
+function openPane(ref, opts = {}) {
+  const onFrame = typeof opts.onFrame === 'function' ? opts.onFrame : () => {};
+  const intervalMs = opts.intervalMs > 0 ? opts.intervalMs : 1000;
+  const lines = opts.lines > 0 ? opts.lines : 200;
+  const target = paneTarget(ref.session, ref.window);
+  let last = null;
+  let closed = false;
+  let busy = false; // never overlap captures — a slow tmux must not stack children
+
+  async function tick() {
+    if (closed || busy) return;
+    busy = true;
+    try {
+      if (!(await paneExists(ref.session, ref.window))) {
+        close();
+        try { onFrame('\n[pane gone]'); } catch { /* subscriber's problem */ }
+        return;
+      }
+      const frame = await t.captureStyled(target, lines);
+      if (closed || frame === null || frame === last) return;
+      last = frame;
+      try { onFrame(frame); } catch { /* a throwing subscriber must not kill the feed */ }
+    } finally {
+      busy = false;
+    }
+  }
+
+  const timer = setInterval(tick, intervalMs);
+  timer.unref?.();
+  tick(); // immediate first frame — the subscriber paints without waiting a tick
+  function close() { closed = true; clearInterval(timer); }
+  return { close };
+}
+
+// paneSnapshot(ref, { lines? }) -> Promise<string> — one-shot styled capture
+// (initial paint / non-streaming fallback). Empty string when unreadable.
+async function paneSnapshot(ref, opts = {}) {
+  const lines = opts.lines > 0 ? opts.lines : 200;
+  const out = await t.captureStyled(paneTarget(ref.session, ref.window), lines);
+  return out === null ? '' : out;
+}
+
+module.exports = {
+  SHELLS,
+  stateDirOf,
+  shellQuote,
+  newSessionName,
+  stateKey,
+  paneTarget,
+  paneCommand,
+  hasSession,
+  hasWindow,
+  paneExists,
+  claimPaneNames,
+  createPane,
+  killPane,
+  launchAndSettle,
+  onTurnEnd,
+  openPane,
+  paneSnapshot,
+};

--- a/harness/tmux.js
+++ b/harness/tmux.js
@@ -22,7 +22,9 @@
 const { execFile } = require('node:child_process');
 
 const BUSY_RE = /esc (to )?interrupt|Working\.\.\./i;
-const PROMPT_GLYPHS = new Set(['>', '❯' /* ❯ */, '$', '%', '#']);
+// '›' (U+203A) is codex's composer prompt; without it a cleared codex composer
+// would classify as pending and verified-submit would read every send as stuck.
+const PROMPT_GLYPHS = new Set(['>', '❯' /* ❯ */, '›' /* U+203A, codex */, '$', '%', '#']);
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));
@@ -109,6 +111,19 @@ function stripGhost(line) {
   return out;
 }
 
+// classifyComposerLine(raw) -> 'empty' | 'pending' — the pure half of
+// composerState: classify one styled cursor-line capture after stripping
+// ghost text, box borders, prompt glyphs, and busy footers.
+function classifyComposerLine(raw) {
+  let s = stripGhost(raw.replace(/\n$/, ''));
+  // Strip composer box borders (claude/codex draw "│ … │"; some TUIs use ┃ or |).
+  s = s.replace(/[│┃|]/g, '').trim();
+  if (s === '') return 'empty';
+  if (PROMPT_GLYPHS.has(s)) return 'empty';
+  if (BUSY_RE.test(s)) return 'empty'; // busy footer landing on the cursor line
+  return 'pending';
+}
+
 // composerState(target) -> 'empty' | 'pending' | 'unknown'
 //   empty   — no pending input (blank, bare prompt glyph, busy footer, or only
 //             ghost text). Safe to inject; also the positive ack that a submit landed.
@@ -120,13 +135,7 @@ async function composerState(target) {
   const row = cy.trim();
   const raw = await tryTmux('capture-pane', '-e', '-p', '-t', target, '-S', row, '-E', row);
   if (raw === null) return 'unknown';
-  let s = stripGhost(raw.replace(/\n$/, ''));
-  // Strip composer box borders (claude/codex draw "│ … │"; some TUIs use ┃ or |).
-  s = s.replace(/[│┃|]/g, '').trim();
-  if (s === '') return 'empty';
-  if (PROMPT_GLYPHS.has(s)) return 'empty';
-  if (BUSY_RE.test(s)) return 'empty'; // busy footer landing on the cursor line
-  return 'pending';
+  return classifyComposerLine(raw);
 }
 
 // paneIsBusy(target) — do the last few non-blank lines of the pane show a
@@ -205,6 +214,7 @@ module.exports = {
   tryTmux,
   sleep,
   stripGhost,
+  classifyComposerLine,
   composerState,
   paneIsBusy,
   capture,

--- a/server/server.js
+++ b/server/server.js
@@ -1405,7 +1405,10 @@ async function doStartCard(card, body) {
     cli: path.join(__dirname, '..', 'cli', 'bc-axi'),
   });
   const spawnOpts = { session, window, stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL };
-  if (body && body.model) spawnOpts.extraArgs = ['--model', String(body.model)];
+  const extraArgs = [];
+  if (body && body.model) extraArgs.push('--model', String(body.model));
+  if (body && body.effort) extraArgs.push('--effort', String(body.effort));
+  if (extraArgs.length) spawnOpts.extraArgs = extraArgs;
   let ref;
   try {
     ref = await impl.spawn(wt.path, prompt, spawnOpts);


### PR DESCRIPTION
Adds the **codex** builtin to the harness port so the board spawns codex-driven sessions exactly like claude ones — both **workers** (`card start <id> --harness codex`) and **lieutenants** (`lieutenant create --spawn --harness codex`). Zero new npm deps; the `--harness` CLI/server plumbing already existed end to end — this PR is the adapter + registration.

## What's in it

- **`harness/codex-tmux.js`** — the seven port verbs + `openPane`/`paneSnapshot`. Launch: `codex --dangerously-bypass-approvals-and-sandbox --dangerously-bypass-hook-trust -c notify=[...] "$(cat <promptfile>)"`. Auto-accepts codex's directory-trust prompt at spawn. Refs are born **without** `resumeId` (codex assigns the thread-id; the server adopts it from the first turn-end). `resume` = `codex resume <thread-id>`, which keeps the **same** thread-id (verified empirically), so refs survive death/resume cycles.
- **`harness/codex-notify.js`** — the notify relay: codex appends its payload as the last argv; normalized into the exact event shape the claude Stop-hook relay emits (`.turnend.jsonl` + `.session-id` + callback POST), so `/api/turn-end` and `onTurnEnd()` needed **zero changes**.
- **`harness/tmux-session.js`** — session/window/pane plumbing extracted verbatim from claude-tmux.js and shared by both adapters. claude-tmux.js keeps only claude specifics.
- **launch-and-settle tail fix** — trust/ready signatures are now matched against the pane **tail**: codex renders inline in the primary screen, so the accepted trust prompt lingers in scrollback and a full-capture match looped forever (Enter spam → 45s timeout). claude's signatures are bottom-anchored, so no behavior change there.
- **`harness/tmux.js`** — codex's `›` (U+203A) composer glyph added to `PROMPT_GLYPHS` (verified-submit's positive ack); pure `classifyComposerLine()` extracted for unit tests.
- **`harness/smoke-codex.js`** — real e2e smoke, skips cleanly without codex on PATH.
- **README** — codex implementation documented (flags, dir-trust, notify turn-end, thread-id resume).

## Verification

- Unit suite: **236/236 green** (`node --test harness/test/*.test.js test/*.test.js`; `stale.test.js` re-run alone per its load-sensitivity).
- `node harness/smoke.js --resume` → **SMOKE OK** (claude unaffected, re-run after the shared settle change).
- `node harness/smoke-codex.js --resume` → **SMOKE-CODEX OK**: settle past dir-trust, notify turn-end lands (`.session-id` = thread-id), verified send clears the `›` composer, alive/kill, resume with memory recall, **thread-id continuity across kill/resume**.
- Board-level on a throwaway workspace: codex **lieutenant** + codex **worker** (window-granular, inside the lieutenant's session) spawned via `--harness codex`; turn-end `resumeId` adoption for both; `worker send` steering; `worker pause`; **server restart** then `card start --resume` with memory intact; **supervise respawn** of a killed codex lieutenant (resume path, same thread-id); pane-peek SSE streaming codex frames.
- Grep-proof: claude launch/resume lines, `TRUST_RE`/`UI_READY_RE` byte-identical; zero codex references in claude-tmux.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)