### PR TITLE
bc-axi papercuts #16/#17: flags-before-verb + honest owner usage

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -37,8 +37,11 @@ function currentTmuxSession() {
 }
 
 // ---------- args ----------
+// Global flags are accepted in ANY position relative to the verb: the whole argv
+// is parsed into flags + positionals first, then the verb is taken from the
+// positionals. So `bc-axi --workspace X board` and `bc-axi board --workspace X`
+// are equivalent.
 const argv = process.argv.slice(2);
-let cmd = argv.shift();
 const opts = {
   workspace: '', port: 0, host: '',
   textFile: null, bodyFile: null, charterFile: null,
@@ -89,6 +92,7 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--uri') opts.uri = argv[++i];
   else positional.push(a);
 }
+let cmd = positional.shift();
 // Two-word verbs mirror the DNA operation names: `card create`, `lieutenant list`, …
 if ((cmd === 'card' || cmd === 'lieutenant' || cmd === 'project' || cmd === 'worker') && positional.length) cmd = cmd + ' ' + positional.shift();
 // Three-word verb: `card artifact add|rm`.
@@ -976,10 +980,11 @@ if (!commands[cmd]) {
     '                                         level-1 event); → working is refused (card start does it).\n' +
     '                                         Captain drags happen in the UI; a captain drag into\n' +
     '                                         working / review→backlog is an ORDER (queue item), not a move\n' +
-    '  card patch <card-id> [--title T] [--type t] [--body-file f|-] [--attr k=v]...\n' +
-    '                                         update card (k= deletes attr; owner is immutable — archive\n' +
-    '                                         and recreate to move work); body = the deliverable,\n' +
-    '                                         rewritten to current state before every handoff\n' +
+    '  card patch <card-id> [--title T] [--type t] [--owner L] [--body-file f|-] [--attr k=v]...\n' +
+    '                                         update card (k= deletes attr; owner reassignable ONLY\n' +
+    '                                         while no worker is bound to the card — else archive and\n' +
+    '                                         recreate); body = the deliverable, rewritten to current\n' +
+    '                                         state before every handoff\n' +
     '  card archive <card-id> [--reason merged|killed] [--note "..."]\n' +
     '                                         kill = archive (append-only file, off the board)\n' +
     '  card restore <card-id> [--note "..."]  resurrect the most recent archived snapshot in full;\n' +

--- a/server/brief.js
+++ b/server/brief.js
@@ -37,7 +37,9 @@ const PROJECT_MODES = Object.keys(MODE_CONTRACTS);
 function workerBrief(b) {
   const card = b.card;
   const investigation = card.type === 'investigation';
-  const cli = b.cli + ' --workspace ' + b.workspace;
+  // Canonical form: verb-first, global flags last (`<cli> <verb> ... --workspace X`).
+  const cli = b.cli;
+  const ws = ' --workspace ' + b.workspace;
   const reportFile = b.workspace + '/.bridge-commander/reports/' + card.id + '.md';
   const parts = [];
 
@@ -56,9 +58,9 @@ function workerBrief(b) {
     + '  in the project clone".\n'
     + '- Work only inside your worktree. Never touch the project clone or the workspace directly.\n'
     + '- Signal real milestones (branch created, tests green, PR open) — not chatter:\n'
-    + '  `' + cli + ' worker signal ' + card.id + ' "<one line>"`\n'
+    + '  `' + cli + ' worker signal ' + card.id + ' "<one line>"' + ws + '`\n'
     + '- When the work is finished per the contract below, report done and stop:\n'
-    + '  `' + cli + ' worker done ' + card.id + ' --outcome "<what landed, incl. PR URL if any>"`\n'
+    + '  `' + cli + ' worker done ' + card.id + ' --outcome "<what landed, incl. PR URL if any>"' + ws + '`\n'
     + '- Do NOT move the card; your lieutenant verifies your work and hands it off.');
 
   const task = String(b.task || card.body || '').trim();

--- a/test/brief.test.js
+++ b/test/brief.test.js
@@ -29,3 +29,12 @@ test('worktree-isolation rule is present for investigation cards too', () => {
   const out = brief({ card: { id: 'demo', title: 'Look into it', type: 'investigation', body: 'why?' } });
   assert.match(out, /Work only inside your worktree\./);
 });
+
+test('worker commands are emitted verb-first with --workspace last (canonical form)', () => {
+  const out = brief();
+  // canonical: `<cli> <verb> ... --workspace X` — never flags before the verb
+  assert.match(out, /bc-axi worker signal demo "<one line>" --workspace \/ws/);
+  assert.match(out, /bc-axi worker done demo --outcome "[^"]*" --workspace \/ws/);
+  // the old broken form (flags before the verb) must be gone
+  assert.doesNotMatch(out, /bc-axi --workspace \/ws worker/);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -50,6 +50,30 @@ test('cli resolves the workspace by walking up from cwd to .bridge-commander', a
   }
 });
 
+test('cli accepts global flags in any position relative to the verb', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    // flags BEFORE the verb — the classic papercut: `--workspace X board` used to
+    // print usage because the parser took the verb from argv[0].
+    let r = await runCli(['--workspace', s.dir, '--port', String(s.port), 'board']);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /backlog/i);
+
+    // flags interleaved with a two-word verb and its positionals
+    r = await runCli(['--workspace', s.dir, 'card', '--port', String(s.port), 'create',
+      '--title', 'Interleaved', '--owner', LT]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /created interleaved in backlog/);
+
+    // flags AFTER the verb still work (unchanged behavior)
+    r = await runCli(['board', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /Interleaved/);
+  } finally {
+    await s.stop();
+  }
+});
+
 test('cli card create / board / say / drain / ack round-trip against a test server', async () => {
   const s = await startServerWithLieutenant();
   const args = ['--workspace', s.dir, '--port', String(s.port)];


### PR DESCRIPTION
Two small bc-axi surface fixes (papercuts #16 and #17), one PR.

## #16 — flags before the verb broke command parsing
`bc-axi --workspace X board` printed usage instead of running because the parser took the verb from `argv[0]`.

- **CLI:** parse the whole argv into flags + positionals first, then take the verb from the positionals. `--workspace X board`, `board --workspace X`, and even interleaved (`--workspace X card --port N create ...`) are now equivalent — works from any cwd.
- **brief.js:** the worker brief composed the CLI as `<cli> --workspace X` (flags before the verb), so every brief taught the broken form. Reordered to canonical `<cli> <verb> ... --workspace X`.

## #17 — usage text lied about owner immutability
`server.js` `patchCard` allows owner reassignment while no worker is bound, but the CLI help claimed owner is immutable. Fixed the text to state the real rule (reassignable only while no worker is bound) and added the missing `[--owner L]` to the `card patch` flag list.

## Tests
- `cli.test.js`: flag position — before / interleaved / after the verb.
- `brief.test.js`: worker commands emitted verb-first with `--workspace` last; old broken form asserted gone.

Full suite: 229/229 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)