### PR TITLE
worker send reopens a done-but-alive worker

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -1543,7 +1543,8 @@ async function doStartCard(card, body) {
     let up = false;
     try { up = await harnessFor(existing.ref).alive(existing.ref); } catch (e) { up = false; }
     if (up) {
-      return { error: 'previous worker session ' + workerName(existing.ref) + ' is still alive — resume it (card start --resume) or steer it instead of spawning over it', code: 409 };
+      const reopenHint = existing.done ? ' (or, since it reported done, reopen it in place with worker send)' : '';
+      return { error: 'previous worker session ' + workerName(existing.ref) + ' is still alive — resume it (card start --resume) or steer it instead of spawning over it' + reopenHint, code: 409 };
     }
     const prevProject = findProject(existing.project) || project;
     const rel = await releaseWorktree(existing.worktree, prevProject.path);
@@ -1663,12 +1664,24 @@ async function workerSend(card, body) {
   if (!w) {
     return { error: 'no worker bound to card ' + card.id + ' — start one first (card start ' + card.id + ')', code: 404 };
   }
-  if (w.done) {
-    return { error: 'worker for ' + card.id + ' already reported done — spawn a fresh one (card start ' + card.id + ') instead of sending into a finished session', code: 409 };
-  }
   let up = false;
   try { up = await harnessFor(w.ref).alive(w.ref); } catch (e) { up = false; }
-  if (!up) {
+  if (w.done) {
+    // A done-but-DEAD worker is a genuine restart: point at the resume recipe.
+    if (!up) {
+      return { error: 'worker for ' + card.id + ' reported done and its session is gone — revive it first (card start ' + card.id + ' --resume), then send', code: 409 };
+    }
+    // Done but its session is still alive+idle: reopen the turn in place (the
+    // reset mirrors the resume path) instead of 409-ing, so a send re-enters
+    // Working without the undiscoverable two-step resume.
+    w.done = false;
+    delete w.outcome;
+    delete w.flagged;
+    delete w.stopNotified;
+    delete w.staleNotified;
+    delete w.paused;
+    enterWorking(card, 'worker ' + workerName(w.ref) + ' reopened for a new turn');
+  } else if (!up) {
     return { error: 'worker session ' + workerName(w.ref) + ' is not alive — resume it first (card start ' + card.id + ' --resume), then send', code: 409 };
   }
   try {

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -438,13 +438,78 @@ test('worker send: delivers into the live worker session + level-2 card event; l
     assert.strictEqual(ev.level, 2);
     assert.match(ev.text, /also fix the flaky test/);
 
-    // empty text rejected; a done worker refuses (spawn fresh instead)
+    // empty text rejected
     assert.strictEqual((await s.api('POST', '/api/cards/steer/worker/send', { text: '  ' })).status, 400);
-    await s.api('POST', '/api/cards/steer/worker/done', { outcome: 'landed' });
-    r = await s.api('POST', '/api/cards/steer/worker/send', { text: 'one more thing' });
-    assert.strictEqual(r.status, 409);
-    assert.match(r.body.error, /already reported done/);
   } finally { await teardown(); }
+});
+
+test('worker send reopens a done-but-alive worker: turn re-enters Working, record reset, text delivered', async () => {
+  const { s, fdir, teardown } = await boot();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Reopen', id: 'reopen', attributes: { repo: 'proj' } }));
+    assert.strictEqual((await s.api('POST', '/api/cards/reopen/start', { harness: 'fake' })).status, 200);
+    const sess = workerKey(s.dir, 'reopen');
+
+    // worker finishes; the lieutenant hands off, so the card leaves Working
+    await s.api('POST', '/api/cards/reopen/worker/done', { outcome: 'first pass done' });
+    await s.api('POST', '/api/cards/reopen/move', { column: 'review', actor: 'agent' });
+    assert.strictEqual(boardOnDisk(s).workers[0].done, true);
+
+    // its session is still alive+idle → a send reopens the turn in place (no 409)
+    const r = await s.api('POST', '/api/cards/reopen/worker/send', { text: 'one more pass: add tests' });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+
+    // the record is reset exactly like a resume; the card is back in Working
+    const disk = boardOnDisk(s);
+    assert.strictEqual(disk.workers[0].done, false);
+    assert.strictEqual(disk.workers[0].outcome, undefined);
+    const card = (await s.api('GET', '/api/cards/reopen')).body;
+    assert.strictEqual(card.column, 'working');
+    // a level-2 reopen event, then the send event
+    const reopened = card.events.find((e) => e.kind === 'started' && /reopened for a new turn/.test(e.text));
+    assert.ok(reopened, 'reopen event recorded');
+    assert.match(reopened.text, /👀 Your review → 🔨 Working/);
+    const sendEv = card.events[card.events.length - 1];
+    assert.strictEqual(sendEv.kind, 'worker-send');
+    assert.match(sendEv.text, /add tests/);
+
+    // the text really reached the session (the fake logs sends)
+    const sends = fs.readFileSync(path.join(fdir, sess + '.sends.jsonl'), 'utf8')
+      .trim().split('\n').map((l) => JSON.parse(l));
+    assert.deepStrictEqual(sends.map((x) => x.text), ['one more pass: add tests']);
+  } finally { await teardown(); }
+});
+
+test('worker send on a done-but-DEAD worker still 409s and names the resume recipe', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-workers-'));
+  const repo = makeRepo(root);
+  const wsDir = path.join(root, 'ws');
+  fs.mkdirSync(wsDir);
+  const fdir = path.join(root, 'fake');
+  const env = {
+    BC_FAKE_STATE: fdir, BC_WORKTREE_TOOL: 'git',
+    BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
+  };
+  let s = await startServerWithLieutenant({ dir: wsDir, env });
+  try {
+    await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'local-only' });
+    await s.api('POST', '/api/cards', withOwner({ title: 'Gone', id: 'gone', attributes: { repo: 'proj' } }));
+    await s.api('POST', '/api/cards/gone/start', { harness: 'fake' });
+    await s.api('POST', '/api/cards/gone/worker/done', { outcome: 'done' });
+
+    // the session dies (restart clears the in-process fake; drop its marker so
+    // cross-process alive() flips false) — done stays true on disk
+    await s.stop();
+    fs.rmSync(path.join(fdir, workerKey(wsDir, 'gone') + '.json'), { force: true });
+    s = await startServerWithLieutenant({ dir: wsDir, env });
+
+    const r = await s.api('POST', '/api/cards/gone/worker/send', { text: 'come back' });
+    assert.strictEqual(r.status, 409);
+    assert.match(r.body.error, /card start gone --resume/);
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('card start --resume refuses a brief and points at worker send (API + CLI)', async () => {


### PR DESCRIPTION
## Bug

After `worker done`, the worker's tmux session stays alive+idle but its record has `done=true`. The card then wedged: `card start` → 409 *"previous worker session … is still alive"*, `worker send` → 409 *"already reported done — spawn a fresh one"*. Each 409 pointed at the other, so the card could not legitimately re-enter Working. (The only escape, `card start --resume`, is a no-op on an alive session that also resets done — but it's undiscoverable and two-step.)

## Fix (decided by captain)

In the `worker send` handler: when the worker is `done` **and** its session is **alive**, auto-reopen the turn instead of 409-ing:
1. Reset the record exactly like the resume path (`done=false`; drop `outcome`, `flagged`, `stopNotified`, `staleNotified`, `paused`).
2. `enterWorking(card, "worker <name> reopened for a new turn")`.
3. Deliver the text as a normal send.

Unchanged:
- done-but-**dead** session → still 409, now naming the real recipe: `card start <id> --resume`, then send.
- Actively-working send semantics.
- tmux sessions are **not** reaped on `worker done` — the idle session is what makes cheap in-place re-review possible.
- The `card start` 409 gains a truthful hint (a done worker reopens on the next `worker send`); start **behavior** is untouched.

## Tests

- `worker send` on done-but-alive → 200, record reset, card back in Working, text delivered (fake harness records the send).
- `worker send` on done-but-dead → 409 naming `card start --resume`.
- Updated the existing send test (its old done→409 tail is superseded).
- Full suite green: **299/299** (`node --test test/*.test.js harness/test/*.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)