### PR TITLE
Skip board re-renders while the artifact viewer is open

### DIFF
--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -302,7 +302,12 @@ export async function openAttachment(att) {
     avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
   } catch (e) { avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)'; }
 }
-export function closeArtifact() { avOverlay.hidden = true; }
+// A close hook lets main.js run one deferred render when the viewer closes
+// (renders are skipped while it's open — see the reading-mode guard). Mirrors
+// state.js onRender: a setter avoids a circular import back into main.js.
+let onCloseFn = () => {};
+export function onArtifactClose(fn) { onCloseFn = fn; }
+export function closeArtifact() { avOverlay.hidden = true; onCloseFn(); }
 export function artifactOpen() { return !avOverlay.hidden; }
 document.getElementById('av-close').onclick = closeArtifact;
 // Maximize / restore the viewer (pure CSS class toggle — see #av-modal.expanded).

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -7,7 +7,7 @@ import { trackEvents, renderNotifSettings } from './notifysettings.js';
 import { onOpenCard as toastOnOpenCard } from './toast.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu, appearancePopoverOpen, closeAppearancePopover } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
-import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, closeOwnerMenu, ownerMenuOpen } from './detail.js';
+import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
@@ -122,8 +122,14 @@ document.addEventListener('keydown', (e) => {
 });
 
 // ---------- render orchestration ----------
+// Reading-mode guard: while the artifact viewer popup is open, workers still
+// push board updates (S.doc keeps updating) but repainting the regions would
+// blink the text/iframe being read. So record the pending render and bail; when
+// the viewer closes, onArtifactClose below runs the one deferred pass.
+let renderPending = false;
 onRender(() => {
   if (!S.doc) return;
+  if (artifactOpen()) { renderPending = true; return; }
   document.title = S.doc.title || 'bridge command';
   document.getElementById('b-title').textContent = S.doc.title || 'bridge command';
   document.getElementById('b-subtitle').textContent = S.doc.subtitle || '';
@@ -140,6 +146,9 @@ onRender(() => {
   // text stays out of the compared markup so it never forces a rebuild)
   refreshAgoLabels();
 });
+// When the viewer closes, flush the render that was deferred while it was open
+// so the board catches up in one pass (no-op if nothing pushed meanwhile).
+onArtifactClose(() => { if (renderPending) { renderPending = false; render(); } });
 
 // ---------- SSE ----------
 // A half-open connection after a server restart can sit silent forever without


### PR DESCRIPTION
## Problem
`ui/js/main.js` render orchestration (`onRender`) runs on every SSE board push; region renders swap `innerHTML` whenever markup changed. Reading an artifact in the viewer popup (md text in `#av-body` or html in `#av-frame`) blinks every few seconds as workers push updates.

## Fix
Reading-mode guard: while the artifact viewer is open (`artifactOpen()`), the render pass records a pending render and returns **without** rendering; when the viewer closes, the one deferred render runs.

- `onRender`: `if (artifactOpen()) { renderPending = true; return; }` right after the `S.doc` guard.
- `closeArtifact` (funnels av-close click, overlay click, and Escape) fires a small `onArtifactClose` hook; `main.js` registers it and flushes the deferred render. A setter (mirroring `state.js` `onRender`) avoids a circular import back into `main.js`.
- **Data safety:** `S.doc` keeps updating from SSE while the popup is open — only the RENDER is deferred. Chat send, notifications polling, the minute tick (`setInterval(render, 60000)`), and the reconnect `applyBoard` refetch all go through the same guarded `render()`, so they're covered too.

## Tests
UI-only diff (no UI test harness). Full suite `node --test test/*.test.js harness/test/*.test.js`: 297/300. The 3 failures (status/supervise/stale ttl-timing) pass 23/23 when run in isolation — pre-existing timing flakes under a loaded box, unrelated to this `ui/js`-only change (`node --test` never loads it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)