### PR TITLE
Slash UI polish: readable dropdown, distinct command replies, rich /status

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -976,8 +976,12 @@ function harnessCommands(ref) {
 // (no wake, no owed). Unknown commands and missing sessions answer in-thread
 // too (a composer conversation, not an HTTP failure).
 async function runChatCommand(target, thread, text) {
-  const stamp = (author, t) => {
-    const msg = { author, text: t, ts: now() };
+  // command messages carry `cmd` metadata the UI keys off for its console-style
+  // rendering: the request (cmd.name only) and its reply (cmd.reply true). The
+  // /status reply additionally carries the structured `status` payload so the UI
+  // renders a real progress bar instead of regex-parsing the formatted prose.
+  const stamp = (author, t, cmd, extra) => {
+    const msg = Object.assign({ author, text: t, ts: now(), cmd }, extra || {});
     thread.push(msg);
     const m = /^card:(.+)$/.exec(target);
     if (m) {
@@ -985,30 +989,39 @@ async function runChatCommand(target, thread, text) {
       if (card) { card.updated = now(); if (!card.threadStart) card.threadStart = msg.ts; }
     }
   };
-  stamp('user', text);
   const name = text.split(/\s+/)[0];
+  const reply = (author, t, extra) => stamp(author, t, { name, reply: true }, extra);
+  stamp('user', text, { name });
   const r = commandTargetRef(target);
   if (r.error) return r; // unknown target — the normal 404, same as a say
   if (!r.ref) {
-    stamp('bridge', '⚠ ' + name + ' — ' + r.why);
+    reply('bridge', '⚠ ' + name + ' — ' + r.why);
     return { ok: true, command: name };
   }
   const cmds = harnessCommands(r.ref);
   if (!cmds.length) {
-    stamp('bridge', '⚠ ' + name + ' — the ' + r.ref.harness + ' harness has no slash commands');
+    reply('bridge', '⚠ ' + name + ' — the ' + r.ref.harness + ' harness has no slash commands');
     return { ok: true, command: name };
   }
   if (!cmds.some((c) => c && c.name === name)) {
-    stamp('bridge', '⚠ unknown command ' + name + ' — available: ' + cmds.map((c) => c.name).join(', '));
+    reply('bridge', '⚠ unknown command ' + name + ' — available: ' + cmds.map((c) => c.name).join(', '));
     return { ok: true, command: name };
   }
   try {
     // the FULL line goes to the harness — pass-through commands (/compact,
     // claude's /autocompact) may carry arguments; `name` only did the match
-    const result = await getHarness(r.ref.harness).runCommand(r.ref, text);
-    stamp(r.ref.harness, String(result == null ? name + ' done' : result));
+    const impl = getHarness(r.ref.harness);
+    const result = await impl.runCommand(r.ref, text);
+    // /status also fetches the structured status (a cheap transcript read) so the
+    // reply carries both the formatted text (fallback) and the payload the UI
+    // renders as model + context bar + rate lines — never parsing the prose.
+    let extra;
+    if (name === '/status' && typeof impl.status === 'function') {
+      try { const st = await impl.status(r.ref); if (st && typeof st === 'object') extra = { status: st }; } catch {}
+    }
+    reply(r.ref.harness, String(result == null ? name + ' done' : result), extra);
   } catch (e) {
-    stamp('bridge', '⚠ ' + name + ' failed: ' + String((e && e.message) || e));
+    reply('bridge', '⚠ ' + name + ' failed: ' + String((e && e.message) || e));
   }
   return { ok: true, command: name };
 }

--- a/ui/app.css
+++ b/ui/app.css
@@ -154,6 +154,41 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg-speak.speaking { opacity: 1; color: var(--accent); border-color: var(--accent2); }
 @media (hover: none) { .msg-speak { opacity: .6; } } /* touch: always visible, small */
 
+/* slash-command request+reply: the SYSTEM speaking, not a lieutenant. Full-width
+   console block — monospace, dim palette, subtle border, a small ⌘ affordance —
+   deliberately unlike the agent/user chat bubbles. No avatar, no speak button. */
+.msg.cmd {
+  align-self: stretch; max-width: 100%; width: 100%;
+  background: var(--bg2); border: 1px solid var(--line); border-radius: 8px;
+  font-family: var(--mono); font-size: 12.5px; line-height: 1.5;
+  padding: 8px 12px; animation: none;
+}
+.msg.cmd .ts { font-family: var(--mono); }
+.msg.cmd.cmd-req {
+  display: flex; align-items: baseline; gap: 8px;
+  background: transparent; border-style: dashed; border-color: var(--line2);
+  color: var(--dim); padding: 6px 12px;
+}
+.msg.cmd-req .cmd-glyph { color: var(--accent); flex: none; }
+.msg.cmd-req .cmd-line { color: var(--text); overflow-wrap: anywhere; flex: 1; min-width: 0; }
+.msg.cmd-req .ts { margin-top: 0; flex: none; align-self: center; }
+.msg.cmd.cmd-reply { border-left: 2px solid var(--line2); }
+.msg.cmd-reply .cmd-badge {
+  display: inline-block; color: var(--faint); font-size: 10.5px; letter-spacing: .04em;
+  text-transform: uppercase; margin-bottom: 6px;
+}
+.msg.cmd-reply .cmd-out { color: var(--dim); white-space: pre-wrap; overflow-wrap: anywhere; }
+.msg.cmd-reply .cmd-out p { margin: 0 0 4px; }
+.msg.cmd-reply .cmd-out p:last-child { margin-bottom: 0; }
+/* /status rich block: model line + context/rate progress bars (context-bar
+   visual language reused from the lane chips) */
+.status-block { display: flex; flex-direction: column; gap: 7px; }
+.status-block .st-model { color: var(--text); font-size: 13px; }
+.status-block .st-row { display: flex; align-items: center; gap: 9px; }
+.status-block .st-lbl { color: var(--dim); flex: none; width: 68px; }
+.status-block .st-bar { flex: 1; min-width: 40px; height: 7px; }
+.status-block .st-val { color: var(--dim); flex: none; font-size: 11.5px; white-space: nowrap; }
+
 .feed-day { align-self: center; color: var(--faint); font-size: 10.5px; margin: 6px 0 2px; font-family: var(--mono); }
 .feed-expand {
   align-self: center; color: var(--faint); font-size: 10.5px; margin: 6px 0 2px; font-family: var(--mono);
@@ -170,11 +205,18 @@ body.resizing { user-select: none; cursor: col-resize; }
   background: var(--panel2); border: 1px solid var(--line2); border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, .45); padding: 4px;
 }
+/* left-aligned rows on the dark panel; explicit bg/color/justify override the
+   generic `.composer button` rule (bright accent2 fill, centered) these buttons
+   would otherwise inherit — that was the unreadable bright-blue-unselected bug */
 #chat-slash .slash-it {
   display: flex; align-items: baseline; gap: 10px; width: 100%; min-width: 0;
-  text-align: left; padding: 7px 10px; border-radius: 7px; font-size: 12.5px;
+  text-align: left; justify-content: flex-start;
+  padding: 7px 10px; border-radius: 7px; font-size: 12.5px;
+  background: transparent; color: var(--text); transition: background .12s;
 }
-#chat-slash .slash-it.on, #chat-slash .slash-it:hover { background: var(--accent-soft); }
+#chat-slash .slash-it:hover { background: var(--panel3); }
+/* the selected/active row gets the accent highlight — subtle tint + accent bar */
+#chat-slash .slash-it.on { background: var(--accent-soft); box-shadow: inset 2px 0 0 var(--accent); }
 #chat-slash .sn { font-family: var(--mono); color: var(--accent); flex: none; }
 #chat-slash .sd { color: var(--dim); font-size: 11.5px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .composer textarea {

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -4,7 +4,7 @@
 // premium composer.
 import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
-import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime } from './util.js';
+import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime, statusBlockHtml } from './util.js';
 import { md } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
 import { openAttachment } from './detail.js';
@@ -104,7 +104,26 @@ function attachmentsHtml(atts, promote) {
       '</span>' + pin + '</div>';
   }).join('') + '</div>';
 }
+// A slash command's request+reply are the SYSTEM, not the lieutenant: they get a
+// full-width console block (monospace, subtle border, dim palette, a small "⌘"
+// affordance) — no avatar, no speak button — so they never read as an agent bubble.
+function cmdMsgHtml(m) {
+  const ts = '<span class="ts">' + hhmm(m.ts) + '</span>';
+  if (!m.cmd.reply) {
+    // the request: a console prompt line echoing exactly what was typed
+    return '<div class="msg cmd cmd-req"><span class="cmd-glyph">⌘</span>' +
+      '<span class="cmd-line">' + esc(m.text) + '</span>' + ts + '</div>';
+  }
+  // the reply: /status renders a rich model+context block; everything else is
+  // the harness's formatted text as console output
+  const body = m.status
+    ? statusBlockHtml(m.status)
+    : '<div class="cmd-out md">' + md(m.text) + '</div>';
+  const badge = '<span class="cmd-badge">⌘ ' + esc(m.cmd.name || '') + '</span>';
+  return '<div class="msg cmd cmd-reply">' + badge + body + ts + '</div>';
+}
 function msgHtml(m, promote, avatarIdx) {
+  if (m.cmd && typeof m.cmd === 'object') return cmdMsgHtml(m);
   const mine = m.author === USER;
   const hasText = !!(m.text && m.text.trim());
   const body = !hasText ? '' : (mine
@@ -254,7 +273,10 @@ export function renderChat() {
     const day = m.ts ? dayLabel(m.ts) : '';
     let h = '';
     if (day && day !== lastDay) { h += '<div class="feed-day">' + esc(day) + '</div>'; lastDay = day; }
-    blocks.push({ html: h + msgHtml(m, isCard, avatarIdx), msg: m.author === USER ? null : m });
+    // command blocks render no speak button, so they carry no `msg` (speak wiring
+    // maps buttons to blocks-with-msg by index — a command block would desync it)
+    const speakable = m.author !== USER && !(m.cmd && typeof m.cmd === 'object');
+    blocks.push({ html: h + msgHtml(m, isCard, avatarIdx), msg: speakable ? m : null });
   };
   if (isCard) {
     for (const m of c.thread || []) push(m);

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -115,6 +115,46 @@ export function ctxBarHtml(st) {
     + '<span class="ctx-fill' + cls + '" style="width:' + pct + '%"></span></span>';
 }
 
+// green → yellow (≥60%) → red (≥80%) — the shared context-bar thresholds
+function ctxFillCls(pct) { return pct >= 80 ? ' red' : pct >= 60 ? ' yellow' : ''; }
+function barRowHtml(label, pct, val) {
+  const bar = pct == null ? ''
+    : '<span class="ctx-bar st-bar"><span class="ctx-fill' + ctxFillCls(pct) + '" style="width:' + pct + '%"></span></span>';
+  return '<div class="st-row"><span class="st-lbl">' + esc(label) + '</span>'
+    + bar + '<span class="st-val">' + esc(val) + '</span></div>';
+}
+// A rate-limit window's short label (10080min=1w, 1440min=1d, 60min=1h, else min),
+// mirroring the server's fmtWindowLabel so codex limits read the same in-thread.
+function windowLabel(minutes) {
+  if (!Number.isFinite(minutes)) return 'rate';
+  if (minutes % 10080 === 0) return (minutes / 10080) + 'w';
+  if (minutes % 1440 === 0) return (minutes / 1440) + 'd';
+  if (minutes % 60 === 0) return (minutes / 60) + 'h';
+  return minutes + 'min';
+}
+// /status rich reply: model name, context usage as a real progress bar (reusing
+// the lane-chip context-bar visual language), plus rate-limit rows when present
+// (codex). Fed the structured `status` payload the server attaches to the reply.
+export function statusBlockHtml(st) {
+  if (!st || typeof st !== 'object') return '';
+  const rows = [];
+  rows.push('<div class="st-model">' + esc(st.model || 'unknown') + '</div>');
+  if (st.contextUsed > 0 && st.contextWindow > 0) {
+    const pct = Math.min(100, Math.round((st.contextUsed / st.contextWindow) * 100));
+    rows.push(barRowHtml('context', pct, fmtTokens(st.contextUsed) + ' / ' + fmtTokens(st.contextWindow) + ' · ' + pct + '%'));
+  } else if (st.contextUsed > 0) {
+    rows.push(barRowHtml('context', null, fmtTokens(st.contextUsed) + ' tokens'));
+  }
+  const rl = st.rateLimits || {};
+  for (const key of ['primary', 'secondary']) {
+    const w = rl[key];
+    if (!w) continue;
+    const pct = Number.isFinite(w.usedPercent) ? Math.min(100, Math.round(w.usedPercent)) : null;
+    rows.push(barRowHtml(windowLabel(w.windowMinutes) + ' limit', pct, (pct == null ? '?' : pct) + '% used'));
+  }
+  return '<div class="status-block">' + rows.join('') + '</div>';
+}
+
 // attributes.artifacts — [{uri, label}] — resources hung on the card (briefs, docs)
 export function cardArtifacts(card) {
   const v = card && card.attributes && card.attributes.artifacts;


### PR DESCRIPTION
UI-only polish to the slash-command feature from #37 (captain's screenshot-verified feedback), plus a small structured-status server touch.

## 1. Autocomplete dropdown — readable + left-aligned
The unselected rows were inheriting the generic `.composer button` rule (bright `accent2` fill, centered content) — an unreadable blue block. `.slash-it` now has an explicit transparent background, `--text` color, and left alignment; the **selected/active** row gets the accent highlight (subtle tint + inset accent bar). Command name + description stay legible in every state.

## 2. Command replies get their own design
A slash command is the **system** speaking, not the lieutenant. Command request+reply now render as a full-width **console block** — monospace, dim palette, subtle border, a small `⌘` affordance — no avatar, no speak button. Instantly distinguishable from agent/user bubbles. Messages carry `cmd` metadata (`{name, reply?}`) the UI keys off; command blocks are excluded from speak-wiring so the button↔message index mapping stays aligned.

## 3. Rich /status rendering
The `/status` reply now carries a structured `status` payload (model, context used/window, rateLimits) the server attaches alongside the formatted text — **no prose parsing**. The UI renders model name + a real context **progress bar** reusing the lane-chip context-bar visual language (green→yellow≥60→red≥80%), plus rate-limit bars when present (codex).

## Verification
- Real browser (chrome-devtools-axi) at **desktop and ~390px**: dropdown states, a command reply, a `/status` reply with the bar, and a normal agent bubble side by side.
- Full suite green (280 tests); `stale.test.js` and `prwatch.test.js` re-run alone (5/5, 4/4).
- Zero new dependencies.

## Files
- `server/server.js` — command messages carry `cmd` metadata; `/status` attaches the structured payload
- `ui/js/util.js` — `statusBlockHtml()` (rich /status block)
- `ui/js/chat.js` — `cmdMsgHtml()` console rendering; speak-wiring guard
- `ui/app.css` — dropdown fix + command-block / status-block styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)