### PR TITLE
fix: workspace discovery must validate a state dir, not just find one

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -18,7 +18,7 @@ const { spawn, execFileSync } = require('child_process');
 
 const SELF_DIR = path.dirname(fs.realpathSync(process.argv[1]));
 const SERVER_JS = path.join(SELF_DIR, '..', 'server', 'server.js');
-const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, migrateStateDir, resolveStateDir, migrateHomeStateDir } =
+const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, migrateStateDir, resolveStateDir, migrateHomeStateDir, isWorkspace } =
   require(path.join(SELF_DIR, '..', 'server', 'statedir.js'));
 const DEFAULT_PORT = 4780;
 
@@ -93,12 +93,14 @@ if (cmd === 'card artifact' && positional.length) cmd = cmd + ' ' + positional.s
 
 // ---------- workspace resolution ----------
 // Discovery accepts BOTH the new and legacy state-dir names so a not-yet-migrated
-// install is still found; STATE_DIR resolution then prefers the new name.
+// install is still found; STATE_DIR resolution then prefers the new name. A bare
+// state dir does NOT qualify — isWorkspace() requires config.json or board.json,
+// so the harness state home (~/.bridge-commander/ holding only harness/) is
+// skipped and `init` under $HOME creates a real workspace instead of adopting it.
 function findWorkspace(start) {
   let dir = path.resolve(start);
   for (;;) {
-    if (fs.existsSync(path.join(dir, STATE_DIR_NAME)) ||
-        fs.existsSync(path.join(dir, LEGACY_STATE_DIR_NAME))) return dir;
+    if (isWorkspace(dir)) return dir;
     const up = path.dirname(dir);
     if (up === dir) return null;
     dir = up;

--- a/server/statedir.js
+++ b/server/statedir.js
@@ -27,6 +27,20 @@ function migrateStateDir(ws, isLive) {
   return nu;
 }
 
+// A directory qualifies as a workspace only if it holds a REAL state dir — one
+// with config.json OR board.json. A bare `.bridge-commander/` (e.g. the harness
+// state home `~/.bridge-commander/` that holds only `harness/`) does NOT count,
+// so upward discovery never adopts $HOME as a phantom workspace. Checks both the
+// new and legacy state-dir names.
+function isWorkspace(dir) {
+  for (const name of [STATE_DIR_NAME, LEGACY_STATE_DIR_NAME]) {
+    const sd = path.join(dir, name);
+    if (fs.existsSync(path.join(sd, 'config.json')) ||
+        fs.existsSync(path.join(sd, 'board.json'))) return true;
+  }
+  return false;
+}
+
 // Resolve the workspace state dir: prefer the new name, accept the legacy one,
 // default to the new name for a fresh install.
 function resolveStateDir(ws) {
@@ -50,5 +64,5 @@ function migrateHomeStateDir(home) {
 
 module.exports = {
   STATE_DIR_NAME, LEGACY_STATE_DIR_NAME,
-  migrateStateDir, resolveStateDir, migrateHomeStateDir,
+  migrateStateDir, resolveStateDir, migrateHomeStateDir, isWorkspace,
 };

--- a/test/discovery.test.js
+++ b/test/discovery.test.js
@@ -1,0 +1,128 @@
+'use strict';
+// Workspace discovery must VALIDATE, not just find, a state dir. A bare
+// `.bridge-commander/` does not make a directory a workspace — only one holding
+// config.json or board.json does. This pins the live bug where the harness state
+// home (`~/.bridge-commander/` with only `harness/`) hijacked upward discovery,
+// so a NEW workspace created anywhere under $HOME resolved to $HOME itself.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { CLI } = require('./helper');
+const {
+  STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, isWorkspace,
+} = require('../server/statedir.js');
+
+function tmp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-discovery-')); }
+function write(dir, rel, content) {
+  const p = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+}
+// Run bc-axi from an explicit cwd + HOME (no --workspace), so upward discovery
+// is exercised exactly as it is in the field.
+function runFrom(cwd, home, args) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, ...args], {
+      cwd,
+      env: Object.assign({}, process.env, { HOME: home }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', (c) => (stdout += c));
+    child.stderr.on('data', (c) => (stderr += c));
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+// ---------- unit: isWorkspace ----------
+
+test('isWorkspace: config.json qualifies', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(STATE_DIR_NAME, 'config.json'), '{"port":4780}');
+    assert.equal(isWorkspace(ws), true);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('isWorkspace: board.json qualifies', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(STATE_DIR_NAME, 'board.json'), '{"cards":[]}');
+    assert.equal(isWorkspace(ws), true);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('isWorkspace: legacy state dir with board.json qualifies', () => {
+  const ws = tmp();
+  try {
+    write(ws, path.join(LEGACY_STATE_DIR_NAME, 'board.json'), '{"cards":[]}');
+    assert.equal(isWorkspace(ws), true);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('isWorkspace: a bare .bridge-commander/ does NOT qualify', () => {
+  const ws = tmp();
+  try {
+    fs.mkdirSync(path.join(ws, STATE_DIR_NAME), { recursive: true });
+    assert.equal(isWorkspace(ws), false);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('isWorkspace: the harness state home (only harness/) does NOT qualify', () => {
+  const home = tmp();
+  try {
+    fs.mkdirSync(path.join(home, STATE_DIR_NAME, 'harness'), { recursive: true });
+    assert.equal(isWorkspace(home), false, '~/.bridge-commander/harness is not a workspace');
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+// ---------- integration: upward discovery via the CLI ----------
+
+test('discovery finds a real ancestor workspace (config.json) from a nested cwd', async () => {
+  const root = tmp();
+  const home = tmp();
+  try {
+    // A genuine workspace two levels up, carrying a distinctive config.
+    write(root, path.join(STATE_DIR_NAME, 'config.json'), '{"voices":["marker-v"]}');
+    const nested = path.join(root, 'projects', 'demo');
+    fs.mkdirSync(nested, { recursive: true });
+    const r = await runFrom(nested, home, ['config', 'show']);
+    assert.equal(r.code, 0, r.stderr);
+    assert.deepEqual(JSON.parse(r.stdout).voices, ['marker-v'], 'walked up to the real workspace');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('the harness state home never hijacks init: a NEW workspace is created under $HOME, not $HOME itself', async () => {
+  const home = tmp();
+  try {
+    // Every install has this once a lieutenant/worker has spawned. It must NOT
+    // count as a workspace — before the fix, discovery adopted $HOME here.
+    fs.mkdirSync(path.join(home, STATE_DIR_NAME, 'harness'), { recursive: true });
+    const fleet = path.join(home, 'fleet2', 'sub');
+    fs.mkdirSync(fleet, { recursive: true });
+    // A non-init command resolves the workspace and must find NONE — proving
+    // $HOME was not adopted. (init would then bootstrap the cwd itself.)
+    const r = await runFrom(fleet, home, ['config', 'show']);
+    assert.equal(r.code, 1, 'no workspace found — $HOME was not hijacked');
+    assert.match(r.stderr, /no workspace found/);
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});
+
+test('fresh machine: ancestors with only non-qualifying state dirs resolve to no workspace (init would use cwd)', async () => {
+  const home = tmp();
+  try {
+    // Bare state dir on an ancestor, no config/board anywhere.
+    fs.mkdirSync(path.join(home, STATE_DIR_NAME), { recursive: true });
+    const cwd = path.join(home, 'work', 'proj');
+    fs.mkdirSync(cwd, { recursive: true });
+    const r = await runFrom(cwd, home, ['config', 'show']);
+    assert.equal(r.code, 1, 'nothing qualifies → no workspace, so init bootstraps the cwd');
+    assert.match(r.stderr, /no workspace found/);
+  } finally { fs.rmSync(home, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
## Problem

`bc-axi`'s upward workspace discovery treated ANY directory containing `.bridge-commander/` as a workspace. But `~/.bridge-commander/` exists on **every** install as the harness state home (`BC_HARNESS_STATE`, default `~/.bridge-commander/harness`). So once any lieutenant/worker had spawned, creating a NEW workspace anywhere under `$HOME` resolved to `$HOME` as the "existing workspace":

- `bc-axi init` in `~/fleet2` reported `workspace: /home/u (existing)` and booted a board on the user's home directory.
- Reproduced live (Docker install test): server reported `"workspace":"/root"` for an init run in `/root/myfleet`.

## Fix

Discovery now **validates** a candidate: a `.bridge-commander/` (or legacy `.bridge-command/`) counts as a workspace only if it holds `config.json` OR `board.json`.

- `server/statedir.js` — new shared `isWorkspace(dir)` validator (the shared home for state-dir logic).
- `cli/bc-axi` `findWorkspace` — validates each candidate instead of a bare `existsSync`.
- The harness state home (holding only `harness/`) is skipped automatically, so `init` under `$HOME` bootstraps the cwd instead of adopting `$HOME`.

## Tests (`test/discovery.test.js`)

- `isWorkspace`: config.json / board.json / legacy dir qualify; bare dir and harness-only home do NOT.
- Integration via the CLI (nested cwd, custom `$HOME`, no `--workspace`):
  - real ancestor workspace is found;
  - **harness state home never hijacks** — init under `$HOME` finds no workspace to adopt;
  - fresh machine (only non-qualifying ancestors) → no workspace, so init uses cwd.

No behavior change for real workspaces. Full suite green from repo root (253 pass); `stale.test.js` re-run alone (5 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)