### PR TITLE
Fail fast when harness or auth is not ready

### DIFF
--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -43,11 +43,21 @@ const s = require('./tmux-session.js');
 
 const HOOK_SCRIPT = path.join(__dirname, 'turnend-hook.js');
 const TRUST_RE = /Yes, I trust this folder|Quick safety check/;
+const FAILURE_DETECTORS = [
+  {
+    re: /(?:^|\n)\s*(?:bash|zsh|sh|fish|dash|ksh)?:?\s*claude: command not found\b|(?:^|\n)\s*claude: not found\b/i,
+    message: 'claude CLI is not installed or not on PATH; install Claude Code and retry',
+  },
+  {
+    re: /(?:^|\n).*(?:claude login|please login|login required|sign in to claude|authenticate to claude)/i,
+    message: 'claude CLI is waiting for interactive sign-in; run `claude login` in a normal terminal and retry',
+  },
+];
 
 // UI_READY_RE matches signatures only the main UI renders (composer prompt,
 // busy footer, permission-mode footer) and the trust screen does not.
 const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
-const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'claude' };
+const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'claude', failureDetectors: FAILURE_DETECTORS };
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
 // Idempotent; preserves any existing settings/hooks. Also hides the file from

--- a/harness/codex-tmux.js
+++ b/harness/codex-tmux.js
@@ -49,13 +49,23 @@ const s = require('./tmux-session.js');
 
 const NOTIFY_SCRIPT = path.join(__dirname, 'codex-notify.js');
 const TRUST_RE = /Do you trust the contents of this directory|Yes, continue/;
+const FAILURE_DETECTORS = [
+  {
+    re: /(?:^|\n)\s*(?:bash|zsh|sh|fish|dash|ksh)?:?\s*codex: command not found\b|(?:^|\n)\s*codex: not found\b/i,
+    message: 'codex CLI is not installed or not on PATH; install the OpenAI Codex CLI and retry',
+  },
+  {
+    re: /(?:^|\n).*(?:codex login|sign in to openai|openai codex login|login required|authenticate to openai)/i,
+    message: 'codex CLI is waiting for interactive sign-in; run `codex login` in a normal terminal and retry',
+  },
+];
 
 // UI_READY_RE matches signatures only the codex main UI renders: the intro
 // box (">_ OpenAI Codex (vX.Y.Z)"), the YOLO-mode permissions line, or the
 // composer prompt glyph '›' at a line start. The directory-trust screen shows
 // none of these as a line of its own — and trustRe is checked first anyway.
 const UI_READY_RE = /OpenAI Codex \(v|YOLO mode|\n›/;
-const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'codex' };
+const SETTLE = { trustRe: TRUST_RE, readyRe: UI_READY_RE, label: 'codex', failureDetectors: FAILURE_DETECTORS };
 
 // The bypass + notify flags every codex launch (spawn AND resume) carries.
 function launchFlags(stateDir, key, callbackUrl) {

--- a/harness/test/tmux-session.test.js
+++ b/harness/test/tmux-session.test.js
@@ -1,0 +1,33 @@
+'use strict';
+const test = require('node:test');
+const assert = require('node:assert');
+const { detectLaunchFailure } = require('../tmux-session.js');
+
+test('detectLaunchFailure: missing CLI gets a crisp reason', () => {
+  const sig = {
+    failureDetectors: [
+      { re: /claude: command not found/i, message: 'claude CLI is not installed or not on PATH; install Claude Code and retry' },
+    ],
+  };
+  assert.strictEqual(
+    detectLaunchFailure(sig, 'bash: claude: command not found'),
+    'claude CLI is not installed or not on PATH; install Claude Code and retry'
+  );
+});
+
+test('detectLaunchFailure: sign-in screen gets a crisp reason', () => {
+  const sig = {
+    failureDetectors: [
+      { re: /sign in to openai|codex login/i, message: 'codex CLI is waiting for interactive sign-in; run `codex login` in a normal terminal and retry' },
+    ],
+  };
+  assert.strictEqual(
+    detectLaunchFailure(sig, 'OpenAI Codex Login\nSign in to OpenAI to continue'),
+    'codex CLI is waiting for interactive sign-in; run `codex login` in a normal terminal and retry'
+  );
+});
+
+test('detectLaunchFailure: unmatched pane tail yields null', () => {
+  const sig = { failureDetectors: [{ re: /command not found/i, message: 'missing' }] };
+  assert.strictEqual(detectLaunchFailure(sig, 'all good\n❯'), null);
+});

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -147,6 +147,15 @@ function paneTail(pane) {
   return pane.replace(/\s+$/, '').split('\n').slice(-SETTLE_TAIL_LINES).join('\n');
 }
 
+function detectLaunchFailure(sig, tail) {
+  if (!sig || !Array.isArray(sig.failureDetectors)) return null;
+  for (const det of sig.failureDetectors) {
+    if (!det || !(det.re instanceof RegExp) || typeof det.message !== 'string') continue;
+    if (det.re.test(tail)) return det.message;
+  }
+  return null;
+}
+
 async function launchAndSettle(target, launchCmd, sig) {
   await t.sendLiteral(target, launchCmd);
   await t.sleep(300);
@@ -157,8 +166,10 @@ async function launchAndSettle(target, launchCmd, sig) {
     await t.sleep(500);
     const cmd = await paneCommand(target);
     if (cmd === null) throw new Error(`tmux pane ${target} vanished during launch`);
-    if (SHELLS.has(cmd)) continue; // agent not up yet (or it already exited — captured by timeout)
     const tail = paneTail(await t.capture(target, 40));
+    const failure = detectLaunchFailure(sig, tail);
+    if (failure) throw new Error(failure + ` (${target})`);
+    if (SHELLS.has(cmd)) continue; // agent not up yet (or it already exited — captured by timeout)
     if (sig.trustRe.test(tail)) {
       await t.sendKey(target, 'Enter');
       await t.sleep(1000);
@@ -167,6 +178,8 @@ async function launchAndSettle(target, launchCmd, sig) {
     if (sig.readyRe.test(tail)) return;
   }
   const tail = await t.capture(target, 20);
+  const failure = detectLaunchFailure(sig, paneTail(tail));
+  if (failure) throw new Error(failure + ` (${target})`);
   throw new Error(`${sig.label} did not start at ${target} within 45s; pane tail:\n${tail}`);
 }
 
@@ -306,6 +319,7 @@ module.exports = {
   claimPaneNames,
   createPane,
   killPane,
+  detectLaunchFailure,
   launchAndSettle,
   onTurnEnd,
   openPane,

--- a/server/server.js
+++ b/server/server.js
@@ -143,6 +143,29 @@ function userConfig() {
   }
   return { voices: null };
 }
+function ghCommand() {
+  return String(process.env.BC_GH_CMD || 'gh').trim() || 'gh';
+}
+function needsGhReady(project) {
+  return !!project && (project.mode === 'direct-PR' || project.mode === 'no-mistakes');
+}
+function ghReadinessError(project) {
+  if (!needsGhReady(project)) return Promise.resolve(null);
+  const gh = ghCommand();
+  return new Promise((resolve) => {
+    execFile(gh, ['auth', 'status'], { encoding: 'utf8', timeout: 10000 }, (err, stdout, stderr) => {
+      if (!err) return resolve(null);
+      const detail = String(stderr || stdout || err.message || '').trim();
+      if (err.code === 'ENOENT') {
+        return resolve(`GitHub CLI is required for ${project.mode} projects but \`${gh}\` is not installed or not on PATH`);
+      }
+      if (/not logged into|not authenticated|authentication failed|run `?gh auth login`?|gh auth login/i.test(detail)) {
+        return resolve(`GitHub CLI is not authenticated for ${project.mode} projects; run \`gh auth login\` and retry`);
+      }
+      return resolve(`GitHub CLI is not ready for ${project.mode} projects: ${detail || 'gh auth status failed'}`);
+    });
+  });
+}
 // Port: --port flag > config.json "port" > 4780. The resolved port is written
 // back into config.json when absent, so the CLI and UI can always find it.
 const cfg = readConfig();
@@ -1376,6 +1399,8 @@ async function doStartCard(card, body) {
   if (!repoAttr) return { error: 'card has no repo attribute — set it first: card patch ' + card.id + ' --attr repo=<project>' };
   const project = findProject(String(repoAttr));
   if (!project) return { error: 'unregistered project: ' + repoAttr + ' (register it: bc-axi project add <url|path> --mode <mode>)' };
+  const ghError = await ghReadinessError(project);
+  if (ghError) return { error: ghError, code: 502 };
 
   // Harness precedence: explicit CLI --harness wins, then the card's stored
   // hint (attributes.harness, set from the new-card modal), then config/default.

--- a/test/prwatch.test.js
+++ b/test/prwatch.test.js
@@ -23,15 +23,18 @@ function makeRepo(root) {
   return repo;
 }
 
-// A gh stub: `gh pr view <url> --json state,mergedAt` answered from a control
-// map file the test rewrites (url -> state). Unknown URL = non-zero exit.
+// A gh stub: `gh auth status` succeeds (startCard's readiness gate) and
+// `gh pr view <url> --json state,mergedAt` is answered from a control map file
+// the test rewrites (url -> state). Unknown URL = non-zero exit.
 function makeGhStub(root) {
   const mapFile = path.join(root, 'gh-map.json');
   fs.writeFileSync(mapFile, '{}');
   const stub = path.join(root, 'gh-stub');
   fs.writeFileSync(stub, '#!/usr/bin/env node\n'
     + "const fs = require('fs');\n"
-    + 'const url = process.argv[4]; // argv: node, stub, pr, view, <url>, --json, ...\n'
+    + 'const args = process.argv.slice(2);\n'
+    + 'if (args[0] === "auth" && args[1] === "status") { process.exit(0); }\n'
+    + 'const url = args[2]; // argv: node, stub, pr, view, <url>, --json, ...\n'
     + 'const map = JSON.parse(fs.readFileSync(' + JSON.stringify(mapFile) + ", 'utf8'));\n"
     + 'if (!map[url]) { console.error("no such pr"); process.exit(1); }\n'
     + 'console.log(JSON.stringify({ state: map[url], mergedAt: map[url] === "MERGED" ? new Date().toISOString() : null }));\n');

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -34,7 +34,7 @@ function makeRepo(root, name = 'srcrepo') {
 }
 
 // One temp tree per boot: fake-harness state + source repo + workspace.
-async function boot(extraEnv = {}) {
+async function boot(extraEnv = {}, projectMode = 'local-only') {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-workers-'));
   const repo = makeRepo(root);
   const fdir = path.join(root, 'fake');
@@ -44,7 +44,7 @@ async function boot(extraEnv = {}) {
       BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
     }, extraEnv),
   });
-  const r = await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+  const r = await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: projectMode });
   assert.strictEqual(r.status, 200, JSON.stringify(r.body));
   const teardown = async () => { await s.stop(); fs.rmSync(root, { recursive: true, force: true }); };
   return { s, root, repo, fdir, teardown };
@@ -89,6 +89,17 @@ test('card.start refusals: plan cards, missing/unregistered repo, already Workin
     r = await s.api('POST', '/api/cards/task/start', { harness: 'fake' });
     assert.strictEqual(r.status, 409);
     assert.match(r.body.error, /already Working/);
+  } finally { await teardown(); }
+});
+
+test('card.start: direct-PR projects fail early when gh is missing or unauthenticated', async () => {
+  const { s, teardown } = await boot({ BC_GH_CMD: 'gh-does-not-exist' }, 'direct-PR');
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Need PR', id: 'need-pr', attributes: { repo: 'proj' } }));
+    const r = await s.api('POST', '/api/cards/need-pr/start', { harness: 'fake' });
+    assert.strictEqual(r.status, 502);
+    assert.match(r.body.error, /GitHub CLI is required for direct-PR projects/i);
+    assert.match(r.body.error, /gh-does-not-exist/);
   } finally { await teardown(); }
 });
 


### PR DESCRIPTION
## Summary
- detect missing CLI and interactive sign-in states directly from tmux harness output for Claude and Codex
- fail direct-PR card starts early when GitHub CLI is missing or unauthenticated
- cover the new readiness and failure messaging paths with harness/server tests

## Testing
- node --test test/*.test.js harness/test/*.test.js