### PR TITLE
feat: UI harness picker for new lieutenants + harness/model hint on cards

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1369,7 +1369,9 @@ async function doStartCard(card, body) {
   const project = findProject(String(repoAttr));
   if (!project) return { error: 'unregistered project: ' + repoAttr + ' (register it: bc-axi project add <url|path> --mode <mode>)' };
 
-  const harnessName = String((body && body.harness) || readConfig().harness || 'claude');
+  // Harness precedence: explicit CLI --harness wins, then the card's stored
+  // hint (attributes.harness, set from the new-card modal), then config/default.
+  const harnessName = String((body && body.harness) || (card.attributes && card.attributes.harness) || readConfig().harness || 'claude');
   let impl;
   try { impl = getHarness(harnessName); } catch (e) { return { error: String((e && e.message) || e) }; }
 
@@ -1406,7 +1408,10 @@ async function doStartCard(card, body) {
   });
   const spawnOpts = { session, window, stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL };
   const extraArgs = [];
-  if (body && body.model) extraArgs.push('--model', String(body.model));
+  // Model precedence mirrors harness: explicit --model wins, else the card's
+  // stored hint (attributes.model, set from the new-card modal).
+  const modelHint = (body && body.model) || (card.attributes && card.attributes.model);
+  if (modelHint) extraArgs.push('--model', String(modelHint));
   if (body && body.effort) extraArgs.push('--effort', String(body.effort));
   if (extraArgs.length) spawnOpts.extraArgs = extraArgs;
   let ref;

--- a/test/recording-harness.js
+++ b/test/recording-harness.js
@@ -1,0 +1,22 @@
+'use strict';
+// Preloaded into the SERVER process (via NODE_OPTIONS=--require) by the
+// card-start harness/model fallback test. Registers a 'recfake' harness: the
+// real fake plus a capture of the extraArgs card.start builds (so a test can
+// assert the --model extraArg the stored hint produces). Lives in test/ — the
+// harness port (harness/) stays untouched; this only *registers* through it.
+const fs = require('node:fs');
+const { registerHarness } = require('../harness/port.js');
+const fake = require('../harness/fake.js');
+
+// Where to record the last spawn's extraArgs (JSON). The test reads it after
+// each card.start to see what --model (if any) was plumbed through.
+const OUT = process.env.BC_REC_EXTRAARGS || '';
+
+const recfake = Object.assign({}, fake, {
+  async spawn(cwd, prompt, opts = {}) {
+    if (OUT) fs.writeFileSync(OUT, JSON.stringify({ extraArgs: opts.extraArgs || [] }) + '\n');
+    return fake.spawn(cwd, prompt, opts);
+  },
+});
+
+registerHarness('recfake', recfake);

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -440,3 +440,60 @@ test('card start --resume refuses a brief and points at worker send (API + CLI)'
     assert.match(cli.stderr, /worker send rez/);
   } finally { await teardown(); }
 });
