### PR TITLE
ensureServer: verified, logged auto-boot (never silent)

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -17,7 +17,9 @@ const path = require('path');
 const { spawn, execFileSync } = require('child_process');
 
 const SELF_DIR = path.dirname(fs.realpathSync(process.argv[1]));
-const SERVER_JS = path.join(SELF_DIR, '..', 'server', 'server.js');
+// BC_SERVER_JS is a test-only seam: it lets tests point auto-boot at a
+// deliberately-crashing script to exercise the boot-failure path.
+const SERVER_JS = process.env.BC_SERVER_JS || path.join(SELF_DIR, '..', 'server', 'server.js');
 const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, migrateStateDir, resolveStateDir, migrateHomeStateDir, isWorkspace } =
   require(path.join(SELF_DIR, '..', 'server', 'statedir.js'));
 const DEFAULT_PORT = 4780;
@@ -130,6 +132,7 @@ if (migratedHome) console.error('[bridge-commander] migrated home state dir → 
 const STATE_DIR = resolveStateDir(WORKSPACE);
 const CONFIG_FILE = path.join(STATE_DIR, 'config.json');
 const PID_FILE = path.join(STATE_DIR, 'server.pid');
+const LOG_FILE = path.join(STATE_DIR, 'server.log');
 
 function readConfig() {
   try {
@@ -194,17 +197,33 @@ function attachmentLines(atts) {
 
 // ---------- server ----------
 // ensureServer — boot the workspace server detached when down (idempotent).
+// Output goes to a logfile (truncated on each boot) — never 'ignore' — so a
+// failed auto-boot leaves a trace instead of failing silently. Boot is then
+// verified by polling /api/status; a boot that never answers is a REAL error
+// pointing at the logfile, not a silent no-op.
 async function ensureServer() {
   let st = await serverUp();
   if (st) return { st, started: false };
+  fs.mkdirSync(STATE_DIR, { recursive: true });
   const args = [SERVER_JS, WORKSPACE, '--port', String(PORT)];
   if (opts.host) args.push('--host', opts.host); // else server resolves: config.json "host" > 127.0.0.1
-  const child = spawn(process.execPath, args, {
-    detached: true, stdio: 'ignore',
-  });
+  const logFd = fs.openSync(LOG_FILE, 'w');
+  let child;
+  try {
+    child = spawn(process.execPath, args, {
+      detached: true, stdio: ['ignore', logFd, logFd],
+    });
+  } finally {
+    fs.closeSync(logFd); // child dup'd its own reference at spawn time
+  }
   child.unref();
   for (let i = 0; i < 20 && !st; i++) { await sleep(150); st = await serverUp(); }
-  if (!st) die('failed to start server on port ' + PORT);
+  if (!st) {
+    const rel = path.relative(WORKSPACE, LOG_FILE) || LOG_FILE;
+    let tail = '';
+    try { tail = fs.readFileSync(LOG_FILE, 'utf8').trim(); } catch (e) {}
+    die('server failed to start — see ' + rel + (tail ? ':\n' + tail.split('\n').slice(-20).join('\n') : ' (empty log)'));
+  }
   return { st, started: true };
 }
 

--- a/server/server.js
+++ b/server/server.js
@@ -163,9 +163,26 @@ const TURNEND_URL = 'http://127.0.0.1:' + PORT + '/api/turn-end';
 
 // ---------- pidfile: single instance per workspace ----------
 function pidAlive(pid) { try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; } }
+// A live pid alone isn't proof it's OUR server — pids get recycled by the OS,
+// so an unrelated process can end up wearing a stale server.pid. Sanity-check
+// via /proc/<pid>/cmdline (Linux only — cmdline is null/unreadable elsewhere,
+// e.g. after the process exits mid-check or on a non-Linux OS) so a recycled
+// pid doesn't block a real boot; null means "can't tell" and falls back to
+// trusting pidAlive, same as before this check existed.
+function looksLikeOurServer(pid) {
+  try {
+    const cmdline = fs.readFileSync('/proc/' + pid + '/cmdline', 'utf8');
+    return cmdline.split('\0').some((a) => a && path.basename(a) === 'server.js');
+  } catch (e) { return null; }
+}
 if (fs.existsSync(PID_FILE)) {
   const old = parseInt(fs.readFileSync(PID_FILE, 'utf8'), 10);
-  if (old && pidAlive(old)) process.exit(0); // live server already owns this workspace
+  if (old && pidAlive(old)) {
+    const ours = looksLikeOurServer(old);
+    if (ours !== false) process.exit(0); // live server already owns this workspace (or unverifiable — trust it)
+    // else: pid is alive but is NOT a bridge-commander server — a recycled pid
+    // wearing a stale pidfile. Fall through and boot normally.
+  }
 }
 fs.writeFileSync(PID_FILE, String(process.pid));
 function cleanup() {

--- a/test/ensure-server.test.js
+++ b/test/ensure-server.test.js
@@ -1,0 +1,104 @@
+'use strict';
+// ensureServer auto-boot: verified, logged, never silent (bc/ensure-server).
+// Covers the three failure shapes from the papercut: a boot that never
+// answers must leave a real logfile and a real error (not stdio:'ignore'
+// swallowing everything); a stale/recycled server.pid must not block a real
+// boot; and the ordinary success path must still print the URL.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+const { runCli, freePort, sleep } = require('./helper');
+
+function tmpWorkspace() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-ensure-'));
+}
+
+async function stopViaPidFile(dir) {
+  const pidFile = path.join(dir, '.bridge-commander', 'server.pid');
+  let pid;
+  try { pid = parseInt(fs.readFileSync(pidFile, 'utf8'), 10); } catch (e) { return; }
+  if (!pid) return;
+  try { process.kill(pid, 'SIGTERM'); } catch (e) {}
+}
+
+test('ensureServer success path: fresh workspace auto-boots, prints the URL, logs to server.log', async () => {
+  const dir = tmpWorkspace();
+  const port = await freePort();
+  try {
+    const r = await runCli(['open', '--workspace', dir, '--port', String(port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /http:\/\/localhost:\d+\//);
+    assert.match(r.stdout, /started workspace=/);
+    const logFile = path.join(dir, '.bridge-commander', 'server.log');
+    assert.ok(fs.existsSync(logFile), 'server.log written on boot');
+    assert.match(fs.readFileSync(logFile, 'utf8'), /bridge-commander server up/);
+  } finally {
+    await stopViaPidFile(dir);
+    await sleep(100);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ensureServer boot failure: surfaces a real error pointing at the logfile, non-zero exit, log has the crash', async () => {
+  const dir = tmpWorkspace();
+  const port = await freePort();
+  const crasher = path.join(dir, 'crash-server.js');
+  fs.writeFileSync(crasher, '#!/usr/bin/env node\nconsole.error("boom: simulated crash for test");\nprocess.exit(1);\n');
+  try {
+    const r = await runCli(['open', '--workspace', dir, '--port', String(port)], { BC_SERVER_JS: crasher });
+    assert.notStrictEqual(r.code, 0, 'non-zero exit on boot failure');
+    assert.match(r.stderr, /server failed to start/);
+    assert.match(r.stderr, /server\.log/);
+    const logFile = path.join(dir, '.bridge-commander', 'server.log');
+    assert.ok(fs.existsSync(logFile), 'server.log written even on a crashing boot');
+    assert.match(fs.readFileSync(logFile, 'utf8'), /boom: simulated crash for test/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ensureServer stale pid: a live pid recycled to a non-bc process does not block a real boot', async () => {
+  const dir = tmpWorkspace();
+  const port = await freePort();
+  const stateDir = path.join(dir, '.bridge-commander');
+  fs.mkdirSync(stateDir, { recursive: true });
+  // A genuinely alive process whose cmdline does NOT mention server.js —
+  // stands in for "pid recycled to a non-bc process" without racing a real pid reuse.
+  const impostor = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 10000)'], { stdio: 'ignore' });
+  fs.writeFileSync(path.join(stateDir, 'server.pid'), String(impostor.pid));
+  try {
+    const r = await runCli(['open', '--workspace', dir, '--port', String(port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /started workspace=/, 'boots for real instead of no-op-ing on the stale pidfile');
+    const pidOnDisk = parseInt(fs.readFileSync(path.join(stateDir, 'server.pid'), 'utf8'), 10);
+    assert.notStrictEqual(pidOnDisk, impostor.pid, 'pidfile now holds the real server pid, not the impostor');
+  } finally {
+    impostor.kill('SIGKILL');
+    await stopViaPidFile(dir);
+    await sleep(100);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('ensureServer stale pid: a dead pid does not block a real boot (pre-existing behavior, still green)', async () => {
+  const dir = tmpWorkspace();
+  const port = await freePort();
+  const stateDir = path.join(dir, '.bridge-commander');
+  fs.mkdirSync(stateDir, { recursive: true });
+  // A pid almost certainly not alive: spawn+exit immediately, then reuse its number.
+  const dead = spawn(process.execPath, ['-e', '0'], { stdio: 'ignore' });
+  await new Promise((resolve) => dead.on('exit', resolve));
+  fs.writeFileSync(path.join(stateDir, 'server.pid'), String(dead.pid));
+  try {
+    const r = await runCli(['open', '--workspace', dir, '--port', String(port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /started workspace=/);
+  } finally {
+    await stopViaPidFile(dir);
+    await sleep(100);
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Auto-boot no longer spawns the server with `stdio:'ignore'`. Output goes to `.bridge-commander/server.log` (truncated on each boot), so a failed boot leaves a trace instead of vanishing.
- Boot is verified: `ensureServer` still polls `/api/status`; a boot that never answers now dies with a real, non-zero-exit error pointing at the logfile (with the tail of the log inlined), instead of the old generic "failed to start server on port N".
- Stale/recycled `server.pid` no longer blocks a real boot: `server.js`'s pidfile guard now sanity-checks `/proc/<pid>/cmdline` before trusting a merely-alive pid, so a pid recycled to an unrelated process falls through to a normal boot instead of silently exiting 0.
- One shared path: both `init` and `open` (the only two auto-boot call sites) go through `ensureServer`, so the fix applies uniformly.

## Test plan
- [x] `node --test test/ensure-server.test.js` — new coverage: success path (URL printed, log written), boot-failure path (crashing `BC_SERVER_JS` → non-zero exit, error message + logfile with the crash), stale-pid path (alive-but-foreign pid doesn't block boot), dead-pid path (pre-existing behavior stays green)
- [x] `node --test test/bootstrap.test.js` — existing pidfile no-op test still passes unchanged
- [x] Full suite from repo root: `node --test test/*.test.js` — 221/221 passing
- [x] `test/stale.test.js` and `test/prwatch.test.js` re-run individually — still green