### PR TITLE
docs: improve first-run onboarding for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,127 @@ sessions and are tracked realtime in a kanban board.
 
 ## Install
 
-Just some dependencies and a new skill:
+There are two ways in:
+
+1. **Use the skill** inside Claude Code / Hermes (the intended captain/lieutenant flow)
+2. **Run the tool checkout directly** with `node cli/bc-axi ...` (best for a first local test)
+
+Install the skill like this:
 
 ```sh
-# dependencies
+# optional helper tools
 curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh
 curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
 
-# bridge-commander
+# bridge-commander skill
 npx skills add tonylampada/bridge-commander -g -y   # first /bridge-commander run clones the full tool
 ```
 
-## Quickstart
+Or clone the repo and run the checkout directly:
+
+```sh
+git clone https://github.com/tonylampada/bridge-commander.git
+cd bridge-commander
+```
+
+## 5-minute first run
+
+This is the fastest way to prove the board works locally.
+
+### Minimum needed just to boot the board
+
+- Node ≥ 18
+- `tmux`
+- `git`
+
+Example (Debian/Ubuntu):
+
+```sh
+sudo apt-get install -y tmux
+```
+
+Then:
+
+```sh
+mkdir myfleet
+cd myfleet
+tmux new -s myfleet
+# now you are inside tmux
+node /path/to/bridge-commander/cli/bc-axi init --name "Founding Lieutenant"
+```
+
+That should print a board URL such as:
+
+```text
+http://localhost:4780/
+```
+
+Open that URL in your browser.
+
+### What `init` actually does
+
+- creates `.bridge-commander/`
+- starts the board server
+- registers the current tmux session as the founding lieutenant
+- installs the turn-end hook
+- scaffolds `AGENTS.md`, `captain.md`, and `learnings/`
+
+## Quickstart (skill / guided flow)
 
 - Create an empty folder (e.g. `myfleet`)
-- Start `claude` in that folder, inside tmux
-- `/bridge-commander`
+- Start `claude` in that folder, **inside tmux**
+- Run `/bridge-commander`
 - Open the printed board URL (default `http://localhost:4780/`)
 - Talk to your lieutenant from there — he'll guide you through the rest of the setup
 
 ## Dependencies
 
-- Node ≥ 18, `tmux`, `git`
+### Minimum to boot the board
+
+- Node ≥ 18
+- `tmux`
+- `git`
+
+### Needed for the default real-agent flow
+
 - [Claude Code](https://claude.com/claude-code), authenticated — the default agent harness
-- [GitHub CLI](https://cli.github.com/), authenticated — PR flows
+
+### Needed for PR / GitHub flows
+
+- [GitHub CLI](https://cli.github.com/), authenticated
+
+### Optional extras
+
+- [OpenAI Codex CLI](https://github.com/openai/codex), authenticated — only for `--harness codex`
 - [treehouse](https://github.com/kunchenguid/treehouse) — worker worktrees (optional; falls back to `git worktree`)
 - [no-mistakes](https://github.com/kunchenguid/no-mistakes) — only for `no-mistakes`-mode projects; the `/no-mistakes` skill appears after running `no-mistakes init` in the project
-- [OpenAI Codex CLI](https://github.com/openai/codex) — only for `--harness codex` (optional)
+
+## Troubleshooting first run
+
+### `not inside tmux`
+
+`bc-axi init` must be run from inside a tmux session because the lieutenant's durable address is the tmux session itself.
+
+```sh
+tmux new -s myfleet
+```
+
+Then re-run `init` inside that session.
+
+### Board boots, but no real agents can work
+
+That usually means a harness dependency is missing:
+
+- Claude flow: `claude` must be installed and authenticated
+- Codex flow: `codex` must be installed and authenticated
+- PR flows: `gh` should be installed and authenticated
+
+A common failure mode is: the board opens fine, but the harness CLI stops on a sign-in screen.
+
+### Which entrypoint should I use?
+
+- Use **`/bridge-commander`** when you are inside the skill-driven agent workflow.
+- Use **`node cli/bc-axi ...`** when you want to test the tool checkout directly.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- split install vs direct-checkout entrypoints
- add a 5-minute first-run path for booting the board locally
- separate minimum board prerequisites from harness/GitHub extras
- add first-run troubleshooting for tmux and harness auth

## Validation
- started a fresh workspace with `bc-axi init --name "README Validation 2" --port 4791`
- confirmed the server started and `/api/status` responded on port 4791

## Why
The current README assumes a lot of context (tmux, skill flow, authenticated harnesses). This PR makes the first successful local run much more explicit for new users.