+
+// The new-card modal stores an optional harness/model hint on the card
+// (attributes.harness / attributes.model). card.start honors them as a
+// FALLBACK: an explicit CLI --harness/--model still wins. Observed through a
+// 'recfake' harness preloaded into the server process (test/recording-harness.js
+// via NODE_OPTIONS) that captures the extraArgs card.start builds — the harness
+// port (harness/) itself stays untouched.
+test('card start honors card.attributes.harness/.model as a fallback; explicit body wins', async () => {
+  const recFile = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'bc-rec-')), 'extraargs.json');
+  const preload = path.join(__dirname, 'recording-harness.js');
+  const { s, teardown } = await boot({
+    NODE_OPTIONS: '--require ' + preload,
+    BC_REC_EXTRAARGS: recFile,
+  });
+  const readExtra = () => JSON.parse(fs.readFileSync(recFile, 'utf8')).extraArgs;
+  const clearExtra = () => { try { fs.unlinkSync(recFile); } catch (e) {} };
+  try {
+    // (a) fallback: no body harness/model → the card's stored hint is used.
+    // recfake is reachable ONLY via attributes.harness, so its extraArgs file
+    // being written proves the harness fallback fired; the --model proves the
+    // model fallback fired.
+    await s.api('POST', '/api/cards', withOwner({
+      title: 'Hint A', id: 'hint-a',
+      attributes: { repo: 'proj', harness: 'recfake', model: 'stored-model' },
+    }));
+    clearExtra();
+    let r = await s.api('POST', '/api/cards/hint-a/start', {});
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.deepStrictEqual(readExtra(), ['--model', 'stored-model']);
+
+    // (b) explicit body.model overrides the stored attributes.model.
+    await s.api('POST', '/api/cards', withOwner({
+      title: 'Hint B', id: 'hint-b',
+      attributes: { repo: 'proj', harness: 'recfake', model: 'stored-model' },
+    }));
+    clearExtra();
+    r = await s.api('POST', '/api/cards/hint-b/start', { model: 'cli-model' });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.deepStrictEqual(readExtra(), ['--model', 'cli-model']);
+
+    // (c) explicit body.harness overrides attributes.harness. attributes names
+    // the plain 'fake' (which never writes the extraArgs file); body picks
+    // recfake — the file IS written, proving body.harness won. No body.model,
+    // so attributes.model still supplies the fallback --model.
+    await s.api('POST', '/api/cards', withOwner({
+      title: 'Hint C', id: 'hint-c',
+      attributes: { repo: 'proj', harness: 'fake', model: 'stored-model' },
+    }));
+    clearExtra();
+    r = await s.api('POST', '/api/cards/hint-c/start', { harness: 'recfake' });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    assert.deepStrictEqual(readExtra(), ['--model', 'stored-model']);
+  } finally {
+    await teardown();
+    fs.rmSync(path.dirname(recFile), { recursive: true, force: true });
+  }
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -320,6 +320,11 @@ body.resizing { user-select: none; cursor: col-resize; }
 .tile .t-owner:hover, .tile .t-owner.active { color: var(--text); }
 .tile .t-owner .dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
 .tile .t-repo { max-width: 45%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* harness/model start-hint badge (attributes.harness / attributes.model) */
+.tile .t-harness {
+  font-family: var(--mono); font-size: 10.5px; padding: 1px 6px; border-radius: 999px;
+  border: 1px solid var(--line); color: var(--dim); white-space: nowrap; flex: none;
+}
 .tile .t-ago { font-family: var(--mono); font-size: 11px; }
 .tile .t-ind { display: inline-flex; align-items: center; gap: 1px; }
 .tile .t-unread { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); flex: none; box-shadow: 0 0 6px var(--accent); }
@@ -623,12 +628,13 @@ a.a-uri { color: var(--accent); }
   box-shadow: var(--shadow); animation: pop-in .15s ease-out;
 }
 .nc-title { font-weight: 650; font-size: 14px; }
-#nc-name, #nc-body, #nc-type, #nc-owner {
+#nc-name, #nc-body, #nc-type, #nc-owner, #nc-harness, #nc-model {
   background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
   padding: 8px 11px; font-size: 13px; outline: none; width: 100%;
 }
-#nc-name:focus, #nc-body:focus, #nc-type:focus, #nc-owner:focus { border-color: var(--accent2); }
-#nc-type, #nc-owner { cursor: pointer; }
+#nc-name:focus, #nc-body:focus, #nc-type:focus, #nc-owner:focus, #nc-harness:focus, #nc-model:focus { border-color: var(--accent2); }
+#nc-type, #nc-owner, #nc-harness { cursor: pointer; }
+#nc-harness { flex: none; width: auto; min-width: 108px; }
 #nc-body { resize: vertical; min-height: 80px; font-family: var(--mono); font-size: 12px; }
 .nc-actions { display: flex; gap: 8px; justify-content: flex-end; }
 #nc-cancel { color: var(--dim); border: 1px solid var(--line); border-radius: 7px; padding: 6px 13px; font-size: 12.5px; }
@@ -648,11 +654,12 @@ a.a-uri { color: var(--accent); }
 }
 .lt-row { display: flex; gap: 8px; align-items: center; }
 #lt-color { width: 38px; height: 34px; padding: 2px; border: 1px solid var(--line); border-radius: 8px; background: var(--panel); cursor: pointer; flex: none; }
-#lt-name, #lt-charter {
+#lt-name, #lt-charter, #lt-harness {
   background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
   padding: 8px 11px; font-size: 13px; outline: none; width: 100%;
 }
-#lt-name:focus, #lt-charter:focus { border-color: var(--accent2); }
+#lt-name:focus, #lt-charter:focus, #lt-harness:focus { border-color: var(--accent2); }
+#lt-harness { flex: none; width: auto; min-width: 92px; cursor: pointer; }
 #lt-charter { resize: vertical; min-height: 80px; font-family: var(--mono); font-size: 12px; }
 #lt-cancel { color: var(--dim); border: 1px solid var(--line); border-radius: 7px; padding: 6px 13px; font-size: 12.5px; }
 #lt-cancel:hover { color: var(--text); }

--- a/ui/index.html
+++ b/ui/index.html
@@ -156,6 +156,14 @@
       <option value="investigation">🕵️ investigation</option>
     </select>
     <textarea id="nc-body" placeholder="body (markdown, optional)" rows="5"></textarea>
+    <div class="lt-row">
+      <select id="nc-harness" title="harness hint (honored when the worker starts)">
+        <option value="">— harness</option>
+        <option value="claude">claude</option>
+        <option value="codex">codex</option>
+      </select>
+      <input id="nc-model" placeholder="model (optional)" autocomplete="off">
+    </div>
     <div class="nc-actions">
       <button type="button" id="nc-cancel">cancel</button>
       <button type="submit" id="nc-create">create</button>
@@ -170,6 +178,10 @@
     <div class="lt-row">
       <input id="lt-color" type="color" value="#58b6ff" title="lieutenant color">
       <input id="lt-name" placeholder="name" autocomplete="off" required>
+      <select id="lt-harness" title="agent harness">
+        <option value="claude" selected>claude</option>
+        <option value="codex">codex</option>
+      </select>
     </div>
     <textarea id="lt-charter" placeholder="charter — the standing mission (markdown, optional)" rows="5"></textarea>
     <div class="nc-actions">

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -91,6 +91,12 @@ function openLtMenu(ltId, x, y) {
 function tileHtml(c) {
   const at = c.attributes || {};
   const repo = at.repo || '';
+  // harness/model hint (set from the new-card modal) — a small badge so the
+  // board tells the truth about how this card will start its worker
+  const hintTxt = [at.harness, at.model].filter(Boolean).join(' · ');
+  const hint = hintTxt
+    ? '<span class="t-harness" title="starts with ' + esc(hintTxt) + '">' + esc(hintTxt) + '</span>'
+    : '';
   const msgs = (c.thread || []).length;
   const st = cardStatus(c);
   // "the lieutenant owes you a reply" balloon: SAME source as the chat typing
@@ -138,6 +144,7 @@ function tileHtml(c) {
     '<span class="t-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) +
       '" title="filter by lieutenant"><span class="dot" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span>' +
     (repo ? '<span class="t-repo" title="repo">' + esc(repo) + '</span>' : '') +
+    hint +
     '<span class="grow"></span>' +
     (hasLink ? '<span class="t-ind" title="has link">📎</span>' : '') +
     (msgs ? '<span class="t-ind" title="' + msgs + ' messages">💬' + msgs + '</span>' : '') +
@@ -301,6 +308,8 @@ export function openNewCard(columnId) {
   }
   document.getElementById('nc-name').value = '';
   document.getElementById('nc-body').value = '';
+  document.getElementById('nc-harness').value = '';
+  document.getElementById('nc-model').value = '';
   ncOverlay.hidden = false;
   document.getElementById('nc-name').focus();
 }
@@ -313,8 +322,17 @@ document.getElementById('nc-modal').onsubmit = async (e) => {
   const title = document.getElementById('nc-name').value.trim();
   if (!title) return;
   const body = document.getElementById('nc-body').value;
+  // Optional harness/model hint → stored as card attributes; card.start honors
+  // them as a fallback (an explicit CLI --harness/--model still wins).
+  const attributes = {};
+  const ncHarness = document.getElementById('nc-harness').value;
+  const ncModel = document.getElementById('nc-model').value.trim();
+  if (ncHarness) attributes.harness = ncHarness;
+  if (ncModel) attributes.model = ncModel;
   try {
-    const r = await api.createCard({ title, column: ncColumnId, body, type: ncType.value, owner: ncOwner.value });
+    const r = await api.createCard(Object.assign(
+      { title, column: ncColumnId, body, type: ncType.value, owner: ncOwner.value },
+      Object.keys(attributes).length ? { attributes } : {}));
     closeNewCard();
     openDetail(r.card.id);
   } catch (err) { alert(err.message); }
@@ -325,6 +343,7 @@ const ltOverlay = document.getElementById('lt-overlay');
 export function openNewLieutenant() {
   document.getElementById('lt-name').value = '';
   document.getElementById('lt-charter').value = '';
+  document.getElementById('lt-harness').value = 'claude';
   ltOverlay.hidden = false;
   document.getElementById('lt-name').focus();
 }
@@ -347,6 +366,7 @@ document.getElementById('lt-modal').onsubmit = async (e) => {
       name,
       color: document.getElementById('lt-color').value,
       charter: document.getElementById('lt-charter').value,
+      harness: document.getElementById('lt-harness').value || 'claude',
       spawn: true,
     });
     closeNewLieutenant();


### PR DESCRIPTION
Let the captain choose the agent harness (claude vs codex) from the UI. Two surfaces, both small — the server-side harness/model plumbing already existed; this wires UI controls to it.

## A. New-lieutenant modal → harness select
- `#lt-modal` gains a `<select id="lt-harness">` (claude default / codex), styled to match `.lt-row`.
- Passed through `api.createLieutenant({..., harness})` → server's existing `body.harness` path (`spawnLieutenant`). No server change for this half.
- **Verified live:** created a **codex** lieutenant from the modal — it spawned a real codex tmux session with `ref.harness: "codex"`.

## B. New-card modal → harness + model hint, honored by `card start`
- `#nc-modal` gains an optional `<select id="nc-harness">` (— / claude / codex) and `<input id="nc-model">`. When set, they persist as `card.attributes.harness` / `card.attributes.model` (the create endpoint already accepts `attributes`).
- **Server `card start` honors the stored hint as a fallback** (`cmdStart`): explicit CLI `--harness`/`--model` wins → card's stored hint → config/default.
  - `harness = body.harness || card.attributes.harness || readConfig().harness || 'claude'`
  - `model  = body.model  || card.attributes.model` → `--model` extraArg
- A small card-face badge (`codex · <model>`) shows the hint, matching the existing chip styles.
- **Verified live:** created a card with a `codex` + `gpt-5-codex` hint — attributes persisted, badge renders on the card face.

## Constraints met
- `harness/` **untouched** (grep-proven) — UI + a tiny `cmdStart` fallback only.
- Claude default preserved everywhere (unset picker = claude / config-default).
- Full suite green (`node --test test/*.test.js harness/test/*.test.js`; the one flake is the load-sensitive `bootstrap` port race — passes alone). New server test proves the `attributes.harness/.model` fallback **and** the explicit-body override, observed via a recording harness registered through the port (no `harness/` edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)