### PR TITLE
Fix codex /status context %: last-turn occupancy, not cumulative total

### DIFF
--- a/harness/agent-status.js
+++ b/harness/agent-status.js
@@ -157,9 +157,15 @@ function codexRateLimits(rl) {
 }
 
 // codexStatus(ref, opts?) -> status | null
-// The last token_count event carries the totals (info.total_token_usage) and
-// the model context window; the model rides every turn_context line, so the
+// The last token_count event carries current context occupancy
+// (info.last_token_usage.total_tokens = input+cached+output of the last turn)
+// and the model context window; the model rides every turn_context line, so the
 // tail always has a fresh one. rate_limits come from the same token_count.
+// NOTE: info.total_token_usage is the CUMULATIVE session total (grows forever,
+// exceeds the window) — it is NOT occupancy. Selecting on last_token_usage is
+// deliberate: rollouts where info is populated always carry it (verified on
+// real rollouts), and the only ones missing it have info === null, which the
+// null-guards below already reject — so no total_token_usage fallback is needed.
 function codexStatus(ref, opts = {}) {
   if (!ref || !ref.resumeId) return null;
   const sessionsDir = opts.sessionsDir || process.env.BC_CODEX_SESSIONS_DIR
@@ -177,7 +183,7 @@ function codexStatus(ref, opts = {}) {
     if (!usage && line.includes('"token_count"')) {
       try { doc = JSON.parse(line); } catch { continue; }
       const p = doc && doc.payload;
-      if (p && p.type === 'token_count' && p.info && p.info.total_token_usage) usage = p;
+      if (p && p.type === 'token_count' && p.info && p.info.last_token_usage) usage = p;
     } else if (!model && line.includes('"turn_context"')) {
       try { doc = JSON.parse(line); } catch { continue; }
       const p = doc && doc.payload;
@@ -187,7 +193,7 @@ function codexStatus(ref, opts = {}) {
   if (!usage) return null;
   const out = {
     model,
-    contextUsed: usage.info.total_token_usage.total_tokens || 0,
+    contextUsed: usage.info.last_token_usage.total_tokens || 0,
     contextWindow: usage.info.model_context_window || null,
   };
   const rl = codexRateLimits(usage.rate_limits);

--- a/harness/test/agent-status.test.js
+++ b/harness/test/agent-status.test.js
@@ -92,14 +92,33 @@ test('claudeStatus: null on missing transcript / ref without resumeId — never 
 
 // A codex rollout fixture: session_meta + turn_context + token_count lines.
 const THREAD = '019ec130-a849-74b2-802e-a3d3bbb57ee0';
-function tokenCountLine(total, rateLimits) {
+// `last` is the current-turn occupancy we report; total_token_usage is the
+// CUMULATIVE session total and must be ignored — so the fixture always makes it
+// far larger (last * 100) to catch any regression back to the cumulative field.
+function tokenCountLine(last, rateLimits) {
+  return JSON.stringify({
+    timestamp: '2026-06-13T13:34:56.765Z',
+    type: 'event_msg',
+    payload: {
+      type: 'token_count',
+      info: {
+        total_token_usage: { total_tokens: last * 100 },
+        last_token_usage: { total_tokens: last },
+        model_context_window: 258400,
+      },
+      rate_limits: rateLimits === undefined ? null : rateLimits,
+    },
+  }) + '\n';
+}
+// An old-shape token_count: info populated but WITHOUT last_token_usage.
+function legacyTokenCountLine(total) {
   return JSON.stringify({
     timestamp: '2026-06-13T13:34:56.765Z',
     type: 'event_msg',
     payload: {
       type: 'token_count',
       info: { total_token_usage: { total_tokens: total }, model_context_window: 258400 },
-      rate_limits: rateLimits === undefined ? null : rateLimits,
+      rate_limits: null,
     },
   }) + '\n';
 }
@@ -153,6 +172,45 @@ test('codexStatus: null rate_limits → field omitted; newest day dir wins the g
       codexRolloutFile(THREAD, sessionsDir).includes(path.join('2026', '07', '02')), true);
     const st = codexStatus({ resumeId: THREAD }, { sessionsDir });
     assert.deepStrictEqual(st, { model: 'gpt-5.5', contextUsed: 200, contextWindow: 258400 });
+  } finally {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  }
+});
+
+test('codexStatus: reports last-turn occupancy, not the cumulative session total', () => {
+  // Real rollout evidence: cumulative 1,110,621 vs last-turn 17,814 / window
+  // 353,400 ≈ 5% (the true value; the cumulative total showed a false 100%+).
+  const sessionsDir = tmpdir('bc-status-codex-occ-');
+  try {
+    writeRollout(sessionsDir, '2026/07/10', THREAD,
+      JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.5' } }) + '\n'
+      + JSON.stringify({
+        type: 'event_msg',
+        payload: {
+          type: 'token_count',
+          info: {
+            total_token_usage: { total_tokens: 1110621 },
+            last_token_usage: { total_tokens: 17814 },
+            model_context_window: 353400,
+          },
+          rate_limits: null,
+        },
+      }) + '\n');
+    const st = codexStatus({ resumeId: THREAD }, { sessionsDir });
+    assert.deepStrictEqual(st, { model: 'gpt-5.5', contextUsed: 17814, contextWindow: 353400 });
+    assert.match(formatStatus(st), /context: 17,814 \/ 353,400 tokens \(5%\)/);
+  } finally {
+    fs.rmSync(sessionsDir, { recursive: true, force: true });
+  }
+});
+
+test('codexStatus: legacy token_count without last_token_usage → null (no cumulative fallback)', () => {
+  const sessionsDir = tmpdir('bc-status-codex-legacy-');
+  try {
+    writeRollout(sessionsDir, '2026/04/12', THREAD,
+      JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.5' } }) + '\n'
+      + legacyTokenCountLine(999999));
+    assert.strictEqual(codexStatus({ resumeId: THREAD }, { sessionsDir }), null);
   } finally {
     fs.rmSync(sessionsDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Bug

`/status` on a codex worker showed context as `1.1M / 353k · 100%` — used exceeded the window and grew forever.

## Cause

`codexStatus` read `info.total_token_usage.total_tokens` from the last `token_count` event — that's the **cumulative** session total, not current context occupancy.

## Fix

Read `info.last_token_usage.total_tokens` (input+cached+output of the last turn = current occupancy).

Real rollout evidence on this machine: cumulative **1,110,621** vs last-turn **17,814** / window **353,400 ≈ 5%** (the true value; UI showed 100%+).

**No cumulative fallback.** Checked all local rollouts: every `token_count` event with populated `info` carries `last_token_usage` (395/395); the only 3 missing it have `info === null` (no `total_token_usage` either) and are already rejected by the existing null-guards. So a `total_token_usage` fallback would help zero real cases. The event selector now keys on `last_token_usage` presence; a legacy shape lacking it yields `null` (graceful, per the null-never-throw contract).

Claude path untouched — its per-message `usage` is already occupancy.

## Scope

`harness/agent-status.js` + its tests only.

## Tests

Extended `codexStatus` tests: fixture now emits both fields (cumulative = last×100) to catch any regression; added a real-evidence occupancy test (17,814/353,400 → 5%) and a legacy-shape → null test. Full harness suite 56/56 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)