### PR TITLE
feat: add first-run onboarding checklist

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1812,6 +1812,7 @@ if (Number.isInteger(PRWATCH_MS) && PRWATCH_MS > 0) setInterval(prWatchTick, PRW
 // ---------- static ui ----------
 const MIME = {
   '.html': 'text/html; charset=utf-8', '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
   '.css': 'text/css; charset=utf-8', '.svg': 'image/svg+xml', '.png': 'image/png',
 };
 function serveStatic(res, rel) {

--- a/test/onboarding.test.mjs
+++ b/test/onboarding.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { buildSetupState } from '../ui/js/onboarding.mjs';
+
+function sampleDoc(overrides = {}) {
+  return {
+    lieutenants: [],
+    cards: [],
+    projects: [],
+    workers: [],
+    ...overrides,
+  };
+}
+
+test('buildSetupState shows onboarding gaps for a fresh board', () => {
+  const state = buildSetupState(sampleDoc(), { workspace: '/tmp/myfleet', queue_pending: 0 }, true);
+  assert.equal(state.show, true);
+  assert.equal(state.workspace, 'myfleet');
+  assert.equal(state.items.find((item) => item.key === 'session').done, false);
+  assert.equal(state.items.find((item) => item.key === 'card').done, false);
+  assert.equal(state.actions.some((action) => action.id === 'add-lieutenant'), true);
+  assert.match(state.nextStep, /registering a lieutenant session/i);
+});
+
+test('buildSetupState collapses once the board is ready', () => {
+  const state = buildSetupState(sampleDoc({
+    lieutenants: [{ id: 'ops', ref: { harness: 'claude', session: 'bc-ops', cwd: '/tmp/myfleet' } }],
+    cards: [{ id: 'card-1' }],
+    projects: [{ name: 'bridge-commander', mode: 'local-only', path: '/tmp/myfleet/projects/bridge-commander' }],
+    workers: [{ card: 'card-1', ref: { harness: 'claude', session: 'bc-ops:1', cwd: '/tmp/myfleet' } }],
+  }), { workspace: '/tmp/myfleet', queue_pending: 2 }, true);
+  assert.equal(state.show, false);
+  assert.equal(state.items.find((item) => item.key === 'session').done, true);
+  assert.equal(state.items.find((item) => item.key === 'project').done, true);
+  assert.equal(state.items.find((item) => item.key === 'harness').done, true);
+  assert.equal(state.counts.queuePending, 2);
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -102,6 +102,54 @@ input, textarea, select { font: inherit; color: var(--text); }
 }
 #board-wrap { flex: 1; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
 
+/* ---------- first-run setup checklist ---------- */
+#setup-panel { flex: none; padding: 10px 14px 0; }
+.setup-card {
+  display: flex; flex-direction: column; gap: 12px; padding: 14px 16px;
+  background: linear-gradient(180deg, rgba(88, 182, 255, .12), rgba(19, 26, 36, .96));
+  border: 1px solid var(--line2); border-radius: 14px; box-shadow: 0 10px 28px rgba(0, 0, 0, .28);
+}
+.setup-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
+.setup-kicker { color: var(--accent); font-size: 10.5px; font-weight: 700; letter-spacing: 1.2px; text-transform: uppercase; }
+.setup-head h2 { margin-top: 2px; font-size: 15px; font-weight: 650; }
+.setup-head p { margin-top: 4px; color: var(--dim); font-size: 12.5px; max-width: 680px; }
+.setup-workspace {
+  flex: none; display: inline-flex; align-items: center; gap: 6px; padding: 5px 9px;
+  border-radius: 999px; background: rgba(10, 13, 18, .42); border: 1px solid var(--line);
+  color: var(--dim); font-size: 11px; white-space: nowrap;
+}
+.setup-list {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px;
+  list-style: none;
+}
+.setup-item {
+  display: flex; align-items: flex-start; gap: 9px; padding: 10px 11px;
+  border-radius: 10px; background: rgba(10, 13, 18, .32); border: 1px solid rgba(43, 58, 78, .9);
+}
+.setup-item.done { border-color: rgba(62, 207, 142, .45); background: rgba(62, 207, 142, .08); }
+.setup-item.optional { border-style: dashed; }
+.setup-mark {
+  flex: none; width: 20px; height: 20px; border-radius: 50%;
+  display: inline-flex; align-items: center; justify-content: center;
+  background: rgba(88, 182, 255, .14); color: var(--accent); font-size: 12px; font-weight: 700;
+}
+.setup-item.done .setup-mark { background: rgba(62, 207, 142, .18); color: var(--ok); }
+.setup-copy { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.setup-label { font-size: 12.5px; font-weight: 620; }
+.setup-detail { color: var(--dim); font-size: 11.5px; line-height: 1.45; }
+.setup-next {
+  color: var(--text); font-size: 12.5px; padding: 9px 11px;
+  border-left: 3px solid var(--accent); background: rgba(10, 13, 18, .34); border-radius: 8px;
+}
+.setup-actions { display: flex; flex-wrap: wrap; gap: 8px; }
+.setup-action {
+  padding: 7px 12px; border-radius: 8px; background: var(--accent2); color: #eaf6ff;
+  border: 1px solid transparent; font-size: 12px; font-weight: 620;
+}
+.setup-action:hover { background: var(--accent); color: #06222f; }
+.setup-action.secondary { background: transparent; color: var(--dim); border-color: var(--line2); }
+.setup-action.secondary:hover { color: var(--text); border-color: var(--accent2); background: rgba(88, 182, 255, .08); }
+
 /* drag handle on a panel's inner edge (resize.js); hidden on narrow screens
    where the panels are full-width */
 .pane-resize { position: absolute; top: 0; bottom: 0; width: 7px; cursor: col-resize; z-index: 5; touch-action: none; }
@@ -772,6 +820,11 @@ a.a-uri { color: var(--accent); }
   #board-wrap { display: none; }
   body[data-view="chat"] #chat { display: flex; }
   body[data-view="board"] #board-wrap { display: flex; }
+  #setup-panel { padding: 10px 10px 0; }
+  .setup-card { padding: 12px; gap: 10px; }
+  .setup-head { flex-direction: column; }
+  .setup-workspace { white-space: normal; }
+  .setup-list { grid-template-columns: 1fr; }
   /* the tab bar is a normal bottom flex child of the viewport-locked column —
      never floating; the home-indicator inset keeps it above the gesture bar */
   #tabs {

--- a/ui/index.html
+++ b/ui/index.html
@@ -95,6 +95,7 @@
   <!-- board: right — lieutenant lane above the columns -->
   <section id="board-wrap">
     <div id="lane"></div>
+    <section id="setup-panel" hidden></section>
     <div id="board"><div class="empty">waiting for board…</div></div>
   </section>
 </main>

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -50,4 +50,5 @@ export const api = {
   artifact: (uri) => j('GET', '/api/artifact?uri=' + encodeURIComponent(uri)),
   board: () => j('GET', '/api/board'),
   config: () => j('GET', '/api/config'),
+  status: () => j('GET', '/api/status'),
 };

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -7,9 +7,63 @@ import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
 import { openCardPane, openLieutenantPane } from './pane.js';
+import { SETUP_DISMISS_KEY, buildSetupState } from './onboarding.mjs';
 
 const laneEl = document.getElementById('lane');
+const setupEl = document.getElementById('setup-panel');
 const boardEl = document.getElementById('board');
+
+function setupDismissed() {
+  try { return localStorage.getItem(SETUP_DISMISS_KEY) === '1'; }
+  catch (e) { return false; }
+}
+
+function setSetupDismissed(v) {
+  try {
+    if (v) localStorage.setItem(SETUP_DISMISS_KEY, '1');
+    else localStorage.removeItem(SETUP_DISMISS_KEY);
+  } catch (e) {}
+}
+
+function setupPanelHtml(state) {
+  const items = state.items.map((item) =>
+    '<li class="setup-item' + (item.done ? ' done' : '') + (item.optional ? ' optional' : '') + '">' +
+      '<span class="setup-mark" aria-hidden="true">' + (item.done ? '✓' : item.optional ? '·' : '○') + '</span>' +
+      '<span class="setup-copy"><span class="setup-label">' + esc(item.label) + '</span>' +
+      '<span class="setup-detail">' + esc(item.detail) + '</span></span>' +
+    '</li>').join('');
+  const actions = state.actions.map((action) =>
+    '<button type="button" class="setup-action' + (action.secondary ? ' secondary' : '') + '" data-action="' + esc(action.id) + '">' + esc(action.label) + '</button>'
+  ).join('');
+  return '<div class="setup-card">' +
+    '<div class="setup-head"><div><div class="setup-kicker">onboarding</div><h2>' + esc(state.title) + '</h2>' +
+    '<p>' + esc(state.summary) + '</p></div>' +
+    (state.workspace ? '<span class="setup-workspace" title="workspace">📂 ' + esc(state.workspace) + '</span>' : '') +
+    '</div>' +
+    '<ul class="setup-list">' + items + '</ul>' +
+    '<div class="setup-next">' + esc(state.nextStep) + '</div>' +
+    '<div class="setup-actions">' + actions + '</div>' +
+  '</div>';
+}
+
+function renderSetupPanel() {
+  const state = buildSetupState(S.doc, S.boardStatus, S.connected, { dismissed: setupDismissed() });
+  if (!state.show) {
+    setupEl.hidden = true;
+    setupEl.textContent = '';
+    return;
+  }
+  setupEl.hidden = false;
+  if (!setHtmlIfChanged(setupEl, setupPanelHtml(state))) return;
+  setupEl.querySelectorAll('[data-action]').forEach((el) => {
+    el.onclick = () => {
+      const action = el.dataset.action;
+      if (action === 'add-lieutenant') { setSetupDismissed(false); openNewLieutenant(); return; }
+      if (action === 'create-card') { setSetupDismissed(false); openNewCard('backlog'); return; }
+      if (action === 'dismiss') { setSetupDismissed(true); render(); }
+    };
+  });
+}
 
 function byRecency(a, b) {
   return (new Date(cardRecency(b) || 0).getTime() || 0) - (new Date(cardRecency(a) || 0).getTime() || 0);
@@ -156,6 +210,7 @@ function tileHtml(c) {
 
 export function renderBoard() {
   renderLane();
+  renderSetupPanel();
   const cols = columns();
   const html = !cols.length
     ? '<div class="empty">waiting for board…</div>'

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -162,7 +162,12 @@ function applyBoard(doc) {
   render();
 }
 function refetchBoard() {
-  api.board().then(applyBoard).catch(() => {}); // still down — the watchdog retries
+  Promise.all([api.board(), api.status().catch(() => null)])
+    .then(([doc, status]) => {
+      if (status) S.boardStatus = status;
+      applyBoard(doc);
+    })
+    .catch(() => {}); // still down — the watchdog retries
 }
 function connect() {
   if (es) es.close();

--- a/ui/js/onboarding.mjs
+++ b/ui/js/onboarding.mjs
@@ -1,0 +1,117 @@
+const WORKSPACE_NAME_RE = /[^/\\]+$/;
+
+function plural(n, one, many = one + 's') {
+  return n === 1 ? one : many;
+}
+
+function uniq(values) {
+  return [...new Set(values.filter(Boolean))];
+}
+
+function workspaceLabel(status) {
+  const ws = status && typeof status.workspace === 'string' ? status.workspace.trim() : '';
+  if (!ws) return '';
+  const m = ws.match(WORKSPACE_NAME_RE);
+  return m ? m[0] : ws;
+}
+
+export const SETUP_DISMISS_KEY = 'bc.setup-checklist.dismissed.v1';
+
+export function buildSetupState(doc, status, connected, opts = {}) {
+  const dismissed = !!opts.dismissed;
+  const lieutenants = Array.isArray(doc && doc.lieutenants) ? doc.lieutenants : [];
+  const cards = Array.isArray(doc && doc.cards) ? doc.cards : [];
+  const projects = Array.isArray(doc && doc.projects) ? doc.projects : [];
+  const workers = Array.isArray(doc && doc.workers) ? doc.workers : [];
+  const registered = lieutenants.filter((lt) => lt && lt.ref && lt.ref.session);
+  const harnesses = uniq([
+    ...registered.map((lt) => lt.ref && lt.ref.harness),
+    ...workers.map((w) => w && w.ref && w.ref.harness),
+  ]);
+  const ws = workspaceLabel(status);
+  const queuePending = Number(status && status.queue_pending) || 0;
+  const boardReady = !!doc && !!connected;
+  const sessionsReady = registered.length > 0;
+  const projectReady = projects.length > 0;
+  const harnessReady = harnesses.length > 0 || workers.length > 0;
+  const cardsReady = cards.length > 0;
+  const canCreateCard = lieutenants.length > 0;
+  const show = !dismissed && (!boardReady || !sessionsReady || !cardsReady || !projectReady);
+
+  const items = [
+    {
+      key: 'board',
+      label: 'Board connection',
+      done: boardReady,
+      detail: boardReady
+        ? 'Live' + (ws ? ' for ' + ws : '') + (queuePending ? ' · ' + queuePending + ' pending ' + plural(queuePending, 'queue item') : '')
+        : 'Waiting for the local board server…',
+    },
+    {
+      key: 'session',
+      label: 'Lieutenant / tmux session',
+      done: sessionsReady,
+      detail: sessionsReady
+        ? registered.length + ' registered ' + plural(registered.length, 'session')
+        : 'No lieutenant session is registered yet — add or re-register one from tmux.',
+    },
+    {
+      key: 'project',
+      label: 'Project integration',
+      done: projectReady,
+      optional: true,
+      detail: projectReady
+        ? projects.length + ' registered ' + plural(projects.length, 'project')
+        : 'Optional: register a repo with bc-axi project add <url|path> --mode <mode>.',
+    },
+    {
+      key: 'harness',
+      label: 'Harness readiness',
+      done: harnessReady,
+      optional: !sessionsReady,
+      detail: harnessReady
+        ? 'Ready via ' + harnesses.join(', ') + (workers.length ? ' · ' + workers.length + ' live ' + plural(workers.length, 'worker') : '')
+        : sessionsReady
+          ? 'A lieutenant is registered; harness details appear once work starts.'
+          : 'Register a lieutenant first so the board can attach to a real session.',
+    },
+    {
+      key: 'card',
+      label: 'First work item',
+      done: cardsReady,
+      detail: cardsReady
+        ? cards.length + ' ' + plural(cards.length, 'card') + ' on the board'
+        : canCreateCard
+          ? 'Create a first card to start routing work through the board.'
+          : 'Add a lieutenant first, then create the first card.',
+    },
+  ];
+
+  const actions = [];
+  if (!lieutenants.length) actions.push({ id: 'add-lieutenant', label: 'Add lieutenant' });
+  if (canCreateCard && !cardsReady) actions.push({ id: 'create-card', label: 'Create first card' });
+  actions.push({ id: 'dismiss', label: 'Hide checklist', secondary: true });
+
+  let nextStep = 'Board is ready.';
+  if (!sessionsReady) nextStep = 'Start by registering a lieutenant session from tmux.';
+  else if (!cardsReady) nextStep = 'Next: create the first card so work can be delegated.';
+  else if (!projectReady) nextStep = 'Optional next: register a project to enable worker worktrees and PR flows.';
+
+  return {
+    show,
+    title: 'First-run setup checklist',
+    summary: 'A lightweight readiness pass for this board before you start delegating work.',
+    nextStep,
+    items,
+    actions,
+    workspace: ws,
+    counts: {
+      lieutenants: lieutenants.length,
+      registeredSessions: registered.length,
+      projects: projects.length,
+      workers: workers.length,
+      cards: cards.length,
+      queuePending,
+    },
+  };
+}

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -4,6 +4,7 @@ export const USER = 'user';
 
 export const S = {
   doc: null,               // full board doc from the server
+  boardStatus: null,       // lightweight /api/status snapshot for readiness UI
   connected: false,
   // The chat panel always talks to a lieutenant: either its main chat or one of
   // its card threads (the interlocutor of a card thread is the owning


### PR DESCRIPTION
## Summary
- add an in-board first-run setup checklist panel above the kanban columns
- surface board/session/project/harness readiness using the existing board + status APIs
- add lightweight onboarding state tests and wire `.mjs` module serving for the browser

## Validation
- node --check server/server.js && node --check ui/js/main.js && node --check ui/js/api.js && node --check ui/js/state.js
- node --check ui/js/board.js && node --check ui/js/onboarding.mjs
- node --test test/onboarding.test.mjs test/status.test.js test/sse.test.js
- node --test
- manual browser check against a local demo board on http://127.0.0.1:4899/