### PR TITLE
DNA rev: apply the 19 captain-approved drift fixes

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -7,12 +7,23 @@ Bridge Commander is an agent-orchestration **harness** whose control surface is 
 The captain pilots N **lieutenants** — orchestrator agents, one tmux session each, shown as a
 horizontal lane above the columns — and every unit of work is a card owned by exactly one
 lieutenant. Lieutenants never implement; they delegate each started card to a **worker**
-(one fresh agent, one tmux session, one isolated worktree). The server is not a mirror of
+(one fresh agent, one tmux window, one isolated worktree). The server is not a mirror of
 anything: it IS the harness — it spawns sessions, delivers messages, supervises workers,
 watches PRs. Board state on disk is the canonical state of the world.
 
 Lineage: UI and board mechanics evolve from [bridge](https://github.com/tonylampada/claudegoodies);
 orchestration doctrine distills firstmate. New project — inspiration, not reuse.
+
+**Altitude.** This document describes what the system DOES — capabilities a PM would name.
+Presentation (how things are shown: viewers, panes, bars, colors, board title/meta), transport
+and plumbing (polling, hooks, sidecars, state-dir layout, migrations), per-user read markers,
+and tuning knobs (TTLs, intervals, TTS voices) live BELOW the conceptual line: they change
+freely without a DNA mutation. The test: if a PM describing the product wouldn't say it, it's
+below the line.
+
+**Structure.** This project keeps its DNA deliberately single-file: no `entities.md` Level 2
+until the entity detail genuinely hurts at this altitude. Implementation-side record fields
+(worker lifecycle flags and the like) stay below the line.
 
 ## The board
 
@@ -22,9 +33,10 @@ One board per **workspace** (the directory where the skill was initialized; hold
 📋 Backlog → 🔨 Working → 👀 Your review → 🤝 Peer review
 
 No Done: cards leave by archive (merge = `merged`; dismissal = `killed`).
-Working means the task is unfinished and SHOULD have a live worker on it; the only door in
-is `card.start`, which spawns that worker atomically. Lieutenant lane sits above the
-columns; each lieutenant has a color, and its cards carry that color stripe.
+Working means the task is unfinished and SHOULD have a live worker on it; the doors in are
+`card.start`, which spawns that worker atomically, and `worker.send` reopening a done-but-alive
+worker for a new turn. Lieutenant lane sits above the columns; each lieutenant has a color,
+and its cards carry that color stripe.
 
 ## Entities
 
@@ -33,12 +45,12 @@ columns; each lieutenant has a color, and its cards carry that color stripe.
 | Workspace | The deployment unit: board state, config (port), shared memory, project clones. Independent of every other workspace |
 | Project | A repo registered in the workspace, with a delivery mode: `no-mistakes` (default) \| `direct-PR` \| `local-only` |
 | Lieutenant | Durable orchestrator: `name` (display, emoji welcome), `color`, `avatar` (optional index 0-63 into the sprite sheet; absent = colored-dot fallback), `charter` (mission). Its `id` and any derived session name come from the ASCII slug of the name — emoji never reach tmux. Its tmux session is an incarnation, not the entity. Converses with the captain; proactive inside its mission (creates cards, starts them); never writes to projects |
-| Card | Unit of work, owned by one lieutenant. `type`: `plan` 🧠 \| `implementation` 🔥 \| `investigation` 🕵️. `body` = the deliverable, always rewritten to current state. `labels` (tags from the board registry). Work attributes live in an open `attributes{}` map, keys by convention: `repo`, `branch`, `worktree`, `session`, `prs {url, state}`, `artifacts {uri, label}` |
-| CardStatus | Live status hung on a card, UI's real-time signal. Worker lease: `absent \| idle \| working \| needs-you`, written ONLY by `card.status` (worker-side), decayed server-side by TTL; plus server-derived `owed` (captain's last thread message unanswered) and `unread` |
-| Worker | Implementation agent bound 1:1 to a Working card: tmux session + isolated worktree (+ delivery pipeline per project mode). Ephemeral — dies with the card's Working state |
+| Card | Unit of work, owned by one lieutenant. `type`: `plan` 🧠 \| `implementation` 🔥 \| `investigation` 🕵️. `body` = the deliverable, always rewritten to current state. `labels` (tags from the board registry). Work attributes live in an open `attributes{}` map, keys by convention: `repo`, `branch`, `worktree`, `session`, `prs {url, state}`, `artifacts {uri, label}`, plus `harness` and `model` (new-card hints consumed by `card.start`) |
+| CardStatus | Live status hung on a card, UI's real-time signal. Worker lease: `absent \| idle \| working \| needs-you`, written ONLY by `card.status` (worker-side), decayed server-side by TTL; plus server-derived `owed` (latest DELIVERED captain message not yet acked — queue truth, not thread order) with `owedState` `queued \| seen` (boundary: the drained cursor), and `unread` |
+| Worker | Implementation agent bound 1:1 to a Working card: tmux **window** (`w-<card-id>`) inside its lieutenant's session + isolated worktree (+ delivery pipeline per project mode). Ephemeral — dies with the card's Working state; the lieutenant-session coupling (lieutenant dies → its worker windows die) is accepted design |
 | Event | Card timeline entry: `text`, `level` (1 = bell, 2 = timeline only), `actor`, `kind` (open token; the board's kinds registry maps kind → emoji + default level) |
-| Message | Chat utterance. `target`: a lieutenant's main chat or a card thread. A card thread is a **context folder**: the interlocutor is always the owning lieutenant, never the worker |
-| QueueItem | One durable delivery to a lieutenant. Kinds: captain `message`, `start-order`, `rework-order`, `card-created` / `card-moved` (captain acts echoed to the owner), `worker-signal`, `worker-said` (a non-owner posted on the card thread), `worker-stopped`, `worker-died`, `worker done`, `pr-merged`, `pr-closed`. `seq`-ordered, at-least-once |
+| Message | Chat utterance. `target`: a lieutenant's main chat or a card thread. May carry `attachments [{id, name, mime, path}]` (captain uploads); attachments ride the QueueItem to the lieutenant with absolute paths. A card thread is a **context folder**: the interlocutor is always the owning lieutenant, never the worker |
+| QueueItem | One durable delivery to a lieutenant. Kinds: captain `message`, `start-order`, `rework-order`, `card-created` / `card-moved` (captain acts echoed to the owner), `worker-signal`, `worker-said` (a non-owner posted on the card thread), `worker-stopped`, `worker-died`, `worker-stalled`, `worker done`, `pr-merged`, `pr-closed`. `seq`-ordered, at-least-once. (`worker-paused` is an event kind only — pausing is the lieutenant's own act, it never queues) |
 | Archive | Append-only frozen card snapshots with `reason`; `card.restore` resurrects with full state and a loud level-1 event (a snapshot frozen in Working restores to Backlog — only `card.start` may enter Working) |
 | Label | Board-level tag registry: name + color, palette auto-assigned; cards carry label names |
 
@@ -46,7 +58,7 @@ columns; each lieutenant has a color, and its cards carry that color stripe.
 
 | Name | Used by | Description |
 |---|---|---|
-| Charter | lieutenant.create | Name, color, mission text (one free-text blob; projects of interest are prose convention) |
+| Charter | lieutenant.create | Name, color, avatar?, mission text (one free-text blob; projects of interest are prose convention) |
 | Brief | card.start | Task description + acceptance criteria handed to the worker |
 | HarnessRef | harness port | Opaque address of a live agent session (tmux target + resume id) |
 
@@ -62,20 +74,24 @@ actor strings are honor-system. The network boundary is the auth boundary.
 | Operation | Signature | Who | When |
 |---|---|---|---|
 | `workspace.init` | `dir → workspace` | ⚓ (the founding agent) | skill invoked in a fresh dir, **inside tmux** (refuses outside, with instruction); creates `.bridge-commander/`, boots the server, registers the caller as the first lieutenant — the "teleport" |
+| `workspace.open` | `dir → workspace` | ⚓ · 🤠 (CLI) | boot or attach to the board WITHOUT the teleport: bootstraps `.bridge-commander/` in cwd if absent, starts the server when down, prints the URL; no founding lieutenant involved |
 | `workspace.addProject` | `url \| path, mode → project` | ⚓ | captain asks to bring a repo into the workspace |
 | `lieutenant.create` | `charter → lieutenant` | 🤠 lane button · ⚓ on captain's ask | a new mission/domain deserves its own commander; server spawns its tmux session via the harness port, doctrine + charter as launch prompt |
-| `lieutenant.update` | `color?, avatar? → lieutenant` | 🤠 (⋯ → appearance) | cosmetic only — name/id stay immutable; `avatar: null` clears back to the colored-dot fallback |
-| `lieutenant.retire` | `lieutenant` | 🤠 | explicit only; refused while the lieutenant owns non-archived cards (archive or finish them first — never reassign); kills its session, removes it and its queue, loud level-1 event |
+| `lieutenant.patch` | `color?, avatar?, name?, charter?, ref? → lieutenant` | 🤠 (⋯ → appearance) · ⚙️ (ref re-registration on init idempotency) | cosmetics + charter; `name` changes the display only — `id` and the derived session name stay immutable; `avatar: null` clears back to the colored-dot fallback |
+| `lieutenant.retire` | `lieutenant` | 🤠 | explicit only; refused while the lieutenant owns non-archived cards (archive or finish them first); kills its session, removes it and its queue, loud level-1 event |
 
 ### card
 
 | Operation | Signature | Who | When |
 |---|---|---|---|
 | `card.create` | `lieutenant, title, type, attrs → card` | 🤠 · ⚓ (proactive) | an idea/task is worth tracking; born in Backlog, nowhere else |
-| `card.start` | `card → worker` | ⚓ (own judgment, or executing a captain drag-order) | ready to work: ONE atomic op — spawn worker session + worktree, bind to card, card → Working. The brief is auto-attached as a card artifact (label `brief`, idempotent across resumes). `plan` cards never start. The ONLY operation that enters Working |
+| `card.start` | `card, {brief?, resume?, harness?, model?, effort?} → worker` | ⚓ (own judgment, or executing a captain drag-order) | ready to work: ONE atomic op — spawn worker window + worktree, bind to card, card → Working. Harness/model resolve: explicit arg → card attribute hint → config default. The brief is auto-attached as a card artifact (label `brief`, idempotent across resumes); `--resume` reincarnates the recorded worker instead (refuses a brief — steer with `worker.send`). Implementation cards get branch `bc/<card-id>`; investigations get NO branch — their deliverable is the report. `plan` cards never start |
 | `card.move` | `card, column` | 🤠 drag = **order** · ⚓ only → Your review (the handoff) · ⚙️ only on objective facts (start, merge) | see side effects for drag semantics |
-| `card.patch` | `card, {title?, body?, type?, attrs?, labels?}` | ⚓ · ⚙️ (mechanical attrs: prs, session) | body rewritten to current state before every handoff. Owner is NOT patchable (see invariant 4) |
+| `card.patch` | `card, {title?, body?, type?, attrs?, labels?, owner?}` | ⚓ · ⚙️ (mechanical attrs: prs, session) | body rewritten to current state before every handoff. `owner` is patchable ONLY while no worker record is bound (see invariant 4) |
+| `card.park` | `card → ()` | ⚓ | the narrow lieutenant door out of Working back to Backlog — legal only when the card's worker is absent or dead (liveness re-checked server-side) |
 | `card.status` | `card, worker-state` | 🛠️ writes · ⚙️ TTL-decays | the live lease behind CardStatus; single-writer |
+| `card.artifact.add` | `card, uri, label? → ()` | ⚓ · 🤠 (📌 on a chat attachment) | promote a file to card artifact — a DELIBERATE act; a chat upload alone never lands here. Idempotent by uri |
+| `card.artifact.remove` | `card, uri → ()` | ⚓ · 🤠 | unlist an artifact (the file itself is untouched) |
 | `card.archive` | `card, reason` | ⚙️ on merge · ⚓/🤠 otherwise | work landed, died, or was dismissed |
 | `card.restore` | `card` | ⚓ · ⚙️ (live evidence for an archived card) | a kill was a mistake; full frozen state + loud level-1 event; Working snapshots land in Backlog |
 
@@ -83,11 +99,12 @@ actor strings are honor-system. The network boundary is the auth boundary.
 
 | Operation | Signature | Who | When |
 |---|---|---|---|
-| `chat.say` | `target: lieutenant-main \| card, text` | 🤠 ↔ ⚓ | any time; captain-side is write-ahead: queue first, then `harness.send` wake. Author defaults to the CALLER's identity (session-resolved), never inferred from the target |
+| `chat.say` | `target: lieutenant-main \| card, text, attachments?` | 🤠 ↔ ⚓ | any time; captain-side is write-ahead: queue first, then `harness.send` wake. Author defaults to the CALLER's identity (session-resolved), never inferred from the target |
 | `feed.drain` | `lieutenant → QueueItem[]` | ⚓ | first act of every lieutenant turn; the caller self-identifies by its tmux session and drains ONLY its own queue |
 | `feed.ack` | `seq` | ⚓ | after handling; only ack removes — unacked re-offers. Identity-scoped: a lieutenant can only commit seqs in its own queue |
 | `event.append` | `card \| board, text, kind, level` | ⚓ · 🛠️ | agent-authored timeline entry (card) or board-level notice |
 | `kinds.register` | `kind → emoji, level` | ⚓ | extend the event vocabulary; built-ins stay |
+| `label.manage` | `create \| rename \| recolor \| delete` | 🤠 | curate the board's label registry; rename/delete propagate across every card carrying the label |
 
 ### worker plumbing
 
@@ -95,8 +112,10 @@ actor strings are honor-system. The network boundary is the auth boundary.
 |---|---|---|---|
 | `worker.signal` | `card, text` | 🛠️ | real milestones (branch, tests green, PR open) → level-2 event + QueueItem to the owner |
 | `worker.done` | `card, outcome` | 🛠️ | worker finished: event + QueueItem wake the owner; the card stays Working until the lieutenant verifies and hands off. PR URLs in the outcome populate the card's `prs` (the PR watch takes it from there); an investigation's report (`.bridge-commander/reports/<card>.md` by convention) is attached as an artifact |
+| `worker.pause` | `card → ()` | ⚓ | deliberately kill the worker's session with NO died alarm; the card stays Working, the record + worktree survive for `card.start --resume`; supervision skips a paused worker. Composes with `card.park` |
 | worker stop | — | ⚙️ turn-end | a worker turn-end IS the stop signal: card still Working and no `done` → immediate `worker-stopped` QueueItem to the owner + level-2 event (coalesced — one per stop, not per turn). After `done`, turn-ends only update counters |
-| worker death | — | ⚙️ supervision loop | a worker ref dead without `done` → `worker-died` QueueItem to the owner + level-2 event; the card stays Working, flagged — the owner resumes (`card.start --resume`) or moves it back |
+| worker death | — | ⚙️ supervision loop | a worker ref dead without `done` → `worker-died` QueueItem to the owner + level-2 event; the card stays Working, flagged — the owner resumes (`card.start --resume`) or parks it |
+| worker stall | — | ⚙️ supervision loop | a worker alive but silent too long (no signal/turn-end) → `worker-stalled` level-1 event + QueueItem to the owner; re-armed by real activity |
 
 ### harness port (internal seam — the multi-harness contract)
 
@@ -110,8 +129,8 @@ actor strings are honor-system. The network boundary is the auth boundary.
 | `harness.kill` | `ref` | ⚙️ | end a session for good (idempotent): merged-PR cleanup, card archive, lieutenant.retire |
 | `harness.onTurnEnd` | `ref, hook` | embedders | turn-boundary detection for port consumers; the SERVER's channel is the spawn-time callback URL — a Stop hook in the session POSTs each turn end (with its tmux session for exact attribution) |
 
-The server speaks ONLY this port. v0 ships the `claude` implementation (plus a file-backed
-`fake` for tests); adding a harness is implementing these seven verbs, nothing else.
+The server speaks ONLY this port. Builtins: `claude`, `codex` (OpenAI Codex CLI), and a
+file-backed `fake` for tests; adding a harness is implementing these seven verbs, nothing else.
 Harness working state (session ids, prompts, turn-end logs) lives in the workspace's
 `.bridge-commander/harness/` — never global; spawned session names are unique per workspace.
 
@@ -119,21 +138,25 @@ Harness working state (session ids, prompts, turn-end logs) lives in the workspa
 verbs for features not every harness can honor. The port never validates them (requiring
 one would force every harness, `fake` included, to implement it); the server
 capability-checks at the call site (`typeof impl.openPane === 'function'`) and degrades
-gracefully when the verb is absent. Current optional verbs (pane viewing — the UI's 👁 peek):
+gracefully when the verb is absent. Current optional verbs (pane viewing, slash commands,
+session status):
 
 | Verb | Signature | Called by | Purpose |
 |---|---|---|---|
 | `harness.openPane` | `ref, {onFrame, intervalMs?, lines?} → {close()}` | ⚙️ pane hub | stream the pane's rendered screen as change-detected frames (strings, MAY carry ANSI SGR) — served to the captain over a dedicated per-target SSE (`GET /api/cards/:id/pane/stream`, `GET /api/lieutenants/:id/pane/stream`), ref-counted so N viewers share ONE feed and the last disconnect releases it; harness lacks the verb → `unsupported`, nothing to watch → `no-pane`, concurrent-pane cap → `busy` (all clean SSE events, never an HTTP error) |
 | `harness.paneSnapshot` | `ref, {lines?} → string` | ⚙️ pane hub | one-shot capture for the stream's initial paint |
+| `harness.commands` | `ref → [{name, description}]` | ⚙️ | list the slash commands this session honors (drives the UI's command palette) |
+| `harness.runCommand` | `ref, line → string` | ⚙️ | run one slash-command line in the session (pass-through or emulated per harness) and return the reply text |
+| `harness.status` | `ref → {model, contextUsed, contextWindow, rateLimits?}` | ⚙️ | session vitals; the server caches the result at each turn-end and serves it on the board payload (the lane/card context bars) |
 
 ## Invariants
 
 1. **Board is truth.** No shadow files, no mirror: cards + charters + queues in `.bridge-commander/` ARE the state. Agent conversation memory is a cache; restart of any session is a non-event.
 2. **Lieutenants never write to projects.** Every change reaches a project through a worker in an isolated worktree, shipped by the project's delivery mode.
-3. **Working ⇔ unfinished task, which SHOULD have a live worker.** The only way into Working is `card.start`, spawning the worker atomically. A Working card may lose its worker only by accident (process died, machine rebooted) — the server flags it and queues the owner; a wound to heal, never a state to create deliberately.
-4. **One owner, for life.** Every card belongs to exactly one lieutenant, fixed at birth — no reassignment; moving work between lieutenants = archive + recreate. The captain converses only with lieutenants (card threads included). `tmux attach` on a predictable session name (`bc-*`; the founding lieutenant keeps its own session name) is the escape hatch, not a channel.
+3. **Working ⇔ unfinished task, which SHOULD have a live worker.** The way into Working is `card.start`, spawning the worker atomically (or `worker.send` reopening a done-but-alive worker). A Working card may lose its worker only by accident (process died, machine rebooted) — the server flags it and queues the owner; a wound to heal — or by `worker.pause`, the ONE deliberate stop, marked so supervision never reads it as a wound.
+4. **One owner while work is bound.** Every card belongs to exactly one lieutenant. Reassignment is legal ONLY for a card with no worker record; mid-work handovers stay forbidden (archive + recreate). The captain converses only with lieutenants (card threads included). `tmux attach` on a predictable session name (`bc-*`; the founding lieutenant keeps its own session name) is the escape hatch, not a channel.
 5. **Territory.** Peer review is the captain's shelf: nothing but a merge-archive touches it.
-6. **No merge without the captain's word** (v0: no yolo).
+6. **No merge without the captain's word.** A standing per-project authorization (yolo) IS the captain's word; absent it, PRs wait.
 7. **Write-ahead delivery.** Queue write precedes the send-keys wake; at-least-once; only ack removes. A dead session loses nothing.
 8. **Supervision is infrastructure.** The server watches sessions, turn-ends, and PRs; lieutenants are purely reactive to their queue — no agent-armed watcher, no poll, no turn ending blind.
 9. **Delegation over subagents.** Work that deserves representation gets a card + worker, not an invisible subagent.
@@ -145,12 +168,14 @@ gracefully when the verb is absent. Current optional verbs (pane viewing — the
 | captain drags any column → Working | start-order QueueItem to the owning lieutenant → it briefs and runs `card.start`; the card does not move until then (it carries a visible `pendingOrder` marker, cleared by any applied move) |
 | captain drags Your review → Backlog | rework-order QueueItem carrying the captain's thread comment; same `pendingOrder` marker |
 | captain creates / moves a card | `card-created` / `card-moved` QueueItem to the owner (awareness, not an order) |
-| `card.start` | worker spawned (worktree + session), card → Working, level-2 event, brief auto-attached as an artifact |
-| `chat.say` by captain | QueueItem (write-ahead) + `harness.send` wake to the owning lieutenant |
+| `card.start` | worker spawned (worktree + window), card → Working, level-2 event, brief auto-attached as an artifact |
+| `chat.say` by captain | QueueItem (write-ahead, attachments riding along) + `harness.send` wake to the owning lieutenant |
+| `chat.say` starting with `/` | routed to `harness.runCommand`, reply lands in-thread — NO QueueItem, no wake, no owed. On a card target the command addresses the WORKER session (unlike say, which always talks to the owner) |
 | `chat.say` on a card thread by anyone but the owning lieutenant (its worker, a peer, unidentified tooling) | `worker-said` QueueItem waking the owner — the thread alone notifies nobody |
-| `worker.send` by the lieutenant | text typed into the card's live worker session (harness `send`, verified submission) + level-2 event; loud error without a live worker. `card.start --resume` refuses a brief and points here |
+| `worker.send` by the lieutenant | text typed into the card's live worker session (harness `send`, verified submission) + level-2 event; on a done-but-alive worker it REOPENS the turn (record reset, card → Working) — send = "more work for this worker"; loud error without a live worker. `card.start --resume` refuses a brief and points here |
 | worker signal | level-2 event on card + QueueItem to the owning lieutenant |
 | worker turn-end without `done` (card still Working) | `worker-stopped` QueueItem to the owner + level-2 event, immediately — a stopped worker is never invisible |
+| worker alive but silent past the stall window | `worker-stalled` level-1 event + QueueItem to the owner |
 | worker done + lieutenant review | lieutenant rewrites body, moves → Your review — the level-1 handoff |
 | PR merged (server watch) | card archived (`merged`), worktree released (only when clean), lingering worker session killed, level-1 event, `pr-merged` QueueItem to the owner |
 | PR closed unmerged (server watch) | `pr-closed` QueueItem to the owner — a decision, not an archive |


### PR DESCRIPTION
Docs-only: applies the captain-approved 19-item drift audit to `docs/api/overview.md` (item 18 amended — DNA declared deliberately single-file, no `entities.md`). Plus the `worker.send` reopen fold-in (PR #42).

## What changed (overview.md only)
- **Invariants**: inv 6 yolo-as-captain's-word; inv 4 one-owner-*while-bound* (reassignment legal only with no worker record); inv 3 adds `worker.pause` as the one deliberate stop + `worker.send` reopen door.
- **Ops**: `worker.pause`, `card.park`, `card.artifact.add/remove`, `card.start` signature (`{brief?, resume?, harness?, model?, effort?}` + resolve order + `bc/<card-id>` branch / no-branch investigations), `label.manage`, `workspace.open`, `lieutenant.update`→`lieutenant.patch` (widened), `card.patch` owner-patchable-while-unbound.
- **Entities**: Message `attachments`, Worker = tmux window `w-<card-id>`, CardStatus `owed`/`owedState` queue-derived, QueueItem `worker-stalled` (+ `worker-paused` event-only), worker-stall side-effect.
- **Harness**: builtins `claude`/`codex`/`fake`; optional verbs `commands`/`runCommand`/`status`; slash-command side-effect row.
- **Structure**: ALTITUDE + STRUCTURE paragraphs; Charter `avatar?`.

## Sanity checks vs code
Verified against `harness/` + `server/server.js`: `codex` builtin present; optional verbs `commands`/`runCommand`/`status`/`openPane` exist; `worker.send` done-but-alive reopen implemented (server.js:1674). No mismatches — applied as prepared.

## Tests
`node --test test/*.test.js harness/test/*.test.js` → **300/300 pass** (no regression; docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)