### PR TITLE
Real context window for lieutenant status via statusline sidecar

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -233,6 +233,7 @@ async function ensureServer() {
 
 async function cmdOpen() {
   const { st, started } = await ensureServer();
+  installStatusLine(WORKSPACE); // self-heal the statusLine wiring on every open
   console.log('http://localhost:' + PORT + '/');
   console.log((started ? 'started' : 'already running') + ' workspace=' + st.workspace + ' cards=' + st.cards);
 }
@@ -255,6 +256,29 @@ function excludeFromGit(dir, entry) {
 }
 function slugId(s) {
   return String(s).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40) || 'lt';
+}
+
+// installStatusLine — MERGE the BC statusLine command into the WORKSPACE's
+// .claude/settings.local.json (create if absent), preserving every other key
+// (hooks, permissions, …). Re-run on every init/open so a rewrite self-heals.
+// NEVER touches user-global ~/.claude/settings.json. The statusline script tees
+// the real context window + rate limits into the sidecar the board reads.
+function installStatusLine(workspace) {
+  const { shellQuote } = require(path.join(SELF_DIR, '..', 'harness', 'tmux-session.js'));
+  const script = path.join(SELF_DIR, '..', 'harness', 'statusline.js');
+  const command = 'node ' + shellQuote(script);
+  const dir = path.join(workspace, '.claude');
+  const file = path.join(dir, 'settings.local.json');
+  let settings = {};
+  try { settings = JSON.parse(fs.readFileSync(file, 'utf8')); } catch (e) { settings = {}; }
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) settings = {};
+  const cur = settings.statusLine;
+  if (!cur || cur.type !== 'command' || cur.command !== command) {
+    settings.statusLine = { type: 'command', command };
+  }
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(settings, null, 2) + '\n');
+  excludeFromGit(workspace, '.claude/settings.local.json');
 }
 async function cmdInit() {
   if (!opts.name) {
@@ -318,6 +342,8 @@ async function cmdInit() {
   const harnessState = process.env.BC_HARNESS_STATE || path.join(STATE_DIR, 'harness');
   await installHooks(WORKSPACE, 'ws', harnessState, 'http://127.0.0.1:' + PORT + '/api/turn-end');
   console.log('turn-end hook installed (.claude/settings.local.json -> /api/turn-end)');
+  installStatusLine(WORKSPACE);
+  console.log('statusLine installed (.claude/settings.local.json -> real context window sidecar)');
 
   // 5. shared memory scaffold (never overwrite what exists)
   const agentsMd = path.join(WORKSPACE, 'AGENTS.md');

--- a/harness/agent-status.js
+++ b/harness/agent-status.js
@@ -72,13 +72,99 @@ function claudeContextWindow(model) {
   return CLAUDE_DEFAULT_WINDOW;
 }
 
+// ---------- claude statusline sidecar ----------
+// harness/statusline.js (the workspace's Claude Code `statusLine` command) tees
+// each stdin payload to <workspace>/.bridge-commander/statusline/<session_id>.json
+// — the ONLY source of the REAL context window (context_window_size), the
+// account rate limits, and the model display name. Lieutenants run with cwd =
+// workspace root, so the sidecar exists for them; workers in worktree cwds have
+// none and fall through to the transcript+map path below (accepted).
+const STATE_DIR_NAME = '.bridge-commander';
+function findBridgeWorkspace(startDir) {
+  if (!startDir) return null;
+  let dir = path.resolve(startDir);
+  for (;;) {
+    try {
+      if (fs.statSync(path.join(dir, STATE_DIR_NAME)).isDirectory()) return dir;
+    } catch { /* keep walking up */ }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// Map the statusline payload's rate_limits (five_hour/seven_day, each
+// {used_percentage, resets_at}) onto the shared status rateLimits shape
+// (primary/secondary, each {usedPercent, windowMinutes, resetsAt epoch secs}),
+// so formatStatus labels them 5h / 1w just like codex.
+function claudeSidecarRateLimits(rl) {
+  if (!rl || typeof rl !== 'object') return null;
+  const toEpochSecs = (v) => {
+    if (v == null) return undefined;
+    if (typeof v === 'number' && Number.isFinite(v)) return v > 1e11 ? Math.floor(v / 1000) : Math.floor(v);
+    if (typeof v === 'string' && v.trim() !== '') {
+      const n = Number(v);
+      if (Number.isFinite(n)) return n > 1e11 ? Math.floor(n / 1000) : Math.floor(n);
+      const p = Date.parse(v);
+      if (!Number.isNaN(p)) return Math.floor(p / 1000);
+    }
+    return undefined;
+  };
+  const pick = (w, windowMinutes) => {
+    if (!w || typeof w !== 'object' || w.used_percentage == null) return undefined;
+    const out = { usedPercent: Number(w.used_percentage), windowMinutes };
+    const r = toEpochSecs(w.resets_at);
+    if (r !== undefined) out.resetsAt = r;
+    return out;
+  };
+  const out = {};
+  const primary = pick(rl.five_hour, 300);
+  const secondary = pick(rl.seven_day, 10080);
+  if (primary) out.primary = primary;
+  if (secondary) out.secondary = secondary;
+  return Object.keys(out).length ? out : null;
+}
+
+// claudeSidecarStatus(ref, opts?) -> status | null
+// Prefer the sidecar when one exists for this session (file name == resumeId)
+// and it carries a real context_window_size. Any missing file / bad JSON /
+// absent window → null, so the caller falls back to the transcript path.
+function claudeSidecarStatus(ref, opts = {}) {
+  const dir = opts.sidecarDir
+    || (() => {
+      const ws = opts.workspace || findBridgeWorkspace(ref.cwd);
+      return ws ? path.join(ws, STATE_DIR_NAME, 'statusline') : null;
+    })();
+  if (!dir) return null;
+  let doc;
+  try {
+    doc = JSON.parse(fs.readFileSync(path.join(dir, ref.resumeId + '.json'), 'utf8'));
+  } catch {
+    return null;
+  }
+  const p = doc && doc.payload;
+  const cw = p && p.context_window;
+  const window = cw && Number(cw.context_window_size);
+  if (!p || !cw || !Number.isFinite(window) || window <= 0) return null;
+  const out = {
+    model: (p.model && (p.model.id || p.model.display_name)) || null,
+    contextUsed: Number(cw.total_input_tokens) || 0,
+    contextWindow: window,
+  };
+  const rl = claudeSidecarRateLimits(p.rate_limits);
+  if (rl) out.rateLimits = rl;
+  return out;
+}
+
 // claudeStatus(ref, opts?) -> status | null
-// The last assistant line's message.usage is the current context truth:
-// contextUsed = input + cache_read + cache_creation + output (what the next
-// turn starts from). No rate limits — claude does not persist them, so the
-// field is omitted rather than faked.
+// Prefer the statusline sidecar (real window + rate limits); else the last
+// assistant line's message.usage: contextUsed = input + cache_read +
+// cache_creation + output (what the next turn starts from), with the context
+// window guessed from the model→window map.
 function claudeStatus(ref, opts = {}) {
   if (!ref || !ref.cwd || !ref.resumeId) return null;
+  const sidecar = claudeSidecarStatus(ref, opts);
+  if (sidecar) return sidecar;
   const projectsDir = opts.projectsDir || process.env.BC_CLAUDE_PROJECTS_DIR
     || path.join(os.homedir(), '.claude', 'projects');
   const file = path.join(projectsDir, claudeProjectSlug(ref.cwd), ref.resumeId + '.jsonl');
@@ -256,6 +342,8 @@ module.exports = {
   tailRead,
   claudeProjectSlug,
   claudeContextWindow,
+  findBridgeWorkspace,
+  claudeSidecarStatus,
   claudeStatus,
   codexRolloutFile,
   codexStatus,

--- a/harness/statusline.js
+++ b/harness/statusline.js
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+'use strict';
+// statusline.js — the BC-owned Claude Code `statusLine` command. Two jobs on
+// every invocation, both best-effort (a statusLine command must never fail):
+//
+//  1. Sidecar. Tee the stdin payload to a per-session file keyed by session_id:
+//     <workspace>/.bridge-commander/statusline/<session_id>.json (atomic
+//     tmp+rename, received-at stamped). This is the ONLY place the Claude Code
+//     binary exports the REAL context window (context_window.context_window_size,
+//     total_input_tokens, used_percentage) and the account rate_limits — the
+//     transcript jsonl carries none of it. The board's status reader
+//     (agent-status.js) prefers this sidecar over its hardcoded model→window map.
+//     Workspace = nearest ancestor of payload.cwd holding a .bridge-commander/;
+//     none found → write nothing, still render.
+//
+//  2. Render. Reproduce the captain's reference statusline: model (cyan), a
+//     20-char block bar colored green / yellow≥60 / red≥80, used%, `118k/1000k`
+//     tokens, then `5h X% (ETA)` and `7d X% (ETA)` from rate_limits with a
+//     compact ETA (2d4h / 3h12m / 45m). Zero deps — no jq, no awk.
+//
+// Usage (as a statusLine command): node statusline.js   (payload JSON on stdin)
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const STATE_DIR_NAME = '.bridge-commander';
+
+const C = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  dim: '\x1b[2m',
+};
+
+// findWorkspace — nearest ancestor of startDir that contains a .bridge-commander/
+// directory; null when none is found (or startDir is empty).
+function findWorkspace(startDir) {
+  if (!startDir) return null;
+  let dir = path.resolve(startDir);
+  for (;;) {
+    try {
+      if (fs.statSync(path.join(dir, STATE_DIR_NAME)).isDirectory()) return dir;
+    } catch { /* not here — keep walking up */ }
+    const parent = path.dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// writeSidecar — atomically tee the payload to its per-session sidecar. Returns
+// the file path written, or null when there is no session_id, no workspace, or
+// any write error (best-effort: never throws). opts.workspace / opts.sidecarDir
+// / opts.now / opts.pid are test seams.
+function writeSidecar(payload, opts = {}) {
+  const sid = payload && payload.session_id;
+  if (!sid || typeof sid !== 'string') return null;
+  const ws = opts.workspace || findWorkspace(payload && payload.cwd);
+  if (!ws) return null;
+  const dir = opts.sidecarDir || path.join(ws, STATE_DIR_NAME, 'statusline');
+  const file = path.join(dir, sid + '.json');
+  const doc = { receivedAt: opts.now || new Date().toISOString(), payload };
+  try {
+    fs.mkdirSync(dir, { recursive: true });
+    const tmp = file + '.' + (opts.pid || process.pid) + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(doc));
+    fs.renameSync(tmp, file);
+    return file;
+  } catch {
+    return null;
+  }
+}
+
+// ---------- render helpers ----------
+
+// bar — a 20-char block progress bar for a used-percentage (0..100).
+function bar(pct) {
+  let filled = Math.floor((Number(pct) || 0) / 5);
+  if (filled > 20) filled = 20;
+  if (filled < 0) filled = 0;
+  return '█'.repeat(filled) + '░'.repeat(20 - filled);
+}
+
+// pctColor — green <60, yellow 60..79, red ≥80 (matches the reference thresholds).
+function pctColor(pct) {
+  const p = Number(pct) || 0;
+  if (p >= 80) return C.red;
+  if (p >= 60) return C.yellow;
+  return C.green;
+}
+
+// fmtK — token count as a rounded `k` string (118213 → "118k", 1000000 → "1000k").
+function fmtK(n) {
+  return Math.round((Number(n) || 0) / 1000) + 'k';
+}
+
+// toEpochSecs — coerce a rate-limit resets_at (epoch seconds, epoch millis, a
+// numeric string, or an ISO timestamp) to epoch SECONDS; null when unparseable.
+function toEpochSecs(v) {
+  if (v == null) return null;
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return v > 1e11 ? Math.floor(v / 1000) : Math.floor(v);
+  }
+  if (typeof v === 'string' && v.trim() !== '') {
+    const n = Number(v);
+    if (Number.isFinite(n)) return n > 1e11 ? Math.floor(n / 1000) : Math.floor(n);
+    const p = Date.parse(v);
+    if (!Number.isNaN(p)) return Math.floor(p / 1000);
+  }
+  return null;
+}
+
+// fmtEta — seconds until resetsAt in compact form: 2d4h / 3h12m / 45m. Empty
+// string when resetsAt is unparseable. `now` is epoch millis.
+function fmtEta(resetsAt, now) {
+  const target = toEpochSecs(resetsAt);
+  if (target === null) return '';
+  let s = target - Math.floor(now / 1000);
+  if (s < 0) s = 0;
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return d + 'd' + h + 'h';
+  if (h > 0) return h + 'h' + m + 'm';
+  return m + 'm';
+}
+
+// rlSegment — one ` | 5h X% (ETA)` rate-limit chunk; empty when the window has
+// no used_percentage.
+function rlSegment(label, w, now) {
+  if (!w || w.used_percentage == null || w.used_percentage === '') return '';
+  const pct = Number(w.used_percentage);
+  const c = pctColor(pct);
+  const e = fmtEta(w.resets_at, now);
+  const eta = e ? ` ${C.dim}(${e})${C.reset}` : '';
+  return ` ${C.dim}|${C.reset} ${C.dim}${label}${C.reset} ${c}${pct.toFixed(0)}%${C.reset}${eta}`;
+}
+
+// render — the full statusline string for a payload. `now` (epoch millis)
+// defaults to the wall clock; passed explicitly by tests for a stable ETA.
+function render(payload, now) {
+  const nowMs = now || Date.now();
+  const p = payload || {};
+  const model = (p.model && (p.model.display_name || p.model.id)) || 'Unknown';
+  const cw = p.context_window || {};
+  const usedPct = cw.used_percentage;
+  let out;
+  if (usedPct != null && usedPct !== '') {
+    const pct = Number(usedPct);
+    const color = pctColor(pct);
+    out = `${C.cyan}${model}${C.reset} ${C.dim}|${C.reset} ${color}${bar(pct)} ${pct.toFixed(0)}%${C.reset}`
+      + ` ${C.dim}|${C.reset} ${fmtK(cw.total_input_tokens)}/${fmtK(cw.context_window_size)}`;
+  } else {
+    out = `${C.cyan}${model}${C.reset}`;
+  }
+  const rl = p.rate_limits || {};
+  out += rlSegment('5h', rl.five_hour, nowMs);
+  out += rlSegment('7d', rl.seven_day, nowMs);
+  return out;
+}
+
+// readStdinSync — the piped payload; '' on any error (statusLine stdin is always
+// a pipe, never a TTY, so a synchronous fd-0 read is safe and prompt).
+function readStdinSync() {
+  try {
+    return fs.readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function main() {
+  let payload = null;
+  try {
+    payload = JSON.parse(readStdinSync());
+  } catch {
+    payload = null;
+  }
+  if (payload) writeSidecar(payload);
+  process.stdout.write(render(payload || {}));
+}
+
+if (require.main === module) main();
+
+module.exports = {
+  findWorkspace,
+  writeSidecar,
+  bar,
+  pctColor,
+  fmtK,
+  toEpochSecs,
+  fmtEta,
+  render,
+  STATE_DIR_NAME,
+};

--- a/harness/test/agent-status.test.js
+++ b/harness/test/agent-status.test.js
@@ -9,6 +9,7 @@ const os = require('node:os');
 const path = require('node:path');
 const {
   claudeProjectSlug, claudeContextWindow, claudeStatus,
+  claudeSidecarStatus, findBridgeWorkspace,
   codexRolloutFile, codexStatus, formatStatus,
 } = require('../agent-status.js');
 
@@ -87,6 +88,103 @@ test('claudeStatus: null on missing transcript / ref without resumeId — never 
     assert.strictEqual(claudeStatus(null, { projectsDir }), null);
   } finally {
     fs.rmSync(projectsDir, { recursive: true, force: true });
+  }
+});
+
+// ---------- claude statusline sidecar ----------
+// The sidecar (statusline.js writes it) carries the REAL context window that the
+// transcript+map path can only guess. Written under <workspace>/
+// .bridge-commander/statusline/<session_id>.json.
+function writeSidecar(workspace, sid, payload, now) {
+  const dir = path.join(workspace, '.bridge-commander', 'statusline');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, sid + '.json'),
+    JSON.stringify({ receivedAt: now || '2026-07-14T00:00:00.000Z', payload }));
+}
+
+test('claudeStatus: prefers the sidecar — real 1M window + rate limits (Opus case)', () => {
+  const ws = tmpdir('bc-status-sidecar-');
+  try {
+    fs.mkdirSync(path.join(ws, '.bridge-commander'), { recursive: true });
+    const sid = 'sc-1111-2222';
+    writeSidecar(ws, sid, {
+      session_id: sid,
+      cwd: ws,
+      model: { id: 'claude-opus-4-8', display_name: 'Opus 4.8' },
+      context_window: { context_window_size: 1000000, total_input_tokens: 118213, used_percentage: 11.8 },
+      rate_limits: {
+        five_hour: { used_percentage: 42, resets_at: 2000000000 },
+        seven_day: { used_percentage: 7, resets_at: 2000100000 },
+      },
+    });
+    // A transcript with the OLD 200k guess also exists — the sidecar must win.
+    const projectsDir = tmpdir('bc-status-sidecar-tx-');
+    try {
+      const tdir = path.join(projectsDir, claudeProjectSlug(ws));
+      fs.mkdirSync(tdir, { recursive: true });
+      fs.writeFileSync(path.join(tdir, sid + '.jsonl'), assistantLine('claude-opus-4-8', USAGE));
+      const st = claudeStatus({ cwd: ws, resumeId: sid }, { projectsDir });
+      assert.strictEqual(st.contextWindow, 1000000);
+      assert.strictEqual(st.contextUsed, 118213);
+      assert.strictEqual(st.model, 'claude-opus-4-8');
+      assert.deepStrictEqual(st.rateLimits, {
+        primary: { usedPercent: 42, windowMinutes: 300, resetsAt: 2000000000 },
+        secondary: { usedPercent: 7, windowMinutes: 10080, resetsAt: 2000100000 },
+      });
+      assert.match(formatStatus(st), /context: 118,213 \/ 1,000,000 tokens \(12%\)/);
+      assert.match(formatStatus(st), /5h limit: 42% used/);
+      assert.match(formatStatus(st), /1w limit: 7% used/);
+    } finally {
+      fs.rmSync(projectsDir, { recursive: true, force: true });
+    }
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+});
+
+test('claudeStatus: no sidecar → transcript+map fallback unchanged (opus → 200k)', () => {
+  const ws = tmpdir('bc-status-nosidecar-');
+  const projectsDir = tmpdir('bc-status-nosidecar-tx-');
+  try {
+    fs.mkdirSync(path.join(ws, '.bridge-commander'), { recursive: true }); // workspace, but NO statusline/ dir
+    const sid = 'nofile-1111';
+    const tdir = path.join(projectsDir, claudeProjectSlug(ws));
+    fs.mkdirSync(tdir, { recursive: true });
+    fs.writeFileSync(path.join(tdir, sid + '.jsonl'), assistantLine('claude-opus-4-8', USAGE));
+    const st = claudeStatus({ cwd: ws, resumeId: sid }, { projectsDir });
+    assert.deepStrictEqual(st, { model: 'claude-opus-4-8', contextUsed: USED, contextWindow: 200000 });
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+    fs.rmSync(projectsDir, { recursive: true, force: true });
+  }
+});
+
+test('claudeSidecarStatus: bad JSON / missing window → null (falls through), never throws', () => {
+  const ws = tmpdir('bc-status-sidecar-bad-');
+  try {
+    const dir = path.join(ws, '.bridge-commander', 'statusline');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'bad.json'), '{not json');
+    assert.strictEqual(claudeSidecarStatus({ cwd: ws, resumeId: 'bad' }), null);
+    // valid JSON but no context_window_size → null (transcript fallback wins)
+    writeSidecar(ws, 'nowin', { session_id: 'nowin', cwd: ws, model: { id: 'claude-opus-4-8' } });
+    assert.strictEqual(claudeSidecarStatus({ cwd: ws, resumeId: 'nowin' }), null);
+    assert.strictEqual(claudeSidecarStatus({ cwd: ws, resumeId: 'absent' }), null);
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+});
+
+test('findBridgeWorkspace: nearest .bridge-commander/ ancestor, else null', () => {
+  const ws = tmpdir('bc-find-ws-');
+  try {
+    fs.mkdirSync(path.join(ws, '.bridge-commander'), { recursive: true });
+    const deep = path.join(ws, 'x', 'y');
+    fs.mkdirSync(deep, { recursive: true });
+    assert.strictEqual(findBridgeWorkspace(deep), ws);
+    assert.strictEqual(findBridgeWorkspace('/'), null);
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
   }
 });
 

--- a/harness/test/statusline.test.js
+++ b/harness/test/statusline.test.js
@@ -1,0 +1,122 @@
+'use strict';
+// statusline.js — the BC-owned Claude Code statusLine command: the sidecar tee
+// (workspace discovery, atomic write, session keying) and the pretty render for
+// full / no-rate-limits / model-only payloads.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { findWorkspace, writeSidecar, render, fmtEta, toEpochSecs } = require('../statusline.js');
+
+function tmpdir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+// A full statusLine stdin payload, matching the Claude Code binary's shape.
+function fullPayload(sid, cwd) {
+  return {
+    session_id: sid,
+    cwd,
+    model: { id: 'claude-opus-4-8', display_name: 'Opus 4.8' },
+    context_window: {
+      context_window_size: 1000000,
+      total_input_tokens: 118213,
+      used_percentage: 11.8,
+    },
+    rate_limits: {
+      five_hour: { used_percentage: 42, resets_at: 2000000000 },
+      seven_day: { used_percentage: 7, resets_at: 2000100000 },
+    },
+  };
+}
+
+// strip ANSI so assertions read the plain text.
+function plain(s) {
+  return s.replace(/\x1b\[[0-9;]*m/g, '');
+}
+
+test('writeSidecar: tees the payload under the nearest .bridge-commander/, keyed by session_id', () => {
+  const root = tmpdir('bc-statusline-ws-');
+  try {
+    fs.mkdirSync(path.join(root, '.bridge-commander'), { recursive: true });
+    const cwd = path.join(root, 'projects', 'app', 'src');
+    fs.mkdirSync(cwd, { recursive: true });
+    const sid = 'sess-1111';
+    const written = writeSidecar(fullPayload(sid, cwd), { now: '2026-07-14T00:00:00.000Z' });
+    assert.strictEqual(written, path.join(root, '.bridge-commander', 'statusline', sid + '.json'));
+    const doc = JSON.parse(fs.readFileSync(written, 'utf8'));
+    assert.strictEqual(doc.receivedAt, '2026-07-14T00:00:00.000Z');
+    assert.strictEqual(doc.payload.context_window.context_window_size, 1000000);
+    assert.strictEqual(doc.payload.session_id, sid);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('writeSidecar: null (writes nothing) when no workspace / no session_id — never throws', () => {
+  const root = tmpdir('bc-statusline-none-');
+  try {
+    // cwd with no .bridge-commander anywhere above → no workspace
+    assert.strictEqual(writeSidecar(fullPayload('s', root)), null);
+    // no session_id → null even with a workspace
+    fs.mkdirSync(path.join(root, '.bridge-commander'), { recursive: true });
+    assert.strictEqual(writeSidecar({ cwd: root }), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('findWorkspace: walks up to the nearest .bridge-commander/; null when none', () => {
+  const root = tmpdir('bc-statusline-find-');
+  try {
+    fs.mkdirSync(path.join(root, '.bridge-commander'), { recursive: true });
+    const deep = path.join(root, 'a', 'b', 'c');
+    fs.mkdirSync(deep, { recursive: true });
+    assert.strictEqual(findWorkspace(deep), root);
+    assert.strictEqual(findWorkspace('/'), null);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('render: full payload — model, bar, used%, tokens, and both rate limits', () => {
+  const now = Date.UTC(2033, 4, 18) / 1; // arbitrary fixed clock (epoch ms)
+  const txt = plain(render(fullPayload('s', '/x'), Date.parse('2033-05-18T03:33:20Z')));
+  // resets_at 2000000000 = 2033-05-18T03:33:20Z → same instant → 0m ETA
+  assert.match(txt, /^Opus 4\.8 \| /);
+  assert.match(txt, /12% \| 118k\/1000k/); // 11.8% rounds to 12; tokens/window in k
+  assert.match(txt, /\| 5h 42% \(/);
+  assert.match(txt, /\| 7d 7% \(/);
+  void now;
+});
+
+test('render: payload without rate_limits — model + context bar only, no 5h/7d', () => {
+  const p = fullPayload('s', '/x');
+  delete p.rate_limits;
+  const txt = plain(render(p, 0));
+  assert.match(txt, /Opus 4\.8 \| .* 12% \| 118k\/1000k/);
+  assert.doesNotMatch(txt, /5h|7d/);
+});
+
+test('render: model-only payload (no context_window) → just the model name', () => {
+  const txt = plain(render({ model: { display_name: 'Opus 4.8' } }, 0));
+  assert.strictEqual(txt, 'Opus 4.8');
+});
+
+test('render: empty payload → Unknown', () => {
+  assert.strictEqual(plain(render({}, 0)), 'Unknown');
+});
+
+test('fmtEta / toEpochSecs: compact forms and format coercion', () => {
+  const now = 1_000_000 * 1000; // epoch ms
+  assert.strictEqual(fmtEta(1_000_000 + 2 * 86400 + 4 * 3600, now), '2d4h');
+  assert.strictEqual(fmtEta(1_000_000 + 3 * 3600 + 12 * 60, now), '3h12m');
+  assert.strictEqual(fmtEta(1_000_000 + 45 * 60, now), '45m');
+  assert.strictEqual(fmtEta(1_000_000 - 500, now), '0m'); // past → clamped
+  assert.strictEqual(fmtEta('nonsense', now), '');
+  // ISO string and epoch-millis both coerce to seconds
+  assert.strictEqual(toEpochSecs('2026-01-01T00:00:00Z'), Math.floor(Date.parse('2026-01-01T00:00:00Z') / 1000));
+  assert.strictEqual(toEpochSecs(1700000000000), 1700000000);
+  assert.strictEqual(toEpochSecs(1700000000), 1700000000);
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -74,6 +74,37 @@ test('cli accepts global flags in any position relative to the verb', async () =
   }
 });
 
+test('cli open installs the statusLine, merging into .claude/settings.local.json', async () => {
+  const s = await startServerWithLieutenant();
+  const args = ['--workspace', s.dir, '--port', String(s.port)];
+  const settingsFile = path.join(s.dir, '.claude', 'settings.local.json');
+  try {
+    // Pre-seed unrelated keys — the merge must preserve them, never clobber.
+    fs.mkdirSync(path.dirname(settingsFile), { recursive: true });
+    fs.writeFileSync(settingsFile, JSON.stringify({
+      permissions: { allow: ['Bash(ls:*)'] },
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'keep-me' }] }] },
+    }));
+
+    let r = await runCli(['open', ...args]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    let cfg = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    assert.strictEqual(cfg.statusLine.type, 'command');
+    assert.match(cfg.statusLine.command, /statusline\.js/);
+    assert.deepStrictEqual(cfg.permissions, { allow: ['Bash(ls:*)'] }); // preserved
+    assert.strictEqual(cfg.hooks.Stop[0].hooks[0].command, 'keep-me'); // preserved
+
+    // Self-heal: delete the file, re-open, it is recreated with the statusLine.
+    fs.rmSync(settingsFile);
+    r = await runCli(['open', ...args]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    cfg = JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
+    assert.match(cfg.statusLine.command, /statusline\.js/);
+  } finally {
+    await s.stop();
+  }
+});
+
 test('cli card create / board / say / drain / ack round-trip against a test server', async () => {
   const s = await startServerWithLieutenant();
   const args = ['--workspace', s.dir, '--port', String(s.port)];


### PR DESCRIPTION
## Problem
The board's context bars and `/status` guessed the context window from a hardcoded model→window map (`harness/agent-status.js`: opus/sonnet/haiku → 200k). A captain on Opus 4.8's **1M** window read `113k/200k` (56%) when the truth was ~`118k/1000k` (12%). The transcript jsonl carries no window field — the only place the Claude Code binary exports the real number is the `statusLine` command's stdin JSON (`context_window.*`, `rate_limits.*`, `model.display_name`).

## Approach (captain-approved design)
1. **`harness/statusline.js`** — BC-owned Claude Code `statusLine` command, doing both jobs on every invocation (best-effort, never fails):
   - **Sidecar**: tees the stdin payload to `<workspace>/.bridge-commander/statusline/<session_id>.json` (atomic tmp+rename, received-at stamped). Workspace = nearest `.bridge-commander/` ancestor of `payload.cwd`; none found → writes nothing, still renders.
   - **Render**: reproduces the captain's statusline — model (cyan), 20-char block bar (green / yellow≥60 / red≥80), used%, `118k/1000k` tokens, `5h X% (ETA)` / `7d X% (ETA)` with compact ETA (`2d4h`/`3h12m`/`45m`). Zero deps (node, no jq/awk).
2. **Consumption** — `agent-status.js` `claudeStatus()` now prefers a fresh sidecar for the session (real `context_window_size`, `total_input_tokens`, model, rate_limits mapped onto the shared `primary`/`secondary` shape → labelled `5h`/`1w`). Falls back to the existing transcript+map path when no sidecar exists (workers in worktree cwds keep the old behavior).
3. **Wiring** — `bc-axi init`/`open` MERGE `statusLine` into the **workspace's** `.claude/settings.local.json` (create if absent, self-heal on every init/open), preserving unrelated keys. Never touches `~/.claude/settings.json`.

Lieutenants run with cwd = workspace root, so they get real numbers on the board bars and `/status`.

## Tests
- statusline render (full / no-rate-limits / model-only / empty) + sidecar tee (workspace discovery, session keying, no-workspace no-op) + ETA coercion.
- status prefers the sidecar (1M window case) over a 200k transcript guess; no sidecar → fallback unchanged; bad JSON / missing window → falls through.
- `settings.local.json` merge preserves unrelated keys; recreated when absent.
- Full suite green: **297** (`node --test test/*.test.js harness/test/*.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)