### PR TITLE
Deflake stale-watchdog and wake-heartbeat tests

### DIFF
--- a/test/stale.test.js
+++ b/test/stale.test.js
@@ -57,12 +57,14 @@ function stallSeed(cardId, ageMs) {
 
 test('alive worker silent past the threshold: ONE worker-stalled item + level-1 card event, no duplicates on later ticks', async () => {
   const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  fakeSession(fdir, 'bc-lt-ada:w-slug'); // ALIVE before the server boots — if the
+  // first supervise tick raced ahead of this marker the worker would read DEAD,
+  // get flagged worker-died once (permanent), and the stall path would never run.
   const s = await startServer({
     env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
     seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
   });
   try {
-    fakeSession(fdir, 'bc-lt-ada:w-slug'); // ALIVE — the whole point: not dead, just silent
     await until('worker-stalled queue item', async () => {
       const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
       return items.some((i) => i.kind === 'worker-stalled' && i.card === 'slug');
@@ -86,12 +88,13 @@ test('alive worker silent past the threshold: ONE worker-stalled item + level-1 
 
 test('a fresh worker.signal re-arms the watchdog: lastSignalAt resets the clock, then a second stall fires AGAIN', async () => {
   const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  fakeSession(fdir, 'bc-lt-ada:w-slug'); // ALIVE before boot (see the first test): a
+  // first tick that raced ahead of the marker would flag worker-died and never stall.
   const s = await startServer({
     env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
     seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
   });
   try {
-    fakeSession(fdir, 'bc-lt-ada:w-slug');
     await until('first worker-stalled item', async () => {
       const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
       return items.filter((i) => i.kind === 'worker-stalled').length === 1;
@@ -153,12 +156,13 @@ test('a DEAD silent worker takes the worker-died path, never worker-stalled (mut
 
 test('leaving Working clears staleNotified (mirrors the stopNotified lifecycle)', async () => {
   const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  fakeSession(fdir, 'bc-lt-ada:w-slug'); // ALIVE before boot (see the first test): a
+  // first tick that raced ahead of the marker would flag worker-died and never stall.
   const s = await startServer({
     env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WORKER_STALE_SECS: '1' },
     seed: (dir) => seedBoard(dir, stallSeed('slug', 10000)),
   });
   try {
-    fakeSession(fdir, 'bc-lt-ada:w-slug');
     await until('worker-stalled fired (flag set)', async () => {
       const b = (await s.api('GET', '/api/board')).body;
       return b.workers[0] && b.workers[0].staleNotified;

--- a/test/supervise.test.js
+++ b/test/supervise.test.js
@@ -187,9 +187,13 @@ test('wake heartbeat: a live lieutenant with pending items is woken by the sweep
     await sleep(600);
     assert.strictEqual(readSends(fdir, 'bc-lt-ada').length, 1, 'coalesced while the nudge is fresh');
     assert.strictEqual((await s.api('GET', '/api/board')).body.events.filter((e) => e.kind === 'respawned').length, 0);
-    // drained AND acked -> nothing pending -> the sweep goes quiet
-    const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
-    await s.api('POST', '/api/feed/ack', { seq: items[items.length - 1].seq });
+    // acked -> nothing pending -> the sweep goes quiet. Ack the seeded item by
+    // its global seq (1) directly rather than draining first: a GET /api/feed
+    // drain clears the nudge while the item is still pending, and any sweep tick
+    // landing in the drain->ack gap re-fires the wake (the historic flake under
+    // load — the drain deletes the nudge entry, so a wide TTL can't suppress it).
+    // Acking closes the queue atomically, leaving no pending-but-un-nudged window.
+    await s.api('POST', '/api/feed/ack', { seq: 1 });
     await sleep(600);
     assert.strictEqual(readSends(fdir, 'bc-lt-ada').length, 1, 'no re-nudge after the queue is handled');
   } finally {
@@ -234,6 +238,9 @@ test('wake heartbeat: a stale nudge lapses after BC_WAKE_TTL_MS and the sweep re
 test('dead worker without done: worker-died QueueItem + card event, card stays Working, flagged once', async () => {
   const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
   const nowIso = new Date().toISOString();
+  fakeSession(fdir, 'bc-lt-ada:w-fine'); // alive BEFORE boot: if the first supervise
+  // tick raced ahead of this marker it would flag the live 'fine' worker died too,
+  // yielding two worker-died items. w-doomed and w-finished windows stay dead.
   const s = await startServer({
     env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0' },
     seed: (dir) => seedBoard(dir, {
@@ -266,7 +273,6 @@ test('dead worker without done: worker-died QueueItem + card event, card stays W
     }),
   });
   try {
-    fakeSession(fdir, 'bc-lt-ada:w-fine'); // alive via marker; w-doomed and w-finished windows are dead
     await until('worker-died queue item', async () => {
       const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
       return items.some((i) => i.kind === 'worker-died' && i.card === 'doomed');


### PR DESCRIPTION
## What

Make the two flaky timing tests deterministic under arbitrary machine load. Both were **structural races**, not slow timeouts — bumping timeouts wouldn't have fixed either.

## Why they flaked

**`test/stale.test.js` — worker-stalled watchdog.** The worker's alive-marker was written *after* the server booted. The 150ms supervise loop starts on boot, so under load a first tick could run before the marker existed → worker read as **dead** → flagged `worker-died` **once and permanently** (flagged workers are skipped on every later tick) → the stall path never ran → `until()` timed out.
Fix: write the marker *before* boot (mirroring the existing wake tests), so the worker is always alive on the first tick. Same latent race fixed in the two sibling stale tests and in supervise.test.js's "dead worker" test — there a raced first tick flagged the *live* worker dead too, producing two `worker-died` items.

**`test/supervise.test.js` — wake heartbeat coalescing.** The test drained via `GET /api/feed` (which clears the in-memory nudge) while the queue item was still pending, then acked. A supervise tick landing in that drain→ack gap saw pending>0 with the nudge cleared and re-fired the wake → `2 !== 1`. A wider TTL can't help — the drain *deletes* the nudge entry, so nothing suppresses the next tick.
Fix: ack the seeded item directly (its global seq is 1), closing the queue in one step with no pending-but-un-nudged window.

## Scope

Test files only — no server changes. The seams were already there; the tests just used them in a racy order.

## Proof

- 20 consecutive `node --test test/stale.test.js test/supervise.test.js` at 12/24-core load: green
- 15 more at 18/24-core load: 0 logic flakes
- Full suite `node --test test/*.test.js harness/test/*.test.js`: 301/301