### PR TITLE
Render HTML artifacts in a sandboxed iframe + expandable artifact popup

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2061,12 +2061,23 @@ const server = http.createServer(async (req, res) => {
         if (!st.isFile()) return sendJson(res, 404, { error: 'not a file' });
         if (st.size > ARTIFACT_MAX_BYTES) return sendJson(res, 413, { error: 'artifact too large (max ' + ARTIFACT_MAX_BYTES + ' bytes)' });
         const ext = path.extname(name).toLowerCase();
-        const ctype = am ? (attMime || 'application/octet-stream') : (ARTIFACT_MIME[ext] || 'application/octet-stream');
-        // Images and pdf may render inline in the browser; other binaries
-        // download. Same hardening as the attachments serve: nosniff pins the
-        // Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
+        // A curated .html/.htm artifact (teach-me page, report) is a self-contained
+        // document meant to be *rendered*: serve it as text/html inline so the
+        // viewer iframe shows the page, not its source. It runs under a stricter-
+        // than-default CSP — `sandbox allow-scripts` gives it a unique origin (no
+        // same-origin access to the board, no top navigation, no forms) while its
+        // own inline JS/CSS still work. Scoped to plain file artifacts, not
+        // attachments (an uploaded .html keeps its neutralized download behavior).
+        const isHtml = !am && (ext === '.html' || ext === '.htm');
+        const ctype = isHtml ? 'text/html; charset=utf-8'
+          : am ? (attMime || 'application/octet-stream')
+          : (ARTIFACT_MIME[ext] || 'application/octet-stream');
+        // Images, pdf, and rendered html show inline in the browser; other
+        // binaries download. Same hardening as the attachments serve: nosniff pins
+        // the Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
         // is navigated to as a document (inline <img> subresources unaffected).
-        const inline = /^image\//.test(ctype) || ctype === 'application/pdf';
+        const inline = isHtml || /^image\//.test(ctype) || ctype === 'application/pdf';
+        const csp = isHtml ? 'sandbox allow-scripts' : 'sandbox';
         let data;
         try { data = fs.readFileSync(file); }
         catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
@@ -2075,7 +2086,7 @@ const server = http.createServer(async (req, res) => {
           'Content-Length': data.length,
           'Cache-Control': 'private, max-age=31536000, immutable',
           'X-Content-Type-Options': 'nosniff',
-          'Content-Security-Policy': 'sandbox',
+          'Content-Security-Policy': csp,
           'Content-Disposition': (inline ? 'inline' : 'attachment') + '; filename="' + name.replace(/["\\\r\n]/g, '_') + '"',
         });
         return res.end(data);

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -91,6 +91,27 @@ test('raw=1 rejects a traversal file:// uri and a non-file:// uri', async () => 
   }
 });
 
+test('raw=1 for a listed .html → 200, text/html inline, sandbox allow-scripts CSP', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const page = path.join(s.dir, 'teach-me.html');
+    fs.writeFileSync(page, '<!doctype html><title>Diff</title><script>document.title="ok"</script>');
+    const { uri } = await cardWithArtifact(s, page, 'explain diff');
+
+    const res = await fetch(s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1');
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'text/html; charset=utf-8');
+    assert.strictEqual(res.headers.get('x-content-type-options'), 'nosniff');
+    const csp = res.headers.get('content-security-policy') || '';
+    assert.match(csp, /sandbox/);
+    assert.match(csp, /allow-scripts/);
+    assert.match(res.headers.get('content-disposition') || '', /^inline/);
+    assert.match(await res.text(), /teach|Diff|doctype/i);
+  } finally {
+    await s.stop();
+  }
+});
+
 test('non-image binary served as bytes with attachment disposition', async () => {
   const s = await startServerWithLieutenant();
   try {

--- a/ui/app.css
+++ b/ui/app.css
@@ -832,10 +832,13 @@ a.a-uri { color: var(--accent); }
   background: var(--bg2); border: 1px solid var(--line2); border-radius: 14px;
   box-shadow: var(--shadow); animation: pop-in .15s ease-out; overflow: hidden;
 }
+/* Maximized viewer — near-fullscreen for HTML artifacts (which open expanded)
+   or on demand via the ⛶ toggle. Toggling the class off restores the size. */
+#av-modal.expanded { width: 94vw; height: 94vh; max-width: 94vw; max-height: 94vh; }
 .av-head { flex: none; display: flex; align-items: center; gap: 10px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
 .av-head .av-name { flex: 1; min-width: 0; font-weight: 650; font-size: 13px; font-family: var(--mono); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-#av-close { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; }
-#av-close:hover { color: var(--text); }
+#av-expand, #av-close { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; }
+#av-expand:hover, #av-close:hover { color: var(--text); }
 #av-body {
   flex: 1; min-height: 60px; overflow: auto; padding: 12px 16px; margin: 0;
   font-family: var(--mono); font-size: 12px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere;
@@ -846,6 +849,9 @@ a.a-uri { color: var(--accent); }
 /* image attachment preview (shares the av-overlay) */
 #av-img-wrap { flex: 1; min-height: 60px; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
 #av-img { max-width: 100%; max-height: 76vh; object-fit: contain; border-radius: 6px; }
+/* rendered html artifact (shares the av-overlay) — fills the body; white backdrop
+   so a self-contained page renders on its own canvas, not the board's dark bg */
+#av-frame { flex: 1; min-height: 60px; width: 100%; border: 0; background: #fff; }
 #av-download { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; text-decoration: none; }
 #av-download:hover { color: var(--accent); }
 

--- a/ui/index.html
+++ b/ui/index.html
@@ -221,9 +221,10 @@
 <!-- artifact viewer -->
 <div id="av-overlay" hidden>
   <div id="av-modal">
-    <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-close" title="close">✕</button></div>
+    <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-expand" title="expand">⛶</button><button id="av-close" title="close">✕</button></div>
     <pre id="av-body"></pre>
     <div id="av-img-wrap" hidden><img id="av-img" alt=""></div>
+    <iframe id="av-frame" sandbox="allow-scripts" hidden></iframe>
   </div>
 </div>
 

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -174,21 +174,28 @@ bodyInput.onkeydown = (e) => {
 
 // ---------- artifact viewer (popup) ----------
 const avOverlay = document.getElementById('av-overlay');
+const avModal = document.getElementById('av-modal');
 const avName = document.getElementById('av-name');
 const avBody = document.getElementById('av-body');
 const avImgWrap = document.getElementById('av-img-wrap');
 const avImg = document.getElementById('av-img');
+const avFrame = document.getElementById('av-frame');
+const avExpand = document.getElementById('av-expand');
 const avDownload = document.getElementById('av-download');
 const MD_EXT = /\.(md|markdown)$/i;
+const HTML_EXT = /\.html?$/i;
 // Reset the shared overlay to a clean text-mode state (used by both openers).
 function avReset(name, uri) {
   avName.textContent = name;
   avName.title = uri || name;
   avImgWrap.hidden = true;
   avImg.removeAttribute('src');
+  avFrame.hidden = true;
+  avFrame.removeAttribute('src'); // drop the previous page so it can't linger
   avBody.hidden = false;
   avBody.className = '';
   avDownload.hidden = true;
+  avModal.classList.remove('expanded'); // each open starts at the default size
   avOverlay.hidden = false;
 }
 async function openArtifact(uri) {
@@ -218,6 +225,16 @@ async function openArtifact(uri) {
   if (IMG_EXT.test(name)) {
     avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
     avBody.hidden = true; avImgWrap.hidden = false; avImg.src = rawUrl; avImg.alt = title;
+    return;
+  }
+  if (HTML_EXT.test(name)) {
+    // A rendered .html/.htm page (teach-me, report): show it live in a sandboxed
+    // iframe (allow-scripts, no same-origin) fed by the raw serve, which sends a
+    // matching CSP. These pages want room — open expanded by default.
+    avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
+    avBody.hidden = true; avImgWrap.hidden = true;
+    avFrame.hidden = false; avFrame.src = rawUrl;
+    avModal.classList.add('expanded');
     return;
   }
   if (BIN_EXT.test(name)) return offerDownload('No inline preview for this file type. Use ⬇ to download.');
@@ -288,6 +305,8 @@ export async function openAttachment(att) {
 export function closeArtifact() { avOverlay.hidden = true; }
 export function artifactOpen() { return !avOverlay.hidden; }
 document.getElementById('av-close').onclick = closeArtifact;
+// Maximize / restore the viewer (pure CSS class toggle — see #av-modal.expanded).
+avExpand.onclick = () => { avModal.classList.toggle('expanded'); };
 avOverlay.onclick = (e) => { if (e.target === avOverlay) closeArtifact(); };
 
 // ---------- owner menu (reassign the owning lieutenant) ----------


### PR DESCRIPTION
## What

Cards carry `.html` artifacts (explain-diff teach-me pages, reports). Until now the viewer fetched them as **text** and showed raw HTML source, and raw mode had no `.html` in the MIME table → octet-stream + `attachment` (download), with a `sandbox` CSP that blocked the page's own inline JS.

## Changes

**Server** (`server/server.js`) — plain-file `.html`/`.htm` artifacts now serve inline as `text/html; charset=utf-8` under `Content-Security-Policy: sandbox allow-scripts`: the self-contained page's inline JS/CSS run, but it gets a unique origin (no same-origin access to the board, no top navigation, no forms). `X-Content-Type-Options: nosniff` kept. Every other type (images/pdf inline, rest download) is byte-for-byte unchanged; attachments and the path-safety allowlist are untouched.

**UI viewer** (`ui/js/detail.js`, `ui/index.html`) — `.html`/`.htm` render in a `<iframe sandbox="allow-scripts" src="…&raw=1">` filling the popup body instead of the text view. Other types unchanged.

**Expandable popup** (`ui/app.css`) — a ⛶ toggle in the viewer header maximizes to ~94vw/94vh and restores (pure CSS `.expanded` class). HTML artifacts open expanded by default.

## Tests

Added a server test: raw serve of a listed `.html` → 200, `text/html`, CSP contains `sandbox` + `allow-scripts`, inline disposition. Existing guards (unlisted 404, traversal 400, `.png` image/png, unknown-ext octet attachment) unchanged.

Full suite green: `node --test test/*.test.js harness/test/*.test.js` → 300 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)