### PR TITLE
feat: add bc-axi doctor preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ npx skills add tonylampada/bridge-commander -g -y   # first /bridge-commander ru
 ## Quickstart
 
 - Create an empty folder (e.g. `myfleet`)
-- Start `claude` in that folder, **inside tmux** (not optional — the lieutenant lives in the tmux session)
+- Start `claude` in that folder, inside tmux
+- Optional but recommended: run `bc-axi doctor` to verify Node/tmux/git/gh/claude/codex, tmux, workspace readiness, and the board port before bootstrapping
 - `/bridge-commander`
 - Open the printed board URL (default `http://localhost:4780/`)
 - Talk to your lieutenant from there — he'll guide you through the rest of the setup

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -12,6 +12,7 @@
 
 const http = require('http');
 const fs = require('fs');
+const net = require('net');
 const os = require('os');
 const path = require('path');
 const { spawn, execFileSync } = require('child_process');
@@ -116,9 +117,12 @@ function stateDirLive(dir) {
     return true;
   } catch (e) { return false; }
 }
+const DISCOVERED_WORKSPACE = findWorkspace(process.cwd());
 const WORKSPACE = opts.workspace
   ? path.resolve(opts.workspace)
-  : (cmd === 'open' || cmd === 'init' ? (findWorkspace(process.cwd()) || process.cwd()) : findWorkspace(process.cwd()));
+  : (cmd === 'open' || cmd === 'init' || cmd === 'doctor'
+    ? (DISCOVERED_WORKSPACE || process.cwd())
+    : DISCOVERED_WORKSPACE);
 if (!WORKSPACE) die('no workspace found: no ' + STATE_DIR_NAME + '/ from cwd upward (run `bc-axi init` to start one here, or pass --workspace)');
 // One-shot rename migrations (bridge-command → bridge-commander), idempotent and
 // guarded so a running legacy server is left alone.
@@ -183,6 +187,65 @@ function parseAttrs(list) {
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 function hhmm(iso) { try { return new Date(iso).toISOString().slice(5, 16).replace('T', ' '); } catch (e) { return ''; } }
 const TARGET_RE = /^(lieutenant:.+|card:.+)$/;
+function compareSemverish(a, b) {
+  const pa = String(a || '').replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b || '').replace(/^v/, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const da = pa[i] || 0;
+    const db = pb[i] || 0;
+    if (da > db) return 1;
+    if (da < db) return -1;
+  }
+  return 0;
+}
+function shellQuote(s) {
+  return /[^A-Za-z0-9_@%+=:,./-]/.test(s) ? '"' + String(s).replace(/(["\\$`])/g, '\\$1') + '"' : String(s);
+}
+function commandOnPath(name) {
+  const pathEnv = process.env.PATH || '';
+  const exts = process.platform === 'win32'
+    ? (process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+    : [''];
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    for (const ext of exts) {
+      const file = path.join(dir, process.platform === 'win32' ? name + ext : name);
+      try {
+        fs.accessSync(file, fs.constants.X_OK);
+        return file;
+      } catch (e) {}
+    }
+  }
+  return null;
+}
+function runCheck(command, args, opts) {
+  try {
+    const out = execFileSync(command, args || [], Object.assign({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }, opts || {}));
+    return { ok: true, output: String(out || '').trim() };
+  } catch (e) {
+    const stderr = e && e.stderr != null ? String(e.stderr).trim() : '';
+    const stdout = e && e.stdout != null ? String(e.stdout).trim() : '';
+    return { ok: false, code: e && e.status, output: stderr || stdout || (e && e.message) || '' };
+  }
+}
+function portAvailable(port, host) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    const finish = (result) => {
+      if (!srv.listening) return resolve(result);
+      srv.close(() => resolve(result));
+    };
+    srv.once('error', (err) => finish({ ok: false, detail: err.code || err.message }));
+    srv.listen(port, host, () => finish({ ok: true, detail: host + ':' + port }));
+  });
+}
+function doctorLine(status, label, detail, fix) {
+  const icon = status === 'PASS' ? '✓' : status === 'WARN' ? '!' : '✗';
+  let line = icon + ' ' + status.padEnd(4) + ' ' + label + ' — ' + detail;
+  if (fix) line += '\n         fix: ' + fix;
+  return line;
+}
 // Agent-facing attachment lines: the ABSOLUTE local path per file, so the agent
 // can Read it. Images are flagged so the agent knows they're viewable inline.
 function attachmentLines(atts) {
@@ -849,6 +912,89 @@ async function cmdStatus() {
     '  pending-queue=' + st.queue_pending + '  url=http://localhost:' + PORT + '/');
 }
 
+// ---------- doctor ----------
+async function cmdDoctor() {
+  const cfg = readConfig();
+  const host = opts.host || (typeof cfg.host === 'string' && cfg.host ? cfg.host : '127.0.0.1');
+  const lines = [];
+  let pass = 0, warn = 0, fail = 0;
+  const add = (status, label, detail, fix) => {
+    if (status === 'PASS') pass++;
+    else if (status === 'WARN') warn++;
+    else fail++;
+    lines.push(doctorLine(status, label, detail, fix));
+  };
+
+  const minNode = '18.0.0';
+  const nodeVersion = process.version;
+  if (compareSemverish(nodeVersion, minNode) >= 0) add('PASS', 'node', nodeVersion + ' (requires >= ' + minNode + ')');
+  else add('FAIL', 'node', nodeVersion + ' is too old (requires >= ' + minNode + ')', 'Upgrade Node before using bridge-commander.');
+
+  const tmuxPath = commandOnPath('tmux');
+  if (tmuxPath) add('PASS', 'tmux installed', tmuxPath);
+  else add('FAIL', 'tmux installed', 'not found on PATH', 'Install tmux, then re-run `bc-axi doctor`.');
+
+  const gitPath = commandOnPath('git');
+  if (gitPath) add('PASS', 'git installed', gitPath);
+  else add('FAIL', 'git installed', 'not found on PATH', 'Install git, then re-run `bc-axi doctor`.');
+
+  const ghPath = commandOnPath('gh');
+  if (!ghPath) add('FAIL', 'gh installed', 'not found on PATH', 'Install GitHub CLI from https://cli.github.com/ .');
+  else {
+    const ghAuth = runCheck('gh', ['auth', 'status']);
+    if (ghAuth.ok) {
+      const first = ghAuth.output.split('\n').find(Boolean) || 'authenticated';
+      add('PASS', 'gh authenticated', first);
+    } else {
+      add('FAIL', 'gh authenticated', ghAuth.output || 'not authenticated', 'Run `gh auth login` and confirm `gh auth status` succeeds.');
+    }
+  }
+
+  const claudePath = commandOnPath('claude');
+  if (claudePath) add('PASS', 'claude installed', claudePath);
+  else add('FAIL', 'claude installed', 'not found on PATH', 'Install/authenticate Claude Code — it is the default harness.');
+
+  const codexPath = commandOnPath('codex');
+  if (!codexPath) add('WARN', 'codex installed', 'not found on PATH (optional unless you use `--harness codex`)');
+  else {
+    const codexAuth = runCheck('codex', ['login', 'status']);
+    if (codexAuth.ok) {
+      const first = codexAuth.output.split('\n').find(Boolean) || 'authenticated';
+      add('PASS', 'codex authenticated', first);
+    } else {
+      add('WARN', 'codex authenticated', codexAuth.output || 'unable to confirm auth', 'If you plan to use Codex workers, run `codex login` first.');
+    }
+  }
+
+  if (process.env.TMUX) add('PASS', 'inside tmux', 'TMUX=' + process.env.TMUX);
+  else add('FAIL', 'inside tmux', 'TMUX is not set', 'Start or re-enter tmux, then run bridge-commander from that session.');
+
+  const currentIsWorkspace = isWorkspace(process.cwd());
+  if (opts.workspace) {
+    if (isWorkspace(WORKSPACE)) add('PASS', 'workspace', 'yes — ' + WORKSPACE);
+    else add('FAIL', 'workspace', 'no workspace at ' + WORKSPACE, 'Run `bc-axi init --workspace ' + shellQuote(WORKSPACE) + ' --name <founding-lieutenant-name>` there.');
+  } else if (currentIsWorkspace) {
+    add('PASS', 'workspace', 'yes — current directory is a workspace root (' + WORKSPACE + ')');
+  } else if (DISCOVERED_WORKSPACE) {
+    add('WARN', 'workspace', 'current directory is inside workspace ' + DISCOVERED_WORKSPACE + ' but is not the workspace root', 'Run from the workspace root or pass `--workspace ' + shellQuote(DISCOVERED_WORKSPACE) + '` explicitly.');
+  } else {
+    add('FAIL', 'workspace', 'current directory is not a bridge-commander workspace', 'Run `bc-axi init --name <founding-lieutenant-name>` in the directory you want to use.');
+  }
+
+  const portCheck = await portAvailable(PORT, host);
+  if (portCheck.ok) add('PASS', 'port ' + PORT, 'available on ' + host);
+  else add('FAIL', 'port ' + PORT, 'in use or unavailable on ' + host + ' (' + portCheck.detail + ')', 'Pick another port with `bc-axi open --port <n>` or update ' + CONFIG_FILE + '.');
+
+  console.log('Bridge Commander doctor');
+  console.log('workspace target: ' + WORKSPACE);
+  console.log('cwd: ' + process.cwd());
+  console.log('');
+  for (const line of lines) console.log(line);
+  console.log('');
+  console.log('Summary: ' + pass + ' pass, ' + warn + ' warn, ' + fail + ' fail');
+  if (fail) process.exit(1);
+}
+
 // ---------- config ----------
 async function cmdConfig() {
   const sub = positional[0];
@@ -874,7 +1020,7 @@ async function cmdConfig() {
 
 const commands = {
   init: cmdInit,
-  open: cmdOpen, stop: cmdStop, status: cmdStatus, config: cmdConfig,
+  open: cmdOpen, stop: cmdStop, status: cmdStatus, doctor: cmdDoctor, config: cmdConfig,
   board: cmdBoard, thread: cmdThread, archived: cmdArchived, kinds: cmdKinds,
   'lieutenant create': cmdLtCreate, 'lieutenant list': cmdLtList, 'lieutenant retire': cmdLtRetire,
   'project add': cmdProjectAdd, 'project list': cmdProjectList,
@@ -901,6 +1047,8 @@ if (!commands[cmd]) {
     '  open [--port N] [--host H]             start the workspace server if needed (idempotent), print URL.\n' +
     '                                         Bootstraps .bridge-commander/ in cwd on first run.\n' +
     '  status                                 up/down, cards, lieutenants, pending queue items\n' +
+    '  doctor [--workspace DIR] [--port N]    preflight checks: node/tmux/git/gh/claude/codex, tmux,\n' +
+    '                                         workspace readiness, and port availability\n' +
     '  stop                                   stop the workspace server\n' +
     '\nlieutenant:\n' +
     '  lieutenant create --name N [--id id] [--color #rrggbb] [--charter-file f|-] [--spawn [--harness h]]\n' +

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -1,0 +1,80 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+const { CLI } = require('./helper');
+
+function runDoctor(args, opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [CLI, 'doctor', ...args], {
+      cwd: opts.cwd,
+      env: Object.assign({}, process.env, opts.env || {}),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (c) => (stdout += c));
+    child.stderr.on('data', (c) => (stderr += c));
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+}
+
+function makeStub(binDir, name, script) {
+  const file = path.join(binDir, name);
+  fs.writeFileSync(file, script, { mode: 0o755 });
+}
+
+test('bc-axi doctor runs outside a workspace and reports actionable preflight state', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-doctor-'));
+  try {
+    const r = await runDoctor([], { cwd: dir });
+    assert.notStrictEqual(r.code, 0, 'doctor should fail when prerequisites are missing');
+    assert.match(r.stdout, /Bridge Commander doctor/i);
+    assert.match(r.stdout, /workspace/i);
+    assert.doesNotMatch(r.stderr, /no workspace found/i);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('bc-axi doctor checks command availability, auth, tmux, workspace, and busy port', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-doctor-'));
+  const binDir = path.join(dir, 'bin');
+  fs.mkdirSync(path.join(dir, '.bridge-commander'), { recursive: true });
+  fs.mkdirSync(binDir, { recursive: true });
+  const port = 48999;
+  fs.writeFileSync(path.join(dir, '.bridge-commander', 'config.json'), JSON.stringify({ port }, null, 2));
+
+  makeStub(binDir, 'tmux', '#!/bin/sh\nif [ "$1" = "display-message" ]; then\n  printf "bridge-session\\n"\n  exit 0\nfi\nexit 0\n');
+  makeStub(binDir, 'git', '#!/bin/sh\nprintf "git version 2.45.0\\n"\n');
+  makeStub(binDir, 'gh', '#!/bin/sh\nif [ "$1" = "auth" ] && [ "$2" = "status" ]; then\n  printf "logged in as botmarvin\\n"\n  exit 0\nfi\nprintf "gh version 2.45.0\\n"\n');
+  makeStub(binDir, 'claude', '#!/bin/sh\nprintf "claude 1.0.0\\n"\n');
+  makeStub(binDir, 'codex', '#!/bin/sh\nif [ "$1" = "login" ] && [ "$2" = "status" ]; then\n  printf "Logged in\\n"\n  exit 0\nfi\nprintf "codex 1.0.0\\n"\n');
+
+  const busy = net.createServer();
+  await new Promise((resolve) => busy.listen(port, '127.0.0.1', resolve));
+  try {
+    const env = {
+      PATH: binDir + path.delimiter + process.env.PATH,
+      TMUX: '/tmp/tmux-stub',
+    };
+    const r = await runDoctor(['--workspace', dir], { cwd: dir, env });
+    assert.notStrictEqual(r.code, 0, 'doctor should fail on a busy port');
+    assert.match(r.stdout, /node/i);
+    assert.match(r.stdout, /tmux[\s\S]*installed/i);
+    assert.match(r.stdout, /git[\s\S]*installed/i);
+    assert.match(r.stdout, /gh[\s\S]*authenticated/i);
+    assert.match(r.stdout, /claude[\s\S]*installed/i);
+    assert.match(r.stdout, /codex[\s\S]*authenticated/i);
+    assert.match(r.stdout, /inside tmux/i);
+    assert.match(r.stdout, /workspace[\s\S]*yes/i);
+    assert.match(r.stdout, new RegExp(String(port) + '[\\s\\S]*in use'));
+  } finally {
+    await new Promise((resolve) => busy.close(resolve));
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add a new `bc-axi doctor` preflight command with actionable checks for toolchain, auth, tmux, workspace readiness, and port availability
- allow doctor to run outside an initialized workspace so it can report what is missing instead of bailing early
- add CLI coverage for outside-workspace and busy-port/tool-auth scenarios, plus a README quickstart note

## Validation
- `node --test test/doctor.test.js test/cli.test.js`
- `node --test test/*.test.js harness/test/*.test.js`
- `node cli/bc-axi doctor --workspace /opt/data/bridge-commander-doctor`