### PR TITLE
Avatar polish: bigger picker grid + avatar inside chat bubble

### DIFF
--- a/ui/app.css
+++ b/ui/app.css
@@ -678,30 +678,31 @@ a.a-uri { color: var(--accent); }
   border: 1.5px solid; display: inline-flex;
 }
 .lt-card .lt-face .avatar, #chat-title .lt-face .avatar { width: 100%; height: 100%; border-radius: 50%; }
-/* an avatar-bearing agent bubble sits in a row next to its face (bottom-aligned,
-   like most chat UIs); bubbles with no avatar stay direct #chat-feed children
-   exactly as before, so this is purely additive */
-.msg-row { display: flex; align-items: flex-end; gap: 6px; align-self: flex-start; max-width: 88%; }
-.msg-row .msg.agent { max-width: 100%; }
-.msg-row .msg-avatar { flex: none; width: 22px; height: 22px; border-radius: 50%; margin-bottom: 2px; }
+/* an avatar-bearing agent bubble anchors the face top-left, inside the balloon,
+   with the text indented to flow beside it; bubbles with no avatar (fallback:
+   no face rendered anywhere for messages) keep the plain look exactly as
+   before — no reserved padding, no empty gap. */
+.msg.agent.has-avatar { position: relative; padding-left: 52px; min-height: 52px; }
+.msg.agent .msg-face { position: absolute; top: 9px; left: 9px; width: 34px; height: 34px; border-radius: 50%; }
 .chat-empty-avatar { width: 44px; height: 44px; border-radius: 50%; margin: 0 auto 10px; }
 .chat-empty-dot { display: block; width: 14px; height: 14px; border-radius: 50%; margin: 0 auto 10px; }
 
 /* avatar picker: a "none" cell + 64 heads, shared by the new-lieutenant modal
-   and the appearance popover */
+   and the appearance popover. 6 columns keeps cells comfortably tappable
+   (~48-64px) at any container width; the grid scrolls vertically for the rest. */
 .avatar-grid {
-  display: grid; grid-template-columns: repeat(8, 1fr); gap: 4px;
-  max-height: 236px; overflow-y: auto; padding: 2px;
+  display: grid; grid-template-columns: repeat(6, 1fr); gap: 6px;
+  max-height: 300px; overflow-y: auto; padding: 2px;
 }
 .avatar-cell {
-  aspect-ratio: 1; border-radius: 6px; border: 2px solid transparent; cursor: pointer;
+  aspect-ratio: 1; border-radius: 8px; border: 2px solid transparent; cursor: pointer;
   background-image: url('/ui/img/avatars.png'); background-size: 800% 800%; background-repeat: no-repeat;
 }
 .avatar-cell:hover { border-color: var(--line2); }
 .avatar-cell.sel { border-color: var(--accent); }
 .avatar-cell.none {
   background-image: none; background: var(--panel); color: var(--faint);
-  display: flex; align-items: center; justify-content: center; font-size: 12px;
+  display: flex; align-items: center; justify-content: center; font-size: 16px;
 }
 .avatar-cell.none:hover { color: var(--text); }
 
@@ -709,7 +710,7 @@ a.a-uri { color: var(--accent); }
 #ap-popover {
   position: fixed; z-index: 70; display: flex; flex-direction: column; gap: 8px;
   background: var(--bg2); border: 1px solid var(--line2); border-radius: 10px; padding: 10px;
-  width: 260px; box-shadow: var(--shadow);
+  width: min(360px, calc(100vw - 24px)); box-shadow: var(--shadow);
 }
 .ap-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .ap-title { font-size: 11px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px; color: var(--faint); }

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -115,13 +115,13 @@ function msgHtml(m, promote, avatarIdx) {
   // speak button only on lieutenant bubbles; 🔊 icon, no message text in markup
   const speakBtn = mine ? '' :
     '<button class="msg-speak" type="button" data-speak title="read this message aloud" aria-label="read this message aloud">🔊</button>';
-  const bubble = '<div class="msg ' + (mine ? 'user' : 'agent') + '">' + body + atts +
-    '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
-  // face sits beside the bubble in a row — same face for every agent bubble in
+  // face sits inside the bubble, top-left — same face for every agent bubble in
   // this feed (a card thread's interlocutor is always the owning lieutenant,
   // so even a worker's stamped-as-owner say gets its face)
-  if (mine || avatarIdx == null) return bubble;
-  return '<div class="msg-row">' + avatarHtml(avatarIdx, 'msg-avatar') + bubble + '</div>';
+  const hasAvatar = !mine && avatarIdx != null;
+  const face = hasAvatar ? avatarHtml(avatarIdx, 'msg-face') : '';
+  return '<div class="msg ' + (mine ? 'user' : 'agent') + (hasAvatar ? ' has-avatar' : '') + '">' + face + body + atts +
+    '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
 }
 // empty-conversation placeholder: the lieutenant's face (or its colored dot,
 // same fallback rule as everywhere else) above the "no messages yet" text


### PR DESCRIPTION
## Summary
- Avatar picker grid (appearance popover + new-lieutenant modal) drops from 8 to 6 columns, growing cells from ~26px to ~48-64px; scrolls vertically for the rest. The appearance popover widens to match (`min(360px, 100vw - 24px)`), landing near full-width on a 390px phone screen.
- Chat bubble avatar moves from beside the bubble (`.msg-row` + small 22px `.msg-avatar`) to inside the bubble, anchored top-left with text indented beside it, and grows to 34px. Timestamp/speak-button layout is unchanged. Bubbles with no avatar are untouched — no reserved padding, no empty gap.

## Test plan
- [x] Full suite: `node --test test/*.test.js harness/test/*.test.js` — 255/255 pass
- [x] Visual check in a real browser (chrome-devtools-axi) against a seeded board: appearance popover grid, new-lieutenant modal grid, agent bubble with avatar, agent bubble without avatar (fallback) — at desktop width and 390px mobile width

🤖 Generated with [Claude Code](https://claude.com/claude-code)