### PR TITLE
Rename product: bridge-command → bridge-commander (BC abbreviations stay)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,7 +25,7 @@ them drift.
 
 - **Delivery is write-ahead and at-least-once**: every append lands in the durable queue
   first, then the server wakes the owning lieutenant — one coalesced
-  `[bridge-command] N pending item(s) — run: bc-axi drain` line typed into its live session,
+  `[bridge-commander] N pending item(s) — run: bc-axi drain` line typed into its live session,
   with the turn-end hook (`POST /api/turn-end`) re-nudging a lieutenant that ends a turn with
   items still unacked. Only ack removes; a dead session loses nothing; a server restart is a
   non-event.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bridge Command
+# Bridge Commander
 
 Agent-orchestration harness whose control surface is a kanban board. The captain (you, in a
 browser) pilots N **lieutenants** — durable orchestrator agents — and every unit of work is a
@@ -16,8 +16,8 @@ How it works inside: [ARCHITECTURE.md](ARCHITECTURE.md). The conceptual API
 ## Install
 
 ```sh
-git clone https://github.com/tonylampada/bridge-command.git
-ln -s "$(pwd)/bridge-command/skill" ~/.claude/skills/bridge-command
+git clone https://github.com/tonylampada/bridge-commander.git
+ln -s "$(pwd)/bridge-commander/skill" ~/.claude/skills/bridge-commander
 ```
 
 Optionally put `cli/bc-axi` on PATH; everything also works via its absolute path.
@@ -53,9 +53,9 @@ those modes have no skill dependency.
    tmux new -s myfleet
    ```
 
-2. **Launch your agent inside it and invoke the skill** (run `claude`, then `/bridge-command`).
+2. **Launch your agent inside it and invoke the skill** (run `claude`, then `/bridge-commander`).
    The skill agrees a lieutenant name with you and runs `bc-axi init --name "<name>"`, which
-   bootstraps `.bridge-command/`, boots the board server detached, registers the caller as the
+   bootstraps `.bridge-commander/`, boots the board server detached, registers the caller as the
    founding lieutenant, and scaffolds workspace memory (`AGENTS.md`, `captain.md`, `learnings/`).
 
 3. **Open the printed board URL** (default `http://localhost:4780/`) — the captain's cockpit.
@@ -68,7 +68,7 @@ Run `bc-axi` bare for full CLI usage, or start the server by hand:
 
 ## Configuration
 
-Per-workspace config lives in `.bridge-command/config.json`:
+Per-workspace config lives in `.bridge-commander/config.json`:
 
 | Key | Default | Meaning |
 |---|---|---|
@@ -86,7 +86,7 @@ Env knobs (set on the server process):
 | `BC_UPLOAD_MAX_BYTES` | `10485760` | per-file chat upload cap |
 | `BC_WORKER_TTL_SECS` | `600` | card status lease TTL — `working`/`needs-you` decays to `idle` past it |
 | `BC_WORKTREE_TOOL` | auto | `treehouse` \| `git` — worker worktree provisioning |
-| `BC_HARNESS_STATE` | `~/.bridge-command/harness` | harness state dir (prompts, session ids, turn-end logs) |
+| `BC_HARNESS_STATE` | `~/.bridge-commander/harness` | harness state dir (prompts, session ids, turn-end logs) |
 | `BC_GH_CMD` | `gh` | gh binary used by the PR watch |
 | `BC_TURNEND_URL` | — | default callback URL baked into installed turn-end hooks |
 | `BC_SEND_RETRIES` / `BC_SEND_SLEEP_MS` | `3` / `400` | verified-submit tuning for `harness.send` |

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -1,13 +1,13 @@
 #!/usr/bin/env node
-// bc-axi — agent CLI for the bridge-command board. Node built-ins only, zero deps.
+// bc-axi — agent CLI for the bridge-commander board. Node built-ins only, zero deps.
 // Run with no args for full usage. Message/body/charter text always goes via
 // --text-file, --body-file, --charter-file, or stdin — never interpolated into a
 // shell command.
 //
 // Workspace resolution (no --board, no global state): --workspace wins; else walk
-// up from cwd to the nearest directory containing .bridge-command/; `open` may
+// up from cwd to the nearest directory containing .bridge-commander/; `open` may
 // bootstrap a fresh workspace in cwd. The server port comes from the workspace's
-// .bridge-command/config.json (default 4780); --port overrides.
+// .bridge-commander/config.json (default 4780); --port overrides.
 'use strict';
 
 const http = require('http');
@@ -18,6 +18,8 @@ const { spawn, execFileSync } = require('child_process');
 
 const SELF_DIR = path.dirname(fs.realpathSync(process.argv[1]));
 const SERVER_JS = path.join(SELF_DIR, '..', 'server', 'server.js');
+const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, migrateStateDir, resolveStateDir, migrateHomeStateDir } =
+  require(path.join(SELF_DIR, '..', 'server', 'statedir.js'));
 const DEFAULT_PORT = 4780;
 
 function die(msg) { console.error(msg); process.exit(1); }
@@ -90,20 +92,39 @@ if ((cmd === 'card' || cmd === 'lieutenant' || cmd === 'project' || cmd === 'wor
 if (cmd === 'card artifact' && positional.length) cmd = cmd + ' ' + positional.shift();
 
 // ---------- workspace resolution ----------
+// Discovery accepts BOTH the new and legacy state-dir names so a not-yet-migrated
+// install is still found; STATE_DIR resolution then prefers the new name.
 function findWorkspace(start) {
   let dir = path.resolve(start);
   for (;;) {
-    if (fs.existsSync(path.join(dir, '.bridge-command'))) return dir;
+    if (fs.existsSync(path.join(dir, STATE_DIR_NAME)) ||
+        fs.existsSync(path.join(dir, LEGACY_STATE_DIR_NAME))) return dir;
     const up = path.dirname(dir);
     if (up === dir) return null;
     dir = up;
   }
 }
+// A legacy state dir is "live" only while its server is running — never rename it
+// out from under one. Absent/stale pid ⇒ safe to migrate.
+function stateDirLive(dir) {
+  try {
+    const pid = parseInt(fs.readFileSync(path.join(dir, 'server.pid'), 'utf8'), 10);
+    if (!pid) return false;
+    process.kill(pid, 0);
+    return true;
+  } catch (e) { return false; }
+}
 const WORKSPACE = opts.workspace
   ? path.resolve(opts.workspace)
   : (cmd === 'open' || cmd === 'init' ? (findWorkspace(process.cwd()) || process.cwd()) : findWorkspace(process.cwd()));
-if (!WORKSPACE) die('no workspace found: no .bridge-command/ from cwd upward (run `bc-axi init` to start one here, or pass --workspace)');
-const STATE_DIR = path.join(WORKSPACE, '.bridge-command');
+if (!WORKSPACE) die('no workspace found: no ' + STATE_DIR_NAME + '/ from cwd upward (run `bc-axi init` to start one here, or pass --workspace)');
+// One-shot rename migrations (bridge-command → bridge-commander), idempotent and
+// guarded so a running legacy server is left alone.
+const migratedState = migrateStateDir(WORKSPACE, stateDirLive);
+if (migratedState) console.error('[bridge-commander] migrated state dir → ' + migratedState);
+const migratedHome = migrateHomeStateDir();
+if (migratedHome) console.error('[bridge-commander] migrated home state dir → ' + migratedHome);
+const STATE_DIR = resolveStateDir(WORKSPACE);
 const CONFIG_FILE = path.join(STATE_DIR, 'config.json');
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
 
@@ -192,7 +213,7 @@ async function cmdOpen() {
 
 // ---------- init: workspace.init — the teleport ----------
 // Mechanical half of the founding flow (the skill drives the agent half):
-// verify tmux, bootstrap .bridge-command/, boot the server, register the CALLER
+// verify tmux, bootstrap .bridge-commander/, boot the server, register the CALLER
 // as the founding lieutenant (its tmux session is the ref), install the
 // workspace-level turn-end Stop hook, scaffold AGENTS.md + captain.md +
 // learnings/, print the board URL. Idempotent — safe to re-run.
@@ -230,8 +251,8 @@ async function cmdInit() {
   // because the agent's cwd drifted from the intended workspace. Announce the resolved
   // target and how it was chosen, so a wrong dir is caught before any state is written.
   const fresh = !fs.existsSync(STATE_DIR);
-  const how = opts.workspace ? '--workspace flag' : (fresh ? 'current directory (cwd)' : 'existing .bridge-command/ found from cwd upward');
-  console.error('┌─ bridge-command init');
+  const how = opts.workspace ? '--workspace flag' : (fresh ? 'current directory (cwd)' : 'existing .bridge-commander/ found from cwd upward');
+  console.error('┌─ bridge-commander init');
   console.error('│  workspace : ' + WORKSPACE + (fresh ? '   (NEW)' : '   (existing)'));
   console.error('│  resolved  : ' + how);
   console.error('│  tmux      : ' + tmuxSession);
@@ -239,7 +260,7 @@ async function cmdInit() {
 
   // 2. state dir + server (detached, idempotent)
   fs.mkdirSync(STATE_DIR, { recursive: true });
-  excludeFromGit(WORKSPACE, '.bridge-command/');
+  excludeFromGit(WORKSPACE, '.bridge-commander/');
   const { started } = await ensureServer();
   console.log('server ' + (started ? 'started' : 'already running') + ' on port ' + PORT);
 
@@ -276,25 +297,25 @@ async function cmdInit() {
   const agentsMd = path.join(WORKSPACE, 'AGENTS.md');
   if (!fs.existsSync(agentsMd)) {
     fs.writeFileSync(agentsMd,
-      '# ' + path.basename(WORKSPACE) + ' — Bridge Command workspace\n\n' +
-      'Every agent here works for the captain through the Bridge Command board.\n\n' +
-      '1. FIRST: load the **bridge-command** skill and follow its doctrine.\n' +
+      '# ' + path.basename(WORKSPACE) + ' — Bridge Commander workspace\n\n' +
+      'Every agent here works for the captain through the Bridge Commander board.\n\n' +
+      '1. FIRST: load the **bridge-commander** skill and follow its doctrine.\n' +
       '2. Read `captain.md` — the captain\'s preferences and working style.\n' +
       '3. Read `learnings/` — per-project engineering learnings, proactively maintained by lieutenants.\n\n' +
-      'Board state lives in `.bridge-command/` (server-owned — never hand-edit).\n' +
+      'Board state lives in `.bridge-commander/` (server-owned — never hand-edit).\n' +
       'Drive the board with `bc-axi` (run it bare for usage).\n');
     console.log('scaffolded AGENTS.md');
   }
   const captainMd = path.join(WORKSPACE, 'captain.md');
   if (!fs.existsSync(captainMd)) {
-    const seed = path.join(os.homedir(), '.bridge-command', 'captain.md');
+    const seed = path.join(os.homedir(), '.bridge-commander', 'captain.md');
     if (fs.existsSync(seed)) {
       fs.copyFileSync(seed, captainMd);
-      console.log('scaffolded captain.md (seeded from ~/.bridge-command/captain.md)');
+      console.log('scaffolded captain.md (seeded from ~/.bridge-commander/captain.md)');
     } else {
       fs.writeFileSync(captainMd,
         '# Captain preferences\n\n' +
-        '(Curated preferences and working style. A global seed can live at ~/.bridge-command/captain.md.)\n');
+        '(Curated preferences and working style. A global seed can live at ~/.bridge-commander/captain.md.)\n');
       console.log('scaffolded captain.md');
     }
   }
@@ -866,17 +887,17 @@ const commands = {
   say: cmdSay, drain: cmdDrain, ack: cmdAck,
 };
 if (!commands[cmd]) {
-  die('bc-axi — agent CLI for the bridge-command board.\n' +
-    'Workspace: nearest .bridge-command/ from cwd upward, or --workspace DIR. Port: workspace config.json (default 4780), or --port N.\n' +
+  die('bc-axi — agent CLI for the bridge-commander board.\n' +
+    'Workspace: nearest .bridge-commander/ from cwd upward, or --workspace DIR. Port: workspace config.json (default 4780), or --port N.\n' +
     'Bind host: config.json "host" (default 127.0.0.1 loopback), or --host H on init/open. Never 0.0.0.0 — there is no app auth.\n' +
     '\nserver & workspace:\n' +
     '  init --name N [--id id] [--charter-file f|-] [--port N] [--host H]\n' +
     '                                         workspace.init (the teleport): run INSIDE tmux; bootstraps\n' +
-    '                                         .bridge-command/, boots the server, registers the caller\'s tmux\n' +
+    '                                         .bridge-commander/, boots the server, registers the caller\'s tmux\n' +
     '                                         session as the founding lieutenant, installs the turn-end hook,\n' +
     '                                         scaffolds AGENTS.md + captain.md + learnings/. Idempotent\n' +
     '  open [--port N] [--host H]             start the workspace server if needed (idempotent), print URL.\n' +
-    '                                         Bootstraps .bridge-command/ in cwd on first run.\n' +
+    '                                         Bootstraps .bridge-commander/ in cwd on first run.\n' +
     '  status                                 up/down, cards, lieutenants, pending queue items\n' +
     '  stop                                   stop the workspace server\n' +
     '\nlieutenant:\n' +

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -1,9 +1,9 @@
-# Bridge Command — Conceptual API (DNA)
+# Bridge Commander — Conceptual API (DNA)
 
 > This IS the spec the implementation follows. A disagreement between this document and
 > the code is a bug in one of them — change deliberately, never let them drift.
 
-Bridge Command is an agent-orchestration **harness** whose control surface is a kanban board.
+Bridge Commander is an agent-orchestration **harness** whose control surface is a kanban board.
 The captain pilots N **lieutenants** — orchestrator agents, one tmux session each, shown as a
 horizontal lane above the columns — and every unit of work is a card owned by exactly one
 lieutenant. Lieutenants never implement; they delegate each started card to a **worker**
@@ -17,7 +17,7 @@ orchestration doctrine distills firstmate. New project — inspiration, not reus
 ## The board
 
 One board per **workspace** (the directory where the skill was initialized; holds state in
-`.bridge-command/`, config, shared memory, and cloned projects). Fixed column frame:
+`.bridge-commander/`, config, shared memory, and cloned projects). Fixed column frame:
 
 📋 Backlog → 🔨 Working → 👀 Your review → 🤝 Peer review
 
@@ -61,7 +61,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 
 | Operation | Signature | Who | When |
 |---|---|---|---|
-| `workspace.init` | `dir → workspace` | ⚓ (the founding agent) | skill invoked in a fresh dir, **inside tmux** (refuses outside, with instruction); creates `.bridge-command/`, boots the server, registers the caller as the first lieutenant — the "teleport" |
+| `workspace.init` | `dir → workspace` | ⚓ (the founding agent) | skill invoked in a fresh dir, **inside tmux** (refuses outside, with instruction); creates `.bridge-commander/`, boots the server, registers the caller as the first lieutenant — the "teleport" |
 | `workspace.addProject` | `url \| path, mode → project` | ⚓ | captain asks to bring a repo into the workspace |
 | `lieutenant.create` | `charter → lieutenant` | 🤠 lane button · ⚓ on captain's ask | a new mission/domain deserves its own commander; server spawns its tmux session via the harness port, doctrine + charter as launch prompt |
 | `lieutenant.retire` | `lieutenant` | 🤠 | explicit only; refused while the lieutenant owns non-archived cards (archive or finish them first — never reassign); kills its session, removes it and its queue, loud level-1 event |
@@ -93,7 +93,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 | Operation | Signature | Who | When |
 |---|---|---|---|
 | `worker.signal` | `card, text` | 🛠️ | real milestones (branch, tests green, PR open) → level-2 event + QueueItem to the owner |
-| `worker.done` | `card, outcome` | 🛠️ | worker finished: event + QueueItem wake the owner; the card stays Working until the lieutenant verifies and hands off. PR URLs in the outcome populate the card's `prs` (the PR watch takes it from there); an investigation's report (`.bridge-command/reports/<card>.md` by convention) is attached as an artifact |
+| `worker.done` | `card, outcome` | 🛠️ | worker finished: event + QueueItem wake the owner; the card stays Working until the lieutenant verifies and hands off. PR URLs in the outcome populate the card's `prs` (the PR watch takes it from there); an investigation's report (`.bridge-commander/reports/<card>.md` by convention) is attached as an artifact |
 | worker stop | — | ⚙️ turn-end | a worker turn-end IS the stop signal: card still Working and no `done` → immediate `worker-stopped` QueueItem to the owner + level-2 event (coalesced — one per stop, not per turn). After `done`, turn-ends only update counters |
 | worker death | — | ⚙️ supervision loop | a worker ref dead without `done` → `worker-died` QueueItem to the owner + level-2 event; the card stays Working, flagged — the owner resumes (`card.start --resume`) or moves it back |
 
@@ -112,7 +112,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 The server speaks ONLY this port. v0 ships the `claude` implementation (plus a file-backed
 `fake` for tests); adding a harness is implementing these seven verbs, nothing else.
 Harness working state (session ids, prompts, turn-end logs) lives in the workspace's
-`.bridge-command/harness/` — never global; spawned session names are unique per workspace.
+`.bridge-commander/harness/` — never global; spawned session names are unique per workspace.
 
 **Optional capability verbs.** Beyond the seven REQUIRED verbs a harness MAY expose extra
 verbs for features not every harness can honor. The port never validates them (requiring
@@ -127,7 +127,7 @@ gracefully when the verb is absent. Current optional verbs (pane viewing — the
 
 ## Invariants
 
-1. **Board is truth.** No shadow files, no mirror: cards + charters + queues in `.bridge-command/` ARE the state. Agent conversation memory is a cache; restart of any session is a non-event.
+1. **Board is truth.** No shadow files, no mirror: cards + charters + queues in `.bridge-commander/` ARE the state. Agent conversation memory is a cache; restart of any session is a non-event.
 2. **Lieutenants never write to projects.** Every change reaches a project through a worker in an isolated worktree, shipped by the project's delivery mode.
 3. **Working ⇔ unfinished task, which SHOULD have a live worker.** The only way into Working is `card.start`, spawning the worker atomically. A Working card may lose its worker only by accident (process died, machine rebooted) — the server flags it and queues the owner; a wound to heal, never a state to create deliberately.
 4. **One owner, for life.** Every card belongs to exactly one lieutenant, fixed at birth — no reassignment; moving work between lieutenants = archive + recreate. The captain converses only with lieutenants (card threads included). `tmux attach` on a predictable session name (`bc-*`; the founding lieutenant keeps its own session name) is the escape hatch, not a channel.

--- a/docs/handoffs/2026-07-10-memory-reorg.md
+++ b/docs/handoffs/2026-07-10-memory-reorg.md
@@ -1,12 +1,12 @@
 # Handoff — memory reorg (2026-07-10)
 
-For: Tony's review of https://github.com/tonylampada/bridge-command/pull/25 (already merged &
+For: Tony's review of https://github.com/tonylampada/bridge-commander/pull/25 (already merged &
 deployed under yolo — this documents what happened and what deserves a skeptical read).
 Written by lieutenant monica at session end.
 
 ## The story
 
-The captain asked for a critical analysis of the Bridge Command memory files — the workspace's
+The captain asked for a critical analysis of the Bridge Commander memory files — the workspace's
 `AGENTS.md`/`captain.md`/`learnings/` and the skill itself — through the lens of the
 `writing-great-skills` skill. The analysis found three diseases across ~23 KB in 6 files:
 
@@ -30,7 +30,7 @@ that motivated the brief.js change.
 
 ## What landed
 
-- **PR https://github.com/tonylampada/bridge-command/pull/25** (this repo, merged, deployed):
+- **PR https://github.com/tonylampada/bridge-commander/pull/25** (this repo, merged, deployed):
   - `server/brief.js` — Process-safety ground rule now in EVERY worker brief (capture pid via
     `$!`, only signal `$PID`, never pgrep/pkill/kill by pattern — a worker once froze itself
     this way). Pinned by new `test/brief.test.js`.
@@ -41,7 +41,7 @@ that motivated the brief.js change.
     a merged PR, the stale-UI trap, orphan-tmux respawn recovery, dev/test notes.
   - `skill/SKILL.md` — step 2 slimmed to 2 lines.
 - **Workspace commit** `roboflow-commander@8d24f20` — `captain.md` 3.5→1.4 KB (only
-  Tony-specific preferences), `learnings/bridge-command-operations.md` 7→1 KB (only
+  Tony-specific preferences), `learnings/bridge-commander-operations.md` 7→1 KB (only
   install-specific facts: port, upload env var, bc-axi path, iOS quirk, papercut pointer).
 
 Verification done: full diff read (exactly the 5 briefed files; `harness/` and
@@ -64,7 +64,7 @@ restarted (pid changed, status 200, env preserved), installed skill copy confirm
 
 ## Suggested skills (next session)
 
-- `bridge-command` — re-enter the workspace as lieutenant (the doctrine/OPERATIONS just changed;
+- `bridge-commander` — re-enter the workspace as lieutenant (the doctrine/OPERATIONS just changed;
   the next lieutenant boots with the new text).
 - `writing-great-skills` — if the review prompts another editing pass on the skill docs.
 - `spleak2me` — if the captain wants the review findings turned into another guided-reading page.

--- a/e2e/fullloop.e2e.js
+++ b/e2e/fullloop.e2e.js
@@ -89,8 +89,8 @@ function dumpDiagnostics() {
   console.error(capture(LT_SESSION).split('\n').slice(-80).join('\n'));
   try {
     console.error('\n--- drain log (queue/' + LT + '.jsonl) ---');
-    console.error(fs.readFileSync(path.join(ws, '.bridge-command', 'queue', LT + '.jsonl'), 'utf8').trim());
-    console.error('ack cursor: ' + fs.readFileSync(path.join(ws, '.bridge-command', 'queue', LT + '.ack'), 'utf8').trim());
+    console.error(fs.readFileSync(path.join(ws, '.bridge-commander', 'queue', LT + '.jsonl'), 'utf8').trim());
+    console.error('ack cursor: ' + fs.readFileSync(path.join(ws, '.bridge-commander', 'queue', LT + '.ack'), 'utf8').trim());
   } catch (e) { console.error('(no queue state: ' + e.message + ')'); }
   for (const s of (tryTmux('list-sessions', '-F', '#S') || '').split('\n').filter((x) => x.startsWith('bc-' + workspaceDisc(ws) + '-w-'))) {
     console.error('\n--- worker pane (' + s + ') ---');

--- a/e2e/prwatch.e2e.js
+++ b/e2e/prwatch.e2e.js
@@ -142,7 +142,7 @@ async function stepCase(name, fn) {
         assert.strictEqual(gh('repo', 'view', login + '/' + SCRATCH, '--json', 'visibility', '-q', '.visibility'), 'PRIVATE');
       } catch (e) {
         gh('repo', 'create', login + '/' + SCRATCH, '--private', '--add-readme',
-          '--description', 'bridge-command e2e scratch repo');
+          '--description', 'bridge-commander e2e scratch repo');
         await until('fresh repo visible', async () => {
           try { return gh('repo', 'view', login + '/' + SCRATCH, '--json', 'visibility', '-q', '.visibility') === 'PRIVATE'; }
           catch (e2) { return false; }

--- a/e2e/run.js
+++ b/e2e/run.js
@@ -90,14 +90,14 @@ async function step(name, fn) {
       await sleep(50);
     }
 
-    await step('board init: fixed frame, empty board, state under .bridge-command', async () => {
+    await step('board init: fixed frame, empty board, state under .bridge-commander', async () => {
       const b = (await api('GET', '/api/board')).body;
       assert.deepStrictEqual(b.columns.map((c) => c.id), ['backlog', 'working', 'review', 'peer']);
       assert.deepStrictEqual(b.lieutenants, []);
       assert.deepStrictEqual(b.cards, []);
-      assert.ok(fs.existsSync(path.join(ws, '.bridge-command', 'board.json')) ||
-        fs.existsSync(path.join(ws, '.bridge-command')), 'state dir exists');
-      const cfg = JSON.parse(fs.readFileSync(path.join(ws, '.bridge-command', 'config.json'), 'utf8'));
+      assert.ok(fs.existsSync(path.join(ws, '.bridge-commander', 'board.json')) ||
+        fs.existsSync(path.join(ws, '.bridge-commander')), 'state dir exists');
+      const cfg = JSON.parse(fs.readFileSync(path.join(ws, '.bridge-commander', 'config.json'), 'utf8'));
       assert.strictEqual(cfg.port, port);
       // the UI is served
       const html = await (await fetch(base + '/')).text();
@@ -131,7 +131,7 @@ async function step(name, fn) {
       assert.strictEqual(r.status, 200);
       const seq = r.body.seq;
       // durable on disk before anything else (write-ahead)
-      const onDisk = fs.readFileSync(path.join(ws, '.bridge-command', 'queue', 'ada.jsonl'), 'utf8');
+      const onDisk = fs.readFileSync(path.join(ws, '.bridge-commander', 'queue', 'ada.jsonl'), 'utf8');
       assert.ok(onDisk.includes('how goes the port?'));
       // drained via CLI (--json = raw QueueItems)
       let cli = await runCli(['drain', '--lieutenant', 'ada', '--json'], wsArgs);
@@ -184,7 +184,7 @@ async function step(name, fn) {
     await step('archive and restore with frozen state + loud resurrection', async () => {
       await api('POST', '/api/cards/chase-the-flake/archive', { reason: 'killed', note: 'wrong lead', actor: 'user' });
       assert.strictEqual((await api('GET', '/api/cards/chase-the-flake')).status, 404);
-      const recs = fs.readFileSync(path.join(ws, '.bridge-command', 'archive.jsonl'), 'utf8')
+      const recs = fs.readFileSync(path.join(ws, '.bridge-commander', 'archive.jsonl'), 'utf8')
         .split('\n').filter(Boolean).map((l) => JSON.parse(l));
       assert.strictEqual(recs[0].reason, 'killed');
       assert.strictEqual(recs[0].note, 'wrong lead');
@@ -268,7 +268,7 @@ async function step(name, fn) {
           assert.strictEqual(b.lt.ref.session, lieutenantSession(b.dir, 'twin'));
           assert.match(b.lt.ref.session, /^bc-[A-Za-z0-9-]+-lt-twin$/, 'workspace-discriminated, ASCII-only');
           const rec = JSON.parse(fs.readFileSync(path.join(b.dir, 'fake', b.lt.ref.session + '.json'), 'utf8'));
-          const want = path.join(b.dir, '.bridge-command', 'harness');
+          const want = path.join(b.dir, '.bridge-commander', 'harness');
           assert.strictEqual(rec.stateDir, want, 'harness state under THIS workspace, never a shared global dir');
           assert.ok(fs.existsSync(want), 'workspace harness state dir provisioned');
         }

--- a/e2e/wake.e2e.js
+++ b/e2e/wake.e2e.js
@@ -134,7 +134,7 @@ const SCOUT = require(path.join(__dirname, '..', 'server', 'names.js')).lieutena
       assert.strictEqual(lt.id, 'founder');
       assert.deepStrictEqual(lt.ref, { harness: 'claude', session: FOUNDER, cwd: fs.realpathSync(ws) });
       // scaffolding: AGENTS.md (skill-first), captain.md, learnings/, Stop hook
-      assert.match(fs.readFileSync(path.join(ws, 'AGENTS.md'), 'utf8'), /bridge-command.*skill/s);
+      assert.match(fs.readFileSync(path.join(ws, 'AGENTS.md'), 'utf8'), /bridge-commander.*skill/s);
       assert.ok(fs.existsSync(path.join(ws, 'captain.md')));
       assert.ok(fs.existsSync(path.join(ws, 'learnings', 'README.md')));
       const hooks = JSON.parse(fs.readFileSync(path.join(ws, '.claude', 'settings.local.json'), 'utf8'));
@@ -162,14 +162,14 @@ const SCOUT = require(path.join(__dirname, '..', 'server', 'names.js')).lieutena
       const r = await api('POST', '/api/feedback', { target: 'lieutenant:founder', text: 'hello founder' });
       assert.strictEqual(r.status, 200);
       firstSeq = r.body.seq;
-      await until('wake in pane', () => capture(FOUNDER).includes('[bridge-command] 1 pending item(s) — run: bc-axi drain'), 15000);
+      await until('wake in pane', () => capture(FOUNDER).includes('[bridge-commander] 1 pending item(s) — run: bc-axi drain'), 15000);
     });
 
     await stepCase('wakes coalesce while pending-and-nudged', async () => {
       await api('POST', '/api/feedback', { target: 'lieutenant:founder', text: 'second message' });
       await api('POST', '/api/feedback', { target: 'lieutenant:founder', text: 'third message' });
       await sleep(2500);
-      const hits = capture(FOUNDER).split('\n').filter((l) => l.includes('[bridge-command]'));
+      const hits = capture(FOUNDER).split('\n').filter((l) => l.includes('[bridge-commander]'));
       // cat echoes the submitted wake line back, so the ONE wake shows at most
       // twice; three stacked wakes would show many more.
       assert.ok(hits.length <= 2, 'expected one coalesced wake, pane shows:\n' + hits.join('\n'));
@@ -188,10 +188,10 @@ const SCOUT = require(path.join(__dirname, '..', 'server', 'names.js')).lieutena
       r = await runCli(['drain', '--lieutenant', 'founder', ...wsArgs]);
       assert.match(r.stdout, /queue empty/);
       // drained + acked -> a new append nudges again (a fresh wake line appears)
-      const before = capture(FOUNDER).split('\n').filter((l) => l.includes('[bridge-command]')).length;
+      const before = capture(FOUNDER).split('\n').filter((l) => l.includes('[bridge-commander]')).length;
       await api('POST', '/api/feedback', { target: 'lieutenant:founder', text: 'fourth message' });
       await until('re-nudge after drain', () => capture(FOUNDER).split('\n')
-        .filter((l) => l.includes('[bridge-command]')).length > before, 15000);
+        .filter((l) => l.includes('[bridge-commander]')).length > before, 15000);
       r = await runCli(['drain', '--lieutenant', 'founder', '--json', ...wsArgs]);
       const items = r.stdout.trim().split('\n').filter(Boolean).map((l) => JSON.parse(l));
       await runCli(['ack', String(items[items.length - 1].seq), ...wsArgs]);
@@ -223,7 +223,7 @@ const SCOUT = require(path.join(__dirname, '..', 'server', 'names.js')).lieutena
       });
       assert.strictEqual(r.status, 200);
       const seq = r.body.seq;
-      const ackFile = path.join(ws, '.bridge-command', 'queue', 'scout.ack');
+      const ackFile = path.join(ws, '.bridge-commander', 'queue', 'scout.ack');
       await until('scout to ack seq ' + seq, () => {
         try { return parseInt(fs.readFileSync(ackFile, 'utf8'), 10) >= seq; } catch (e) { return false; }
       }, 240000, 1000);
@@ -236,7 +236,7 @@ const SCOUT = require(path.join(__dirname, '..', 'server', 'names.js')).lieutena
     tryTmux('kill-server');
     // stop the workspace server via its pidfile
     try {
-      const pid = parseInt(fs.readFileSync(path.join(ws, '.bridge-command', 'server.pid'), 'utf8'), 10);
+      const pid = parseInt(fs.readFileSync(path.join(ws, '.bridge-commander', 'server.pid'), 'utf8'), 10);
       if (pid) process.kill(pid, 'SIGTERM');
     } catch (e) { /* already gone */ }
     await sleep(300);

--- a/harness/README.md
+++ b/harness/README.md
@@ -112,8 +112,8 @@ is the captain's escape hatch). `resumeId` is the harness-native conversation id
   (fs.watch + 1s polling backstop) and fires the hook per event.
 
 State lives in `opts.stateDir` — the server and CLI always pass the
-workspace's `.bridge-command/harness/` (`BC_HARNESS_STATE` overrides; the
-global `~/.bridge-command/harness/` is a last-resort for bare embedders only):
+workspace's `.bridge-commander/harness/` (`BC_HARNESS_STATE` overrides; the
+global `~/.bridge-commander/harness/` is a last-resort for bare embedders only):
 `<session>.prompt`, `<session>.session-id`, `<session>.turnend.jsonl`.
 
 ## The codex implementation

--- a/harness/smoke-codex.js
+++ b/harness/smoke-codex.js
@@ -24,7 +24,7 @@
 //      SAME across the death/resume cycle (refs survive repeated cycles)
 //
 // State is fully isolated in a temp stateDir (passed via opts), so nothing
-// touches ~/.bridge-command or any workspace.
+// touches ~/.bridge-commander or any workspace.
 
 const fs = require('node:fs');
 const os = require('node:os');

--- a/harness/smoke.js
+++ b/harness/smoke.js
@@ -116,7 +116,7 @@ async function main() {
       }
       await t.tryTmux('kill-session', '-t', `=${ref.session}:`);
       const stateDir = process.env.BC_HARNESS_STATE
-        || path.join(os.homedir(), '.bridge-command', 'harness');
+        || path.join(os.homedir(), '.bridge-commander', 'harness');
       for (const suffix of ['.prompt', '.session-id', '.turnend.jsonl']) {
         try { fs.unlinkSync(path.join(stateDir, ref.session + suffix)); } catch { /* absent */ }
       }

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -20,12 +20,12 @@ const t = require('./tmux.js');
 const SHELLS = new Set(['bash', 'zsh', 'sh', 'fish', 'dash', 'ksh']);
 
 // State dir resolution: opts.stateDir (the server/CLI always pass the
-// workspace's .bridge-command/harness), then BC_HARNESS_STATE, then a global
+// workspace's .bridge-commander/harness), then BC_HARNESS_STATE, then a global
 // last-resort for bare embedders only — shared across workspaces, so never
 // rely on it from workspace-aware callers.
 function stateDirOf(opts = {}) {
   const dir = opts.stateDir || process.env.BC_HARNESS_STATE
-    || path.join(os.homedir(), '.bridge-command', 'harness');
+    || path.join(os.homedir(), '.bridge-commander', 'harness');
   fs.mkdirSync(dir, { recursive: true });
   return dir;
 }

--- a/harness/tmux.js
+++ b/harness/tmux.js
@@ -14,7 +14,7 @@
 //
 // Zero dependencies; child_process + tmux only.
 //
-// Everything here is async: these primitives run inside the bridge-command
+// Everything here is async: these primitives run inside the bridge-commander
 // server, whose event loop must never block on a subprocess (a sync tmux
 // call per session per supervision tick froze the whole server — UI, SSE,
 // every request — for the duration).

--- a/server/brief.js
+++ b/server/brief.js
@@ -38,12 +38,12 @@ function workerBrief(b) {
   const card = b.card;
   const investigation = card.type === 'investigation';
   const cli = b.cli + ' --workspace ' + b.workspace;
-  const reportFile = b.workspace + '/.bridge-command/reports/' + card.id + '.md';
+  const reportFile = b.workspace + '/.bridge-commander/reports/' + card.id + '.md';
   const parts = [];
 
   parts.push(
     '# Worker brief — card "' + card.title + '" (' + card.id + ')\n\n'
-    + 'You are a Bridge Command **worker**: one fresh agent bound 1:1 to this card, working in an\n'
+    + 'You are a Bridge Commander **worker**: one fresh agent bound 1:1 to this card, working in an\n'
     + 'isolated git worktree. You implement; your owning lieutenant orchestrates and reviews. You\n'
     + 'never talk to the captain and you have no delivery queue — your only board verbs are the two\n'
     + '`worker` commands below.');

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// bridge-command server — the harness control surface. Node built-ins only, zero deps.
+// bridge-commander server — the harness control surface. Node built-ins only, zero deps.
 // Usage: node server/server.js [workspace] [--workspace DIR] [--port N] [--host H]
-// One workspace = one board. All state lives in <workspace>/.bridge-command/:
+// One workspace = one board. All state lives in <workspace>/.bridge-commander/:
 //   board.json     the board (canonical state of the world)
 //   archive.jsonl  append-only frozen card snapshots (reason: merged|killed)
 //   config.json    { port, host?, voices? } — port default 4780, written on first boot
@@ -58,6 +58,7 @@ const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '.
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
 const { workerBrief, PROJECT_MODES } = require(path.join(__dirname, 'brief.js'));
 const names = require(path.join(__dirname, 'names.js'));
+const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
 const { execFile } = require('child_process');
 
 // ---------- args ----------
@@ -79,13 +80,20 @@ const opts = parseArgs(process.argv.slice(2));
 
 // ---------- paths (workspace-scoped; no global state) ----------
 const WORKSPACE = path.resolve(opts.workspace || process.cwd());
-const STATE_DIR = path.join(WORKSPACE, '.bridge-command');
+// One-shot rename migrations (bridge-command → bridge-commander). Boot-time and
+// idempotent: the server owns this workspace as it starts, so renaming the state
+// dir before any path below is used is safe. Legacy installs survive the flag day.
+const migratedState = migrateStateDir(WORKSPACE);
+if (migratedState) console.log('[bridge-commander] migrated state dir → ' + migratedState);
+const migratedHome = migrateHomeStateDir();
+if (migratedHome) console.log('[bridge-commander] migrated home state dir → ' + migratedHome);
+const STATE_DIR = path.join(WORKSPACE, STATE_DIR_NAME);
 const BOARD_FILE = path.join(STATE_DIR, 'board.json');
 const ARCHIVE_FILE = path.join(STATE_DIR, 'archive.jsonl');
 const CONFIG_FILE = path.join(STATE_DIR, 'config.json');
 const QUEUE_DIR = path.join(STATE_DIR, 'queue');
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
-// Chat file uploads. Lives under the workspace .bridge-command/ (already
+// Chat file uploads. Lives under the workspace .bridge-commander/ (already
 // git-ignored). NOTE: this dir grows unbounded — an upload is never garbage
 // collected here; a prune policy (age/size cap, orphan sweep) can come later.
 // Each file is stored as <id>__<safeName> with a sidecar <id>.json holding its
@@ -119,7 +127,7 @@ const ARTIFACT_MIME = {
 
 const DEFAULT_PORT = 4780;
 
-// ---------- workspace config (.bridge-command/config.json) ----------
+// ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
   try {
     const c = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
@@ -538,7 +546,7 @@ function commitAck(seq, ownerId) {
 const WAKE_TTL_MS = process.env.BC_WAKE_TTL_MS !== undefined
   ? parseInt(process.env.BC_WAKE_TTL_MS, 10) : 90000;
 const nudged = new Map(); // lieutenant id -> epoch-ms of the last wake sent since its last drain
-function wakeLine(n) { return '[bridge-command] ' + n + ' pending item(s) — run: bc-axi drain'; }
+function wakeLine(n) { return '[bridge-commander] ' + n + ' pending item(s) — run: bc-axi drain'; }
 function scheduleWake(ltId) {
   const lt = findLieutenant(ltId);
   if (!lt || !isHarnessRef(lt.ref)) return;
@@ -1670,7 +1678,7 @@ async function superviseTick() {
         else {
           const target = lt.ref;
           Promise.resolve()
-            .then(() => harnessFor(target).send(target, '[bridge-command] session respawned — run: bc-axi drain'))
+            .then(() => harnessFor(target).send(target, '[bridge-commander] session respawned — run: bc-axi drain'))
             .catch(() => {});
         }
       } catch (e) {
@@ -2472,7 +2480,7 @@ const server = http.createServer(async (req, res) => {
 
 server.on('error', (e) => { console.error('server error: ' + e.message); cleanup(); process.exit(1); });
 server.listen(PORT, BIND_HOST, () => {
-  console.log('bridge-command server up: http://localhost:' + PORT + '/ host=' + BIND_HOST +
+  console.log('bridge-commander server up: http://localhost:' + PORT + '/ host=' + BIND_HOST +
     ' workspace=' + WORKSPACE + ' pid=' + process.pid);
 });
 // Non-loopback bind: also listen on loopback so local CLI/UI keep working.

--- a/server/statedir.js
+++ b/server/statedir.js
@@ -1,0 +1,54 @@
+// statedir.js — canonical state-dir names + one-shot rename migrations from the
+// pre-rename product name (bridge-command → bridge-commander). Node built-ins
+// only, zero deps; shared by the server and the bc-axi CLI.
+//
+// Every migration is idempotent and non-destructive: it renames ONLY when the
+// new dir is absent and the legacy dir exists. Re-runs are no-ops, and a
+// both-present install always prefers the new dir (no second, destructive
+// rename). The `bc-` / `BC_*` abbreviations are a separate namespace and never
+// appear here.
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const STATE_DIR_NAME = '.bridge-commander';
+const LEGACY_STATE_DIR_NAME = '.bridge-command';
+
+// Rename <ws>/.bridge-command → <ws>/.bridge-commander when safe. Returns the
+// new path if a rename happened, else null. Optional `isLive(legacyDir)` guards
+// against renaming a state dir out from under a running legacy server — when it
+// returns true the rename is skipped.
+function migrateStateDir(ws, isLive) {
+  const nu = path.join(ws, STATE_DIR_NAME);
+  const old = path.join(ws, LEGACY_STATE_DIR_NAME);
+  if (fs.existsSync(nu) || !fs.existsSync(old)) return null;
+  if (typeof isLive === 'function' && isLive(old)) return null;
+  fs.renameSync(old, nu);
+  return nu;
+}
+
+// Resolve the workspace state dir: prefer the new name, accept the legacy one,
+// default to the new name for a fresh install.
+function resolveStateDir(ws) {
+  const nu = path.join(ws, STATE_DIR_NAME);
+  if (fs.existsSync(nu)) return nu;
+  const old = path.join(ws, LEGACY_STATE_DIR_NAME);
+  if (fs.existsSync(old)) return old;
+  return nu;
+}
+
+// Home last-resort dir holds the captain.md seed and the harness fallback state.
+// Same non-destructive rule. `home` defaults to os.homedir() (override for tests).
+function migrateHomeStateDir(home) {
+  const base = home || os.homedir();
+  const nu = path.join(base, STATE_DIR_NAME);
+  const old = path.join(base, LEGACY_STATE_DIR_NAME);
+  if (fs.existsSync(nu) || !fs.existsSync(old)) return null;
+  fs.renameSync(old, nu);
+  return nu;
+}
+
+module.exports = {
+  STATE_DIR_NAME, LEGACY_STATE_DIR_NAME,
+  migrateStateDir, resolveStateDir, migrateHomeStateDir,
+};

--- a/server/worktrees.js
+++ b/server/worktrees.js
@@ -10,7 +10,7 @@
 // (non-interactive durable acquire: prints only the worktree path to stdout;
 // `treehouse return <path>` releases — the pattern mined from firstmate's
 // fm-spawn.sh, with --lease replacing the interactive-subshell dance), else
-// plain `git worktree add -d` under <workspace>/.bridge-command/worktrees/.
+// plain `git worktree add -d` under <workspace>/.bridge-commander/worktrees/.
 // BC_WORKTREE_TOOL=git|treehouse forces the choice (tests pin `git` for
 // hermetic cleanup).
 //
@@ -93,7 +93,7 @@ function createWorktree(projectPath, cardId, workspace) {
     }
     if (!wt) {
       tool = 'git';
-      const dir = path.join(workspace, '.bridge-command', 'worktrees');
+      const dir = path.join(workspace, '.bridge-commander', 'worktrees');
       fs.mkdirSync(dir, { recursive: true });
       wt = path.join(dir, String(cardId).replace(/[^A-Za-z0-9_.-]/g, '-'));
       if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);

--- a/skill/DOCTRINE.md
+++ b/skill/DOCTRINE.md
@@ -1,6 +1,6 @@
 # Lieutenant doctrine (v0)
 
-You are a **lieutenant** on a Bridge Command workspace: a durable orchestrator working for
+You are a **lieutenant** on a Bridge Commander workspace: a durable orchestrator working for
 the captain. The kanban board is your shared control surface; `bc-axi` (run it bare for
 usage) is how you drive it. Board state is the truth — your conversation memory is a cache,
 and a restart of your session is a non-event.
@@ -30,7 +30,7 @@ captain's shelf: never touch it.
 pending delivery: captain messages, start/rework orders, card events. Handle each item, then
 `bc-axi ack <highest seq handled>`. Only ack removes; ack **only after** actually handling —
 an early ack can lose a delivery forever, an unacked item merely re-offers. When a wake line
-(`[bridge-command] N pending item(s)…`) lands in your session, that IS your cue to drain.
+(`[bridge-commander] N pending item(s)…`) lands in your session, that IS your cue to drain.
 
 ## Card hygiene
 
@@ -108,4 +108,4 @@ worker session still bound to the card, so never kill sessions yourself.
 
 ---
 
-Maintaining or deploying the bridge-command tool itself → read `OPERATIONS.md` next to this file.
+Maintaining or deploying the bridge-commander tool itself → read `OPERATIONS.md` next to this file.

--- a/skill/OPERATIONS.md
+++ b/skill/OPERATIONS.md
@@ -1,4 +1,4 @@
-# Operating the bridge-command tool
+# Operating the bridge-commander tool
 
 On-demand reference for a lieutenant or agent running a live board server or shipping changes
 to the tool itself. The doctrine governs how you orchestrate; this governs how you keep the

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,22 +1,22 @@
 ---
-name: bridge-command
-description: Turn the current directory into a Bridge Command workspace and become its founding lieutenant (the teleport), or re-enter an existing one. Use when the user asks to init/set up bridge command, open the bridge board, or orchestrate work through the kanban board.
+name: bridge-commander
+description: Turn the current directory into a Bridge Commander workspace and become its founding lieutenant (the teleport), or re-enter an existing one. Use when the user asks to init/set up bridge command, open the bridge board, or orchestrate work through the kanban board.
 ---
 
-# Bridge Command — the teleport
+# Bridge Commander — the teleport
 
-Bridge Command is an agent-orchestration harness whose control surface is a kanban board.
+Bridge Commander is an agent-orchestration harness whose control surface is a kanban board.
 Invoking this skill turns YOU into a **lieutenant** on the workspace board: durable
 orchestrator, one tmux session, supervised through durable delivery queues.
 
-`bc-axi` is the board CLI. If it is not on PATH, use `<bridge-command checkout>/cli/bc-axi`
+`bc-axi` is the board CLI. If it is not on PATH, use `<bridge-commander checkout>/cli/bc-axi`
 (this skill lives in that checkout's `skill/` directory; run it bare for full usage).
 
 ## 1. Verify you are inside tmux
 
 Check `$TMUX`. If it is empty, REFUSE to init and tell the user exactly this, then stop:
 
-> Bridge Command lieutenants live in tmux sessions — I need to be running inside one.
+> Bridge Commander lieutenants live in tmux sessions — I need to be running inside one.
 > Please start `tmux new -s <workspace-name>`, launch me again in there, and re-invoke
 > this skill.
 
@@ -37,7 +37,7 @@ workspace directory run:
 bc-axi init --name "<your-name>" [--charter-file <f|->]
 ```
 
-This is mechanical and safe to re-run: it creates `.bridge-command/`, boots the board server
+This is mechanical and safe to re-run: it creates `.bridge-commander/`, boots the board server
 detached, registers YOUR tmux session as the founding lieutenant, installs the turn-end hook
 (note: your own turn-end tracking activates on your next claude restart — hooks are captured
 at startup), scaffolds `AGENTS.md`, `captain.md`, `learnings/`, and prints the board URL.
@@ -53,5 +53,5 @@ Give the user that URL — the board is the captain's cockpit.
 
 From now on behave per the doctrine: `bc-axi drain` as the first act of every turn, ack only
 after handling, orchestrate through cards, never implement in a project yourself, talk to
-the captain in outcomes. A `[bridge-command] N pending item(s)` line appearing in your
+the captain in outcomes. A `[bridge-commander] N pending item(s)` line appearing in your
 session is a wake: drain immediately.

--- a/test/attachments.test.js
+++ b/test/attachments.test.js
@@ -22,8 +22,8 @@ test('upload → stored + served with the right Content-Type and correct size', 
     assert.strictEqual(up.body.mime, 'text/plain');
     assert.strictEqual(up.body.size, Buffer.byteLength(payload));
 
-    // stored on disk under .bridge-command/uploads with a sidecar
-    const up_dir = path.join(s.dir, '.bridge-command', 'uploads');
+    // stored on disk under .bridge-commander/uploads with a sidecar
+    const up_dir = path.join(s.dir, '.bridge-commander', 'uploads');
     assert.ok(fs.existsSync(path.join(up_dir, up.body.id + '.json')), 'sidecar written');
     assert.ok(fs.existsSync(path.join(up_dir, up.body.id + '__note.txt')), 'file written with id prefix');
 
@@ -74,7 +74,7 @@ test('path traversal in the id or the filename is blocked', async () => {
     const up = await s.api('POST', '/api/attachments', { name: '../../../etc/passwd', mime: 'text/plain', dataBase64: b64('x') });
     assert.strictEqual(up.status, 200);
     assert.strictEqual(up.body.name, 'passwd'); // stripped to the basename
-    const up_dir = path.join(s.dir, '.bridge-command', 'uploads');
+    const up_dir = path.join(s.dir, '.bridge-commander', 'uploads');
     const stored = fs.readdirSync(up_dir).filter((f) => f.startsWith(up.body.id + '__'));
     assert.strictEqual(stored.length, 1);
     assert.ok(!stored[0].includes('..') && !stored[0].includes('/'), 'stored name has no traversal');
@@ -100,7 +100,7 @@ test('captain feedback with attachments persists them on the thread message and 
     assert.strictEqual(att[0].id, up.body.id);
     assert.strictEqual(att[0].name, 'shot.png');
     assert.strictEqual(att[0].mime, 'image/png');
-    const absPath = path.join(s.dir, '.bridge-command', 'uploads', up.body.id + '__shot.png');
+    const absPath = path.join(s.dir, '.bridge-commander', 'uploads', up.body.id + '__shot.png');
     assert.strictEqual(att[0].path, absPath);
 
     // the queue item to the owner carries the same attachments (with path)
@@ -133,7 +133,7 @@ test('drain and thread output surface the absolute attachment path to the agent'
     await s.api('POST', '/api/cards', withOwner({ title: 'Paths' }));
     const up = await s.api('POST', '/api/attachments', { name: 'diag.log', mime: 'text/plain', dataBase64: b64('trace') });
     await s.api('POST', '/api/feedback', { target: 'card:paths', text: 'look', attachments: [{ id: up.body.id }] });
-    const absPath = path.join(s.dir, '.bridge-command', 'uploads', up.body.id + '__diag.log');
+    const absPath = path.join(s.dir, '.bridge-commander', 'uploads', up.body.id + '__diag.log');
 
     const drain = await runCli(['drain', '--lieutenant', LT, '--workspace', s.dir, '--port', String(s.port)]);
     assert.strictEqual(drain.code, 0, drain.stderr);

--- a/test/bootstrap.test.js
+++ b/test/bootstrap.test.js
@@ -1,5 +1,5 @@
 'use strict';
-// Workspace bootstrapping: state under <workspace>/.bridge-command, fixed column
+// Workspace bootstrapping: state under <workspace>/.bridge-commander, fixed column
 // frame, config.json port, pidfile, isolation between workspaces.
 const test = require('node:test');
 const assert = require('node:assert');
@@ -8,13 +8,13 @@ const os = require('node:os');
 const path = require('node:path');
 const { startServer, startServerWithLieutenant, withOwner, COLUMNS } = require('./helper');
 
-test('fresh board bootstraps empty with the fixed column frame, state under .bridge-command', async () => {
+test('fresh board bootstraps empty with the fixed column frame, state under .bridge-commander', async () => {
   const s = await startServer();
   try {
-    const stateDir = path.join(s.dir, '.bridge-command');
-    assert.ok(fs.existsSync(stateDir), '.bridge-command under the workspace');
+    const stateDir = path.join(s.dir, '.bridge-commander');
+    assert.ok(fs.existsSync(stateDir), '.bridge-commander under the workspace');
     assert.ok(fs.existsSync(path.join(stateDir, 'queue')), 'queue dir created');
-    // pidfile lands under .bridge-command and holds the server pid
+    // pidfile lands under .bridge-commander and holds the server pid
     const pidFile = path.join(stateDir, 'server.pid');
     assert.strictEqual(parseInt(fs.readFileSync(pidFile, 'utf8'), 10), s.child.pid);
     // config.json records the resolved port
@@ -39,7 +39,7 @@ test('fresh board bootstraps empty with the fixed column frame, state under .bri
 test('the column frame is fixed: no columns endpoint, board files cannot change it', async () => {
   const s = await startServer({
     seed: (dir) => {
-      const stateDir = path.join(dir, '.bridge-command');
+      const stateDir = path.join(dir, '.bridge-commander');
       fs.mkdirSync(stateDir, { recursive: true });
       // a hand-edited board file with a foreign frame is normalized back
       fs.writeFileSync(path.join(stateDir, 'board.json'), JSON.stringify({
@@ -65,8 +65,8 @@ test('mutations persist to board.json and survive a restart', async () => {
   try {
     const c = await s1.api('POST', '/api/cards', withOwner({ title: 'Persisted card' }));
     assert.strictEqual(c.status, 200);
-    const boardFile = path.join(dir, '.bridge-command', 'board.json');
-    assert.ok(fs.existsSync(boardFile), 'board.json written under .bridge-command');
+    const boardFile = path.join(dir, '.bridge-commander', 'board.json');
+    assert.ok(fs.existsSync(boardFile), 'board.json written under .bridge-commander');
     const onDisk = JSON.parse(fs.readFileSync(boardFile, 'utf8'));
     assert.strictEqual(onDisk.cards.length, 1);
     assert.strictEqual(onDisk.lieutenants.length, 1);

--- a/test/cards.test.js
+++ b/test/cards.test.js
@@ -6,7 +6,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { startServer, startServerWithLieutenant, withOwner, runCli, LT } = require('./helper');
 
-function archivePath(s) { return path.join(s.dir, '.bridge-command', 'archive.jsonl'); }
+function archivePath(s) { return path.join(s.dir, '.bridge-commander', 'archive.jsonl'); }
 
 test('card create: defaults, slug ids, created event, owner + type validated', async () => {
   const s = await startServerWithLieutenant();

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -12,8 +12,8 @@ test('cli config reads and writes the workspace config.json', async () => {
   try {
     let r = await runCli(['config', 'voices', 'alpha,beta', '--workspace', dir]);
     assert.strictEqual(r.code, 0, r.stderr);
-    const cfgFile = path.join(dir, '.bridge-command', 'config.json');
-    assert.ok(fs.existsSync(cfgFile), 'config.json written under .bridge-command');
+    const cfgFile = path.join(dir, '.bridge-commander', 'config.json');
+    assert.ok(fs.existsSync(cfgFile), 'config.json written under .bridge-commander');
     assert.deepStrictEqual(JSON.parse(fs.readFileSync(cfgFile, 'utf8')).voices, ['alpha', 'beta']);
 
     r = await runCli(['config', 'show', '--workspace', dir]);
@@ -27,7 +27,7 @@ test('cli config reads and writes the workspace config.json', async () => {
   }
 });
 
-test('cli resolves the workspace by walking up from cwd to .bridge-command', async () => {
+test('cli resolves the workspace by walking up from cwd to .bridge-commander', async () => {
   const s = await startServerWithLieutenant();
   try {
     const nested = path.join(s.dir, 'projects', 'demo-app', 'src');

--- a/test/feed.test.js
+++ b/test/feed.test.js
@@ -9,7 +9,7 @@ const os = require('node:os');
 const path = require('node:path');
 const { startServer, startServerWithLieutenant, LT } = require('./helper');
 
-function queueDir(s) { return path.join(s.dir, '.bridge-command', 'queue'); }
+function queueDir(s) { return path.join(s.dir, '.bridge-commander', 'queue'); }
 
 test('unacked items re-offer on every drain; ack commits and persists the cursor', async () => {
   const s = await startServerWithLieutenant();

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,5 +1,5 @@
 'use strict';
-// Test helper — boots a bridge-command server against a fresh temp WORKSPACE
+// Test helper — boots a bridge-commander server against a fresh temp WORKSPACE
 // on an ephemeral port, and tears it down cleanly. Node built-ins only.
 //
 // Run the suite with:
@@ -34,7 +34,7 @@ function freePort() {
 }
 
 // startServer({ dir?, port?, env?, seed? }) -> { dir, port, base, api, stop, child }
-//   dir: the WORKSPACE (state lives in <dir>/.bridge-command)
+//   dir: the WORKSPACE (state lives in <dir>/.bridge-commander)
 //   seed: optional (dir) => {} callback to pre-populate state before the server boots
 async function startServer(opts = {}) {
   const dir = opts.dir || fs.mkdtempSync(path.join(os.tmpdir(), 'bc-test-'));

--- a/test/kinds.test.js
+++ b/test/kinds.test.js
@@ -81,7 +81,7 @@ test('registered kinds persist with the board and survive a restart', async () =
   const s1 = await startServer({ dir });
   try {
     await s1.api('PUT', '/api/kinds', reg);
-    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, '.bridge-command', 'board.json'), 'utf8'));
+    const onDisk = JSON.parse(fs.readFileSync(path.join(dir, '.bridge-commander', 'board.json'), 'utf8'));
     assert.deepStrictEqual(onDisk.kinds, reg); // only the registered map is stored
   } finally {
     await s1.stop();
@@ -237,7 +237,7 @@ test('cli: bc-axi kinds sets from a file and prints the effective map', async ()
 test('hand-edited board json (kindless events, foreign columns) loads and serves', async () => {
   const s = await startServer({
     seed(dir) {
-      const stateDir = path.join(dir, '.bridge-command');
+      const stateDir = path.join(dir, '.bridge-commander');
       fs.mkdirSync(stateDir, { recursive: true });
       fs.writeFileSync(path.join(stateDir, 'board.json'), JSON.stringify({
         title: 'legacy', seq: 3,

--- a/test/lieutenants.test.js
+++ b/test/lieutenants.test.js
@@ -140,7 +140,7 @@ test('lieutenant.retire: refuses with owned cards; else kills session, removes q
     });
     await s.api('POST', '/api/cards', { title: 'Held', id: 'held', owner: 'ret' });
     await s.api('POST', '/api/feedback', { target: 'lieutenant:ret', text: 'note' });
-    const queueFile = path.join(s.dir, '.bridge-command', 'queue', 'ret.jsonl');
+    const queueFile = path.join(s.dir, '.bridge-commander', 'queue', 'ret.jsonl');
     assert.ok(fs.existsSync(queueFile), 'queue file exists before retire');
 
     // refused while the lieutenant owns non-archived cards

--- a/test/migrate.test.js
+++ b/test/migrate.test.js
@@ -1,0 +1,101 @@
+'use strict';
+// State-dir rename migrations (bridge-command → bridge-commander). Proves:
+//   - fresh install uses the new dir;
+//   - a legacy dir gets migrated once (non-destructively — content is moved);
+//   - both-present prefers the new one (no destructive second rename);
+//   - a live legacy server is left alone;
+//   - the server migrates a legacy workspace at boot.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  STATE_DIR_NAME, LEGACY_STATE_DIR_NAME,
+  migrateStateDir, resolveStateDir, migrateHomeStateDir,
+} = require('../server/statedir.js');
+const { startServer } = require('./helper.js');
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-migrate-')); }
+function write(dir, rel, content) {
+  const p = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+
+test('fresh install: resolves to the new dir, nothing to migrate', () => {
+  const ws = tmp();
+  try {
+    assert.equal(migrateStateDir(ws), null, 'no legacy dir → no rename');
+    assert.equal(resolveStateDir(ws), path.join(ws, STATE_DIR_NAME));
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('legacy dir migrated once, content preserved, then a no-op', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(LEGACY_STATE_DIR_NAME, 'board.json'), '{"marker":1}');
+    const moved = migrateStateDir(ws);
+    assert.equal(moved, path.join(ws, STATE_DIR_NAME));
+    assert.ok(!fs.existsSync(path.join(ws, LEGACY_STATE_DIR_NAME)), 'legacy dir gone');
+    assert.equal(
+      fs.readFileSync(path.join(ws, STATE_DIR_NAME, 'board.json'), 'utf8'),
+      '{"marker":1}', 'content moved intact');
+    // second run is a no-op
+    assert.equal(migrateStateDir(ws), null);
+    assert.equal(resolveStateDir(ws), path.join(ws, STATE_DIR_NAME));
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('both present: prefers the new dir, never touches the legacy one', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(STATE_DIR_NAME, 'board.json'), '{"new":1}');
+    write(ws, path.join(LEGACY_STATE_DIR_NAME, 'board.json'), '{"legacy":1}');
+    assert.equal(migrateStateDir(ws), null, 'new present → no destructive rename');
+    assert.equal(
+      fs.readFileSync(path.join(ws, LEGACY_STATE_DIR_NAME, 'board.json'), 'utf8'),
+      '{"legacy":1}', 'legacy dir untouched');
+    assert.equal(resolveStateDir(ws), path.join(ws, STATE_DIR_NAME));
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('live legacy server: rename is skipped by the isLive guard', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(LEGACY_STATE_DIR_NAME, 'board.json'), '{"legacy":1}');
+    assert.equal(migrateStateDir(ws, () => true), null, 'live → skip');
+    assert.ok(fs.existsSync(path.join(ws, LEGACY_STATE_DIR_NAME)), 'legacy left in place');
+    // once it is no longer live, the same call migrates.
+    assert.equal(migrateStateDir(ws, () => false), path.join(ws, STATE_DIR_NAME));
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('home state dir migrates the same way', () => {
+  const home = tmp();
+  try {
+    write(home, path.join(LEGACY_STATE_DIR_NAME, 'captain.md'), 'seed');
+    const moved = migrateHomeStateDir(home);
+    assert.equal(moved, path.join(home, STATE_DIR_NAME));
+    assert.equal(fs.readFileSync(path.join(home, STATE_DIR_NAME, 'captain.md'), 'utf8'), 'seed');
+    assert.equal(migrateHomeStateDir(home), null, 'idempotent');
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+test('server migrates a legacy workspace at boot', async () => {
+  const ws = tmp();
+  // Seed a legacy state dir with a marker; the booting server should move it.
+  write(ws, path.join(LEGACY_STATE_DIR_NAME, 'legacy-marker.txt'), 'ok');
+  const s = await startServer({ dir: ws });
+  try {
+    assert.ok(!fs.existsSync(path.join(ws, LEGACY_STATE_DIR_NAME)), 'legacy dir migrated away');
+    assert.equal(
+      fs.readFileSync(path.join(ws, STATE_DIR_NAME, 'legacy-marker.txt'), 'utf8'),
+      'ok', 'legacy content now under the new dir');
+    const r = await s.api('GET', '/api/status');
+    assert.equal(r.status, 200, 'server healthy on the migrated dir');
+  } finally {
+    await s.stop();
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+});

--- a/test/pause-park.test.js
+++ b/test/pause-park.test.js
@@ -50,10 +50,10 @@ async function boot(extraEnv = {}) {
   return { s, root, repo, fdir, teardown };
 }
 function boardOnDisk(s) {
-  return JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-command', 'board.json'), 'utf8'));
+  return JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-commander', 'board.json'), 'utf8'));
 }
 function seedBoard(dir, board) {
-  const sd = path.join(dir, '.bridge-command');
+  const sd = path.join(dir, '.bridge-commander');
   fs.mkdirSync(sd, { recursive: true });
   fs.writeFileSync(path.join(sd, 'board.json'), JSON.stringify(Object.assign({
     title: 'seeded', seq: 0, lieutenants: [], cards: [], events: [], labels: [], reads: {}, kinds: {},

--- a/test/restore.test.js
+++ b/test/restore.test.js
@@ -8,7 +8,7 @@ const path = require('node:path');
 const { startServerWithLieutenant, withOwner, LT, runCli } = require('./helper');
 
 function archiveRecords(s) {
-  return fs.readFileSync(path.join(s.dir, '.bridge-command', 'archive.jsonl'), 'utf8')
+  return fs.readFileSync(path.join(s.dir, '.bridge-commander', 'archive.jsonl'), 'utf8')
     .split('\n').filter(Boolean).map((l) => JSON.parse(l));
 }
 
@@ -105,7 +105,7 @@ test('a snapshot frozen in Working restores into Backlog (never workerless Worki
   const nowIso = new Date().toISOString();
   const s = await startServerWithLieutenant({
     seed(dir) {
-      const sd = path.join(dir, '.bridge-command');
+      const sd = path.join(dir, '.bridge-commander');
       fs.mkdirSync(sd, { recursive: true });
       fs.writeFileSync(path.join(sd, 'archive.jsonl'), JSON.stringify({
         ts: nowIso, actor: 'user', reason: 'killed',

--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -29,7 +29,7 @@ async function until(what, fn, ms = 15000) {
   }
 }
 function seedBoard(dir, board) {
-  const sd = path.join(dir, '.bridge-command');
+  const sd = path.join(dir, '.bridge-commander');
   fs.mkdirSync(sd, { recursive: true });
   fs.writeFileSync(path.join(sd, 'board.json'), JSON.stringify(Object.assign({
     title: 'seeded', seq: 0, lieutenants: [], cards: [], events: [], labels: [], reads: {}, kinds: {},

--- a/test/supervise.test.js
+++ b/test/supervise.test.js
@@ -33,7 +33,7 @@ async function until(what, fn, ms = 5000) {
   }
 }
 function seedBoard(dir, board) {
-  const sd = path.join(dir, '.bridge-command');
+  const sd = path.join(dir, '.bridge-commander');
   fs.mkdirSync(sd, { recursive: true });
   fs.writeFileSync(path.join(sd, 'board.json'), JSON.stringify(Object.assign({
     title: 'seeded', seq: 0, lieutenants: [], cards: [], events: [], labels: [], reads: {}, kinds: {},
@@ -101,7 +101,7 @@ test('non-resumable respawn relaunches with charter + owned cards + pending queu
           threadStart: null, pendingOrder: null, events: [], thread: [],
         }],
       });
-      const qdir = path.join(dir, '.bridge-command', 'queue');
+      const qdir = path.join(dir, '.bridge-commander', 'queue');
       fs.mkdirSync(qdir, { recursive: true });
       fs.writeFileSync(path.join(qdir, 'ada.jsonl'),
         JSON.stringify({ seq: 1, ts: nowIso, lieutenant: 'ada', kind: 'message', text: 'pending one' }) + '\n');
@@ -170,7 +170,7 @@ test('wake heartbeat: a live lieutenant with pending items is woken by the sweep
       });
       // Seeded straight into the queue file: no queuePush ran, so no wake was
       // ever scheduled — exactly the missed-wake shape the sweep must heal.
-      const qdir = path.join(dir, '.bridge-command', 'queue');
+      const qdir = path.join(dir, '.bridge-commander', 'queue');
       fs.mkdirSync(qdir, { recursive: true });
       fs.writeFileSync(path.join(qdir, 'ada.jsonl'),
         JSON.stringify({ seq: 1, ts: nowIso, lieutenant: 'ada', kind: 'message', text: 'unseen all night' }) + '\n');
@@ -211,7 +211,7 @@ test('wake heartbeat: a stale nudge lapses after BC_WAKE_TTL_MS and the sweep re
           ref: { harness: 'fake', session: 'bc-lt-ada', cwd: '/tmp', resumeId: 'uuid-ada' },
         }],
       });
-      const qdir = path.join(dir, '.bridge-command', 'queue');
+      const qdir = path.join(dir, '.bridge-commander', 'queue');
       fs.mkdirSync(qdir, { recursive: true });
       fs.writeFileSync(path.join(qdir, 'ada.jsonl'),
         JSON.stringify({ seq: 1, ts: nowIso, lieutenant: 'ada', kind: 'message', text: 'stuck wake' }) + '\n');

--- a/test/unblock.test.js
+++ b/test/unblock.test.js
@@ -140,7 +140,7 @@ test('async window is guarded: same-card double start and duplicate in-flight pr
     assert.deepStrictEqual(statuses, [200, 409], JSON.stringify([a.body, b.body]));
     const loser = a.status === 409 ? a : b;
     assert.match(loser.body.error, /already in progress|already Working/);
-    const disk = JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-command', 'board.json'), 'utf8'));
+    const disk = JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-commander', 'board.json'), 'utf8'));
     assert.strictEqual(disk.workers.filter((w) => w.card === 'one').length, 1, 'exactly one worker bound');
 
     // two concurrent adds of the SAME project name: exactly one clone lands

--- a/test/wake.test.js
+++ b/test/wake.test.js
@@ -46,7 +46,7 @@ test('queue append wakes a live-ref lieutenant once; drain re-arms; ack re-arms'
     await s.api('POST', '/api/feedback', { target: 'lieutenant:fk1', text: 'hello' });
     let sends = await waitSends(fdir, 'bc-fk1', 1);
     assert.strictEqual(sends.length, 1);
-    assert.match(sends[0].text, /^\[bridge-command\] 1 pending item\(s\) — run: bc-axi drain$/);
+    assert.match(sends[0].text, /^\[bridge-commander\] 1 pending item\(s\) — run: bc-axi drain$/);
 
     // coalescing: more appends while pending-and-nudged do NOT stack wakes
     await s.api('POST', '/api/feedback', { target: 'lieutenant:fk1', text: 'again' });
@@ -177,7 +177,7 @@ test('lieutenant.create with spawn: real harness.spawn in the workspace root, re
     // launch prompt = doctrine + charter + situating line (recorded by the fake's spawn marker)
     const rec = JSON.parse(fs.readFileSync(path.join(fdir, lt.ref.session + '.json'), 'utf8'));
     // harness state plumbed through the port is the WORKSPACE's, never global
-    assert.strictEqual(rec.stateDir, path.join(s.dir, '.bridge-command', 'harness'));
+    assert.strictEqual(rec.stateDir, path.join(s.dir, '.bridge-commander', 'harness'));
     assert.match(rec.prompt, /Lieutenant doctrine/);
     assert.match(rec.prompt, /guard the gate/);
     assert.match(rec.prompt, /lieutenant "Spawn Bot" \(id: spawn-bot\)/);
@@ -187,7 +187,7 @@ test('lieutenant.create with spawn: real harness.spawn in the workspace root, re
     await s.api('POST', '/api/feedback', { target: 'lieutenant:spawn-bot', text: 'welcome aboard' });
     const sends = await waitSends(fdir, lt.ref.session, 1);
     assert.strictEqual(sends.length, 1);
-    assert.match(sends[0].text, /\[bridge-command\] 1 pending item\(s\)/);
+    assert.match(sends[0].text, /\[bridge-commander\] 1 pending item\(s\)/);
 
     // spawn failure = clean error, no lieutenant registered
     const bad = await s.api('POST', '/api/lieutenants', { name: 'Spawn Bot', spawn: true, harness: 'fake' });

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -50,7 +50,7 @@ async function boot(extraEnv = {}) {
   return { s, root, repo, fdir, teardown };
 }
 function boardOnDisk(s) {
-  return JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-command', 'board.json'), 'utf8'));
+  return JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-commander', 'board.json'), 'utf8'));
 }
 
 test('cards cannot be created in Working (Working ⇔ live worker)', async () => {
@@ -227,7 +227,7 @@ test('investigation: brief carries the report contract, no branch; done attaches
     assert.doesNotMatch(rec.prompt, /Delivery mode/);
 
     // the worker writes the report, then reports done → auto-attached artifact
-    const report = path.join(s.dir, '.bridge-command', 'reports', 'why-slow.md');
+    const report = path.join(s.dir, '.bridge-commander', 'reports', 'why-slow.md');
     fs.mkdirSync(path.dirname(report), { recursive: true });
     fs.writeFileSync(report, '# Findings\nIt was DNS.\n');
     await s.api('POST', '/api/cards/why-slow/worker/done', { outcome: 'report written: it was DNS' });


### PR DESCRIPTION
## What
Rename the product **bridge-command → bridge-commander** / **Bridge Command → Bridge Commander** across docs, skill, server strings, and the state-dir constants. The abbreviation namespace is untouchable and stays byte-identical: `bc-` prefixes, `bc-axi`, `BC_*` env vars, `bc-e2e-scratch`. The GitHub repo rename happens after merge (lieutenant), so this PR ships the code/docs **plus** state migrations so live installs survive flag day.

## Migrations (`server/statedir.js`, shared by server + `bc-axi`)
1. **Workspace state dir** — `<ws>/.bridge-command` → `<ws>/.bridge-commander`, at server boot.
2. **Home state dir** — `~/.bridge-command` → `~/.bridge-commander` (captain.md seed + harness fallback).
3. **`bc-axi` discovery** — walks up accepting **both** names, prefers `.bridge-commander`; migrates on startup when the legacy dir's server isn't live.

All three are idempotent and **non-destructive**: rename only when the new dir is absent; both-present prefers the new dir (no destructive second rename); a live legacy server is left alone (`isLive` pid guard).

## Tests
`test/migrate.test.js` proves: fresh install uses new dir · legacy migrated once (content preserved) · both-present prefers new · live-server guard skips · home migration · server migrates a legacy workspace at boot. Full suite green: **245 pass / 0 fail** (`node --test test/*.test.js harness/test/*.test.js`).

## Kept deliberately
- `bc-axi`, all `bc-` tmux/session/branch prefixes, all `BC_*` env vars, `bc-e2e-scratch`.
- claudegoodies lineage link.
- Legacy-name references remain only in migration comments + the `LEGACY_STATE_DIR_NAME` constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)