### PR TITLE
Show reasoning effort next to the model in /status

### DIFF
--- a/harness/agent-status.js
+++ b/harness/agent-status.js
@@ -8,7 +8,9 @@
 // null, never a throw.
 //
 // Status shape (the port's `status(ref)` return value):
-//   { model, contextUsed, contextWindow, rateLimits? }
+//   { model, contextUsed, contextWindow, effort?, rateLimits? }
+//   effort (reasoning level, e.g. "high") — from the claude sidecar or the codex
+//   turn_context; absent when unknown (e.g. the claude transcript fallback).
 //   rateLimits (codex only — claude does not persist them): { primary?,
 //   secondary? } each { usedPercent, windowMinutes, resetsAt (epoch secs) }.
 //
@@ -151,6 +153,8 @@ function claudeSidecarStatus(ref, opts = {}) {
     contextUsed: Number(cw.total_input_tokens) || 0,
     contextWindow: window,
   };
+  const effort = p.effort && p.effort.level;
+  if (effort) out.effort = String(effort);
   const rl = claudeSidecarRateLimits(p.rate_limits);
   if (rl) out.rateLimits = rl;
   return out;
@@ -263,6 +267,7 @@ function codexStatus(ref, opts = {}) {
   const lines = text.split('\n');
   let usage = null;
   let model = null;
+  let effort = null;
   for (let i = lines.length - 1; i >= 0 && !(usage && model); i--) {
     const line = lines[i];
     let doc = null;
@@ -273,7 +278,10 @@ function codexStatus(ref, opts = {}) {
     } else if (!model && line.includes('"turn_context"')) {
       try { doc = JSON.parse(line); } catch { continue; }
       const p = doc && doc.payload;
-      if (doc.type === 'turn_context' && p && p.model) model = String(p.model);
+      if (doc.type === 'turn_context' && p && p.model) {
+        model = String(p.model);
+        if (p.effort) effort = String(p.effort);
+      }
     }
   }
   if (!usage) return null;
@@ -282,6 +290,7 @@ function codexStatus(ref, opts = {}) {
     contextUsed: usage.info.last_token_usage.total_tokens || 0,
     contextWindow: usage.info.model_context_window || null,
   };
+  if (effort) out.effort = effort;
   const rl = codexRateLimits(usage.rate_limits);
   if (rl) out.rateLimits = rl;
   return out;
@@ -317,7 +326,8 @@ function fmtWindowLabel(minutes) {
 
 // formatStatus(status) -> the human /status reply.
 function formatStatus(st) {
-  const lines = ['model: ' + (st.model || 'unknown')];
+  const modelLine = 'model: ' + (st.model || 'unknown') + (st.effort ? ' (' + st.effort + ')' : '');
+  const lines = [modelLine];
   if (Number.isFinite(st.contextUsed) && st.contextWindow > 0) {
     const pct = Math.round((st.contextUsed / st.contextWindow) * 100);
     lines.push('context: ' + fmtInt(st.contextUsed) + ' / ' + fmtInt(st.contextWindow)

--- a/harness/test/agent-status.test.js
+++ b/harness/test/agent-status.test.js
@@ -111,6 +111,7 @@ test('claudeStatus: prefers the sidecar — real 1M window + rate limits (Opus c
       session_id: sid,
       cwd: ws,
       model: { id: 'claude-opus-4-8', display_name: 'Opus 4.8' },
+      effort: { level: 'high' },
       context_window: { context_window_size: 1000000, total_input_tokens: 118213, used_percentage: 11.8 },
       rate_limits: {
         five_hour: { used_percentage: 42, resets_at: 2000000000 },
@@ -127,16 +128,36 @@ test('claudeStatus: prefers the sidecar — real 1M window + rate limits (Opus c
       assert.strictEqual(st.contextWindow, 1000000);
       assert.strictEqual(st.contextUsed, 118213);
       assert.strictEqual(st.model, 'claude-opus-4-8');
+      assert.strictEqual(st.effort, 'high');
       assert.deepStrictEqual(st.rateLimits, {
         primary: { usedPercent: 42, windowMinutes: 300, resetsAt: 2000000000 },
         secondary: { usedPercent: 7, windowMinutes: 10080, resetsAt: 2000100000 },
       });
+      assert.match(formatStatus(st), /model: claude-opus-4-8 \(high\)/);
       assert.match(formatStatus(st), /context: 118,213 \/ 1,000,000 tokens \(12%\)/);
       assert.match(formatStatus(st), /5h limit: 42% used/);
       assert.match(formatStatus(st), /1w limit: 7% used/);
     } finally {
       fs.rmSync(projectsDir, { recursive: true, force: true });
     }
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+});
+
+test('claudeSidecarStatus: no effort field → effort absent from the status shape', () => {
+  const ws = tmpdir('bc-status-sidecar-noeffort-');
+  try {
+    const sid = 'noeffort-1';
+    writeSidecar(ws, sid, {
+      session_id: sid,
+      cwd: ws,
+      model: { id: 'claude-opus-4-8' },
+      context_window: { context_window_size: 200000, total_input_tokens: 5000 },
+    });
+    const st = claudeSidecarStatus({ cwd: ws, resumeId: sid });
+    assert.deepStrictEqual(st, { model: 'claude-opus-4-8', contextUsed: 5000, contextWindow: 200000 });
+    assert.strictEqual(formatStatus(st), 'model: claude-opus-4-8\n\ncontext: 5,000 / 200,000 tokens (3%)');
   } finally {
     fs.rmSync(ws, { recursive: true, force: true });
   }
@@ -233,7 +254,7 @@ test('codexStatus: last token_count wins — totals, window, model, rate limits'
   try {
     writeRollout(sessionsDir, '2026/06/13', THREAD,
       JSON.stringify({ type: 'session_meta', payload: { id: THREAD } }) + '\n'
-      + JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.5' } }) + '\n'
+      + JSON.stringify({ type: 'turn_context', payload: { model: 'gpt-5.5', effort: 'medium' } }) + '\n'
       + tokenCountLine(11111) // stale — must not win
       + tokenCountLine(58034, {
         primary: { used_percent: 1.0, window_minutes: 300, resets_at: 1781371082 },
@@ -242,6 +263,7 @@ test('codexStatus: last token_count wins — totals, window, model, rate limits'
     const st = codexStatus({ resumeId: THREAD }, { sessionsDir });
     assert.deepStrictEqual(st, {
       model: 'gpt-5.5',
+      effort: 'medium',
       contextUsed: 58034,
       contextWindow: 258400,
       rateLimits: {
@@ -250,7 +272,7 @@ test('codexStatus: last token_count wins — totals, window, model, rate limits'
       },
     });
     const text = formatStatus(st);
-    assert.match(text, /model: gpt-5\.5/);
+    assert.match(text, /model: gpt-5\.5 \(medium\)/);
     assert.match(text, /context: 58,034 \/ 258,400 tokens \(22%\)/);
     assert.match(text, /5h limit: 1% used/);
     assert.match(text, /1w limit: 21% used/);


### PR DESCRIPTION
## What
`/status` now shows the reasoning effort next to the model — `model: claude-fable-5 (high)` — when it's known.

## Why
Both harnesses already record effort on disk but `/status` only surfaced the model. Effort is useful context alongside the model id.

## How
Added an optional `effort` field to the status shape:
- **claude (sidecar path):** picks up `effort.level` from the statusline payload.
- **codex:** extracts `effort` from the same `turn_context` line that carries the model.
- **claude transcript fallback:** effort isn't on disk there, so it stays `null` and renders model-only (accepted degradation).

`formatStatus` renders `model: <id> (<effort>)` when present, unchanged otherwise. Contract preserved: missing/weird fields never throw.

Scope: `harness/agent-status.js` + its tests. Full suite (301 tests) green.