### PR TITLE
Lieutenant switcher dropdown in the chat header — chip lane removed

### DIFF
--- a/ui/app.css
+++ b/ui/app.css
@@ -181,7 +181,7 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg.cmd-reply .cmd-out p { margin: 0 0 4px; }
 .msg.cmd-reply .cmd-out p:last-child { margin-bottom: 0; }
 /* /status rich block: model line + context/rate progress bars (context-bar
-   visual language reused from the lane chips) */
+   visual language reused from the chat header) */
 .status-block { display: flex; flex-direction: column; gap: 7px; }
 .status-block .st-model { color: var(--text); font-size: 13px; }
 .status-block .st-effort { color: var(--dim); }
@@ -284,38 +284,67 @@ body.resizing { user-select: none; cursor: col-resize; }
 .att-file .att-pin { position: static; margin-left: 4px; align-self: center; background: var(--panel2); color: var(--dim); }
 @media (hover: none) { .att-pin { opacity: .7; } }
 
-/* ---------- lieutenant lane (above the columns) ---------- */
-#lane {
-  flex: none; display: flex; gap: 8px; align-items: stretch; padding: 10px 14px 0;
-  overflow-x: auto; overflow-y: hidden;
+/* ---------- lieutenant switcher (chat header) ----------
+   The header trigger carries the current lieutenant (face, name, model+effort,
+   context bar, owed state); the dropdown lists every lieutenant with the same
+   info + unread/owed and the per-lieutenant controls (👁 / ⋯ / ＋ lieutenant). */
+#chat-lt {
+  position: relative; flex: 1; min-width: 0; display: flex; align-items: center; gap: 8px;
+  padding: 3px 8px; margin-left: -4px; border-radius: 8px; text-align: left;
+  transition: background .12s;
 }
-.lt-card {
-  position: relative; flex: none; display: inline-flex; align-items: center; gap: 7px;
-  background: var(--panel); border: 1px solid var(--line); border-left: 3px solid var(--faint);
-  border-radius: 9px; padding: 7px 11px; cursor: pointer; user-select: none; -webkit-user-select: none;
-  transition: border-color .15s, transform .12s, box-shadow .15s;
+#chat-lt:hover { background: var(--panel); }
+.lt-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; }
+.clt-main { flex: 0 1 auto; min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.clt-name {
+  display: inline-flex; align-items: center; gap: 6px; font-weight: 600; font-size: 13.5px;
+  max-width: 100%; overflow: hidden; white-space: nowrap;
 }
-.lt-card:hover { border-top-color: var(--line2); border-right-color: var(--line2); border-bottom-color: var(--line2); transform: translateY(-1px); }
-.lt-card.on { border-top-color: var(--accent2); border-right-color: var(--accent2); border-bottom-color: var(--accent2); background: var(--accent-soft); }
-.lt-card.filtered { box-shadow: 0 0 0 1px var(--accent2) inset; }
-.lt-card .lt-dot, #chat-title .lt-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; }
-.lt-card .lt-name { font-size: 13px; font-weight: 620; white-space: nowrap; }
-.lt-card .lt-counts { color: var(--faint); font-size: 11px; font-family: var(--mono); white-space: nowrap; }
-.lt-card .badge-n { top: -6px; right: -6px; }
-.lt-card .t-typing { display: inline-flex; align-items: center; gap: 3px; flex: none; }
-.lt-card .t-typing .tdot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent); animation: typing-blink 1.2s infinite; }
-.lt-card .t-typing .tdot:nth-child(2) { animation-delay: .2s; }
-.lt-card .t-typing .tdot:nth-child(3) { animation-delay: .4s; }
-.lt-card .t-typing.stale { color: var(--warn); font-size: 11px; line-height: 1; }
-.lt-card .t-typing.queued { color: var(--dim); font-size: 11px; line-height: 1; }
-.lt-card .lt-menu { color: var(--faint); font-size: 14px; line-height: 1; padding: 0 3px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
-.lt-card:hover .lt-menu { opacity: 1; }
-.lt-card .lt-menu:hover { color: var(--fg); background: var(--panel2); }
-.lt-add {
-  flex: none; color: var(--faint); font-size: 12px; border: 1px dashed var(--line2);
-  border-radius: 9px; padding: 7px 12px; white-space: nowrap; transition: color .15s, border-color .15s;
+.clt-meta {
+  display: inline-flex; align-items: center; gap: 6px; max-width: 100%;
+  color: var(--dim); font-size: 10.5px; font-family: var(--mono); white-space: nowrap;
 }
-.lt-add:hover { color: var(--accent); border-color: var(--accent2); }
+.clt-model { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+.clt-effort { color: var(--faint); }
+.clt-caret { color: var(--faint); font-size: 10px; flex: none; }
+#chat-lt:hover .clt-caret { color: var(--accent); }
+#chat-lt .badge-n { top: -3px; right: -3px; }
+/* owed indicator (trigger + rows): same dots/⏳/⚠ language as tiles and chat */
+#chat-lt .t-typing, .lts-row .t-typing { display: inline-flex; align-items: center; gap: 3px; flex: none; }
+#chat-lt .t-typing .tdot, .lts-row .t-typing .tdot { width: 4px; height: 4px; border-radius: 50%; background: var(--accent); animation: typing-blink 1.2s infinite; }
+#chat-lt .t-typing .tdot:nth-child(2), .lts-row .t-typing .tdot:nth-child(2) { animation-delay: .2s; }
+#chat-lt .t-typing .tdot:nth-child(3), .lts-row .t-typing .tdot:nth-child(3) { animation-delay: .4s; }
+#chat-lt .t-typing.stale, .lts-row .t-typing.stale { color: var(--warn); font-size: 11px; line-height: 1; }
+#chat-lt .t-typing.queued, .lts-row .t-typing.queued { color: var(--dim); font-size: 11px; line-height: 1; }
+
+#lt-switcher {
+  position: absolute; top: 47px; left: 8px; right: 8px; z-index: 60;
+  display: flex; flex-direction: column; gap: 2px; padding: 6px;
+  background: var(--bg2); border: 1px solid var(--line2); border-radius: 12px;
+  box-shadow: var(--shadow); animation: pop-in .14s ease-out;
+  max-height: min(440px, 72vh); overflow-y: auto;
+}
+.lts-row {
+  display: flex; align-items: center; gap: 9px; padding: 8px 9px; border-radius: 9px;
+  cursor: pointer; user-select: none; -webkit-user-select: none; transition: background .12s;
+}
+.lts-row:hover { background: var(--panel2); }
+.lts-row.on { background: var(--accent-soft); box-shadow: inset 2px 0 0 var(--accent); }
+.lts-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.lts-name { display: inline-flex; align-items: center; gap: 6px; font-size: 13.5px; font-weight: 620; max-width: 100%; overflow: hidden; white-space: nowrap; }
+.lts-name .badge-n { position: static; flex: none; }
+.lts-meta { display: flex; align-items: center; gap: 7px; min-width: 0; color: var(--dim); font-size: 11px; font-family: var(--mono); white-space: nowrap; }
+.lts-model { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+.lts-counts { flex: none; color: var(--faint); }
+.lts-cur { flex: none; color: var(--accent); font-size: 12px; }
+.lts-peek, .lts-menu { flex: none; color: var(--faint); font-size: 14px; line-height: 1; padding: 8px 7px; border-radius: 7px; transition: color .12s, background .12s; }
+.lts-peek:hover, .lts-menu:hover { color: var(--accent); background: var(--accent-soft); }
+.lts-add {
+  display: flex; align-items: center; justify-content: center; margin-top: 4px;
+  color: var(--faint); font-size: 12.5px; border: 1px dashed var(--line2);
+  border-radius: 9px; padding: 10px; transition: color .15s, border-color .15s;
+}
+.lts-add:hover { color: var(--accent); border-color: var(--accent2); }
 
 /* ---------- board ---------- */
 #board { flex: 1; min-height: 0; display: flex; gap: 12px; padding: 14px; overflow-x: auto; }
@@ -793,11 +822,13 @@ a.a-uri { color: var(--accent); }
   display: inline-block; flex: none; background-image: url('/ui/img/avatars.png');
   background-size: 800% 800%; background-repeat: no-repeat; border-radius: 5px;
 }
-.lt-card .lt-face, #chat-title .lt-face {
+.lt-face {
   width: 20px; height: 20px; border-radius: 50%; flex: none; padding: 1px;
   border: 1.5px solid; display: inline-flex;
 }
-.lt-card .lt-face .avatar, #chat-title .lt-face .avatar { width: 100%; height: 100%; border-radius: 50%; }
+.lt-face .avatar { width: 100%; height: 100%; border-radius: 50%; }
+#chat-lt .lt-face { width: 26px; height: 26px; }
+.lts-row .lt-face { width: 30px; height: 30px; }
 /* an avatar-bearing agent bubble anchors the face top-left, inside the balloon,
    with the text indented to flow beside it; bubbles with no avatar (fallback:
    no face rendered anywhere for messages) keep the plain look exactly as
@@ -826,7 +857,7 @@ a.a-uri { color: var(--accent); }
 }
 .avatar-cell.none:hover { color: var(--text); }
 
-/* ---------- appearance popover (lane ⋯ → appearance) ---------- */
+/* ---------- appearance popover (switcher ⋯ → appearance) ---------- */
 #ap-popover {
   position: fixed; z-index: 70; display: flex; flex-direction: column; gap: 8px;
   background: var(--bg2); border: 1px solid var(--line2); border-radius: 10px; padding: 10px;
@@ -865,16 +896,13 @@ a.a-uri { color: var(--accent); }
   white-space: pre; overscroll-behavior: contain;
 }
 #pane-msg { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--dim); font-size: 13px; padding: 24px; text-align: center; }
-/* 👁 affordances: hover-revealed on the tile foot and the lieutenant chip */
+/* 👁 affordance: hover-revealed on the tile foot */
 .tile .t-peek { color: var(--faint); font-size: 12px; line-height: 1; padding: 0 2px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
 .tile:hover .t-peek { opacity: 1; }
 .tile .t-peek:hover { color: var(--accent); background: var(--accent-soft); }
-.lt-card .lt-peek { color: var(--faint); font-size: 12px; line-height: 1; padding: 0 3px; border-radius: 5px; opacity: 0; flex: none; transition: opacity .12s, color .12s; }
-.lt-card:hover .lt-peek { opacity: 1; }
-.lt-card .lt-peek:hover { color: var(--accent); background: var(--accent-soft); }
-@media (hover: none) { .tile .t-peek, .lt-card .lt-peek { opacity: .6; } } /* touch: always visible */
+@media (hover: none) { .tile .t-peek { opacity: .6; } } /* touch: always visible */
 
-/* context bar (lane chips + Working tiles): used ÷ window from agentStatus.
+/* context bar (chat header, switcher rows, Working tiles): used ÷ window from agentStatus.
    Green → yellow → red; red ≈ auto-compact territory (~80%). Rendered only
    when status data exists — graceful absence, like avatars. */
 .ctx-bar {

--- a/ui/index.html
+++ b/ui/index.html
@@ -77,9 +77,15 @@
   <section id="chat">
     <div id="chat-head">
       <button id="chat-back" hidden>←</button>
+      <!-- lieutenant switcher trigger: the current lieutenant's face + name +
+           model/context; tapping it opens the #lt-switcher dropdown below -->
+      <button id="chat-lt" type="button" hidden aria-haspopup="listbox" aria-expanded="false"></button>
       <div id="chat-title">💬 chat</div>
       <button id="chat-card-open" title="open card" hidden>open card</button>
     </div>
+    <!-- lieutenant switcher dropdown: one row per lieutenant (avatar, name,
+         model, context bar, unread/owed) + the ＋ lieutenant row -->
+    <div id="lt-switcher" role="listbox" hidden></div>
     <div id="chat-feed"></div>
     <div id="chat-send-err" hidden></div>
     <div id="chat-atts" hidden></div>
@@ -95,9 +101,8 @@
     <div class="pane-resize" id="chat-resize" title="drag to resize · double-click to reset"></div>
   </section>
 
-  <!-- board: right — lieutenant lane above the columns -->
+  <!-- board: right -->
   <section id="board-wrap">
-    <div id="lane"></div>
     <div id="board"><div class="empty">waiting for board…</div></div>
   </section>
 </main>
@@ -147,7 +152,7 @@
 <!-- owner menu (detail ✎ on the lieutenant chip — reassign the owning lieutenant) -->
 <div id="owner-menu" hidden></div>
 
-<!-- lieutenant appearance popover (lane ⋯ → appearance): avatar + color, edits commit on pick -->
+<!-- lieutenant appearance popover (switcher ⋯ → appearance): avatar + color, edits commit on pick -->
 <div id="ap-popover" hidden>
   <div class="ap-head">
     <span class="ap-title">appearance</span>

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -1,131 +1,20 @@
-// board: lieutenant lane above the columns, dense tiles, drag&drop, long-press
-// move menu, new-card / new-lieutenant modals.
-import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, lieutenantAvatar, lieutenantUnread, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, render, workerFor } from './state.js';
+// board: dense card tiles, drag&drop, long-press move menu, new-card /
+// new-lieutenant modals. (Lieutenant switching lives in the chat header —
+// ltswitcher.js — not on the board.)
+import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, workerFor } from './state.js';
 import { api } from './api.js';
-import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, setHtmlIfChanged, ctxBarHtml } from './util.js';
+import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, ctxBarHtml } from './util.js';
 import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
-import { openCardPane, openLieutenantPane } from './pane.js';
-import { avatarHtml, avatarGridHtml, wireAvatarGrid } from './avatars.js';
+import { openCardPane } from './pane.js';
+import { avatarGridHtml, wireAvatarGrid } from './avatars.js';
 
-const laneEl = document.getElementById('lane');
 const boardEl = document.getElementById('board');
 
 function byRecency(a, b) {
   return (new Date(cardRecency(b) || 0).getTime() || 0) - (new Date(cardRecency(a) || 0).getTime() || 0);
 }
-
-// ---------- lieutenant lane (above the columns) ----------
-// One card per lieutenant: color, name, charter tooltip, live counts, unread
-// badge for his main chat. Clicking it opens that lieutenant's chat — the
-// captain converses only with lieutenants.
-function ltCardHtml(l) {
-  const mine = cards().filter((c) => c.owner === l.id);
-  const working = mine.filter((c) => c.column === 'working').length;
-  const unread = lieutenantUnread(l);
-  const active = S.chatMode && S.chatMode.mode === 'lieutenant' && S.chatMode.id === l.id;
-  const owed = targetOwedState('lieutenant:' + l.id);
-  const staleW = owed && targetOwedStale('lieutenant:' + l.id);
-  const ind = staleW
-    ? '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>'
-    : owed === 'queued'
-    ? '<span class="t-typing queued" title="delivered — not picked up yet">⏳</span>'
-    : owed
-    ? '<span class="t-typing" title="owes you a reply"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>'
-    : '';
-  const av = lieutenantAvatar(l.id);
-  const face = av != null
-    ? '<span class="lt-face" style="border-color:' + esc(lieutenantColor(l.id)) + '">' + avatarHtml(av) + '</span>'
-    : '<span class="lt-dot" style="background:' + esc(lieutenantColor(l.id)) + '"></span>';
-  return '<div class="lt-card' + (active ? ' on' : '') + (filterSelected('owner', l.id) ? ' filtered' : '') + '" data-id="' + esc(l.id) + '"' +
-    ' style="border-left-color:' + esc(lieutenantColor(l.id)) + '"' +
-    (l.charter ? ' title="' + esc(l.charter.split('\n')[0].slice(0, 160)) + '"' : '') + '>' +
-    face +
-    '<span class="lt-name">' + esc(l.name || l.id) + '</span>' +
-    ind +
-    ctxBarHtml(l.agentStatus) +
-    '<span class="lt-counts">' + mine.length + (working ? ' · 🔨' + working : '') + '</span>' +
-    '<button class="lt-peek" title="watch this lieutenant\'s terminal live">👁</button>' +
-    '<button class="lt-menu" title="lieutenant actions">⋯</button>' +
-    (unread ? '<span class="badge-n">' + (unread > 99 ? '99+' : unread) + '</span>' : '') +
-    '</div>';
-}
-
-function renderLane() {
-  const html = lieutenants().map(ltCardHtml).join('') +
-    '<button class="lt-add" title="new lieutenant">＋ lieutenant</button>';
-  if (!setHtmlIfChanged(laneEl, html)) return; // unchanged — keep the DOM (and its handlers)
-  laneEl.querySelectorAll('.lt-card').forEach((el) => {
-    el.onclick = (e) => {
-      if (e.target.closest('.lt-menu')) { e.stopPropagation(); openLtMenu(el.dataset.id, e.clientX, e.clientY); return; }
-      if (e.target.closest('.lt-peek')) { e.stopPropagation(); openLieutenantPane(el.dataset.id); return; }
-      openLieutenantChat(el.dataset.id);
-    };
-    el.oncontextmenu = (e) => { e.preventDefault(); toggleFilter('owner', el.dataset.id); };
-  });
-  laneEl.querySelector('.lt-add').onclick = openNewLieutenant;
-}
-
-// lieutenant ⋯ menu — lieutenant.retire lives here (explicit only, per the DNA:
-// the server refuses while the lieutenant still owns non-archived cards).
-function openLtMenu(ltId, x, y) {
-  const l = lieutenant(ltId);
-  if (!l) return;
-  menuEl.textContent = '';
-  const head = document.createElement('div');
-  head.className = 'mm-head';
-  head.textContent = l.name || ltId;
-  menuEl.appendChild(head);
-  const appearance = document.createElement('button');
-  appearance.textContent = '🖼 appearance';
-  appearance.onclick = (e) => { e.stopPropagation(); closeMoveMenu(); openAppearancePopover(ltId, x, y); };
-  menuEl.appendChild(appearance);
-  const owned = cards().filter((c) => c.owner === ltId).length;
-  const retire = document.createElement('button');
-  retire.className = 'danger';
-  retire.textContent = '⚓ retire' + (owned ? ' (' + owned + ' card' + (owned > 1 ? 's' : '') + ' in the way)' : '');
-  retire.onclick = async () => {
-    closeMoveMenu();
-    if (!confirm('Retire ' + (l.name || ltId) + '? Its live session is killed and its queue removed.')) return;
-    try { await api.retireLieutenant(ltId); } catch (e) { alert(e.message); }
-  };
-  menuEl.appendChild(retire);
-  menuEl.hidden = false;
-  const r = menuEl.getBoundingClientRect();
-  menuEl.style.left = Math.max(8, Math.min(x, window.innerWidth - r.width - 8)) + 'px';
-  menuEl.style.top = Math.max(8, Math.min(y, window.innerHeight - r.height - 8)) + 'px';
-}
-
-// ---------- appearance popover (⋯ → appearance): avatar + color, each pick
-// PATCHes immediately (mirrors the label manager's recolor-on-change) ----------
-const apEl = document.getElementById('ap-popover');
-const apColor = document.getElementById('ap-color');
-const apGrid = document.getElementById('ap-grid');
-let apLtId = null;
-function openAppearancePopover(ltId, x, y) {
-  const l = lieutenant(ltId);
-  if (!l) return;
-  apLtId = ltId;
-  apColor.value = lieutenantColor(ltId);
-  apGrid.innerHTML = avatarGridHtml(lieutenantAvatar(ltId));
-  wireAvatarGrid(apGrid, async (idx) => {
-    try { await api.updateLieutenant(ltId, { avatar: idx }); } catch (e) { alert(e.message); }
-  });
-  apEl.hidden = false;
-  const r = apEl.getBoundingClientRect();
-  apEl.style.left = Math.max(8, Math.min(x, window.innerWidth - r.width - 8)) + 'px';
-  apEl.style.top = Math.max(8, Math.min(y, window.innerHeight - r.height - 8)) + 'px';
-}
-export function closeAppearancePopover() { apLtId = null; apEl.hidden = true; }
-export function appearancePopoverOpen() { return !apEl.hidden; }
-apColor.onchange = async () => {
-  if (!apLtId) return;
-  try { await api.updateLieutenant(apLtId, { color: apColor.value }); } catch (e) { alert(e.message); }
-};
-document.addEventListener('click', (e) => {
-  if (!apEl.hidden && !apEl.contains(e.target) && !e.target.closest('.lt-menu')) closeAppearancePopover();
-});
 
 // ---------- tiles ----------
 function tileHtml(c) {
@@ -197,7 +86,6 @@ function tileHtml(c) {
 }
 
 export function renderBoard() {
-  renderLane();
   const cols = columns();
   const html = !cols.length
     ? '<div class="empty">waiting for board…</div>'
@@ -402,7 +290,7 @@ document.getElementById('lt-modal').onsubmit = async (e) => {
   e.preventDefault();
   const name = document.getElementById('lt-name').value.trim();
   if (!name) return;
-  // The lane button births a REAL lieutenant: the server spawns its agent
+  // This modal births a REAL lieutenant: the server spawns its agent
   // session (doctrine + charter as launch prompt) and persists the ref. Slow
   // (up to a minute) — keep the modal up, button disabled, until it lands.
   const btn = document.getElementById('lt-create');

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -2,9 +2,9 @@
 // the lieutenant's main chat or one of its card threads (a card thread's
 // interlocutor is always the owning lieutenant). Whole-window mode switch,
 // premium composer.
-import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
+import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, lieutenantUnread, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
-import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime, statusBlockHtml } from './util.js';
+import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime, statusBlockHtml, ctxBarHtml, owedIndHtml } from './util.js';
 import { md, mdEnhance } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
 import { openAttachment } from './detail.js';
@@ -12,6 +12,7 @@ import { avatarHtml } from './avatars.js';
 
 const feedEl = document.getElementById('chat-feed');
 const titleEl = document.getElementById('chat-title');
+const ltBtn = document.getElementById('chat-lt'); // switcher trigger (ltswitcher.js owns its click)
 const backBtn = document.getElementById('chat-back');
 const openBtn = document.getElementById('chat-card-open');
 const inputEl = document.getElementById('chat-input');
@@ -43,7 +44,7 @@ function currentLieutenant() {
   return c ? lieutenant(c.owner) : null;
 }
 
-// Open a lieutenant's main chat (lane card click, new-lieutenant create).
+// Open a lieutenant's main chat (switcher row tap, new-lieutenant create).
 export function openLieutenantChat(id) {
   S.chatMode = { mode: 'lieutenant', id };
   S.view = 'chat'; // on mobile, switch to the chat tab
@@ -226,16 +227,44 @@ function wireSpeak(blocks, target) {
   });
 }
 
+// The switcher trigger: the current lieutenant's face + name (the lane chip's
+// content, relocated) plus model (+effort), context bar and owed state. A
+// badge with the OTHER lieutenants' unread total keeps their activity visible
+// now that the chips are gone.
+function ltTriggerHtml(lt) {
+  const av = lieutenantAvatar(lt.id);
+  const face = av != null
+    ? '<span class="lt-face" style="border-color:' + esc(lieutenantColor(lt.id)) + '">' + avatarHtml(av) + '</span>'
+    : '<span class="lt-dot" style="background:' + esc(lieutenantColor(lt.id)) + '"></span>';
+  const owed = targetOwedState('lieutenant:' + lt.id);
+  const ind = owedIndHtml(owed, owed && targetOwedStale('lieutenant:' + lt.id));
+  const st = lt.agentStatus || {};
+  const model = st.model
+    ? '<span class="clt-model">' + esc(st.model) + (st.effort ? ' <span class="clt-effort">(' + esc(st.effort) + ')</span>' : '') + '</span>'
+    : '';
+  const meta = model || ctxBarHtml(st) ? '<span class="clt-meta">' + model + ctxBarHtml(st) + '</span>' : '';
+  const others = lieutenants().reduce((n, l) => n + (l.id === lt.id ? 0 : lieutenantUnread(l)), 0);
+  return face +
+    '<span class="clt-main">' +
+    '<span class="clt-name">' + esc(lt.name || lt.id) + ind + '</span>' + meta +
+    '</span>' +
+    '<span class="clt-caret">▾</span>' +
+    (others ? '<span class="badge-n" title="unread in other lieutenants\' chats">' + (others > 99 ? '99+' : others) + '</span>' : '');
+}
+
 export function renderChat() {
   const target = currentTarget();
   if (!target) {
     backBtn.hidden = true;
     openBtn.hidden = true;
-    setHtmlIfChanged(titleEl, '💬 chat');
+    titleEl.hidden = true;
+    // no lieutenants yet: the trigger doubles as the create button
+    ltBtn.hidden = false;
+    setHtmlIfChanged(ltBtn, '<span class="clt-main"><span class="clt-name">＋ lieutenant</span></span>');
     inputEl.placeholder = 'create a lieutenant to start…';
     inputEl.disabled = true;
     attachBtn.disabled = true;
-    if (feed.key !== '') feedEl.innerHTML = '<div class="empty">no lieutenants yet — add one above the board to start commanding</div>';
+    if (feed.key !== '') feedEl.innerHTML = '<div class="empty">no lieutenants yet — tap ＋ lieutenant above to start commanding</div>';
     feed = { key: '', blocks: [], tail: '' };
     return;
   }
@@ -248,13 +277,12 @@ export function renderChat() {
 
   backBtn.hidden = !isCard;
   openBtn.hidden = !isCard;
-  const titleAv = lt ? lieutenantAvatar(lt.id) : null;
-  const titleFace = titleAv != null
-    ? '<span class="lt-face" style="border-color:' + esc(lieutenantColor(lt.id)) + '">' + avatarHtml(titleAv) + '</span>'
-    : '<span class="lt-dot" style="background:' + esc(lieutenantColor((lt || {}).id)) + '"></span>';
-  setHtmlIfChanged(titleEl, isCard
-    ? esc(cardEmoji(c) + ' ' + (c.title || c.id))
-    : titleFace + ' ' + esc(ltName));
+  // card thread: plain card title (back returns to the lieutenant, where the
+  // switcher lives); lieutenant chat: the switcher trigger IS the header
+  ltBtn.hidden = isCard || !lt;
+  titleEl.hidden = !ltBtn.hidden;
+  if (isCard || !lt) setHtmlIfChanged(titleEl, esc(cardEmoji(c) + ' ' + (c.title || c.id)));
+  else setHtmlIfChanged(ltBtn, ltTriggerHtml(lt));
   inputEl.placeholder = isCard ? 'message ' + ltName + ' about this card…' : 'message ' + ltName + '…';
 
   // Land at the newest message when the visible conversation changes (first

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -47,8 +47,8 @@ document.getElementById('dt-close').onclick = closeDetail;
 // the one closeDetail path (which also returns the left chat to the lieutenant on
 // desktop). Excluded from "outside": the left chat pane (#chat — on desktop it
 // shows the selected card's own thread, so it's part of the card context, not
-// outside), a .tile (its own handler switches to that card's detail — a switch,
-// not a close), a .lt-card (switches the chat to that lieutenant), the transient
+// outside — and the lieutenant switcher dropdown lives inside it), a .tile (its
+// own handler switches to that card's detail — a switch, not a close), the transient
 // popovers (move menu, label picker, notif/settings panels) so dismissing one of
 // those never also closes the detail, and the floating stop-speaking bubble
 // (stopping TTS is not a navigation intent). Net effect: only a click on the
@@ -64,7 +64,6 @@ document.addEventListener('click', (e) => {
   if (t.closest && (
     t.closest('#chat') ||                     // left chat = the selected card's thread; part of its context
     t.closest('.tile') ||                     // another card — switch, handled by its onclick
-    t.closest('.lt-card') ||                  // a lane card — switches the chat, not a close
     t.closest('#lt-overlay') ||               // new-lieutenant modal
     t.closest('#move-menu') ||                // transient popovers dismiss on their own
     t.closest('#owner-menu') ||

--- a/ui/js/ltswitcher.js
+++ b/ui/js/ltswitcher.js
@@ -1,0 +1,156 @@
+// ltswitcher.js — the chat header's lieutenant dropdown. The header trigger
+// (#chat-lt, rendered by chat.js) opens a panel with one row per lieutenant —
+// avatar, name, model, context bar, unread/owed — so the captain switches
+// conversations in place, without leaving the chat. The rows also carry the
+// per-lieutenant controls that used to live on the lane chips: 👁 watch
+// terminal, ⋯ actions (appearance / retire), and the ＋ lieutenant row.
+import { S, cards, lieutenants, lieutenant, lieutenantColor, lieutenantAvatar, lieutenantUnread, targetOwedState, targetOwedStale } from './state.js';
+import { api } from './api.js';
+import { esc, setHtmlIfChanged, ctxBarHtml, owedIndHtml } from './util.js';
+import { avatarHtml, avatarGridHtml, wireAvatarGrid } from './avatars.js';
+import { openLieutenantChat } from './chat.js';
+import { openLieutenantPane } from './pane.js';
+import { openNewLieutenant, closeMoveMenu } from './board.js';
+
+const trigEl = document.getElementById('chat-lt');
+const panelEl = document.getElementById('lt-switcher');
+const menuEl = document.getElementById('move-menu'); // shared with the board's move menu
+
+let open = false;
+export function ltSwitcherOpen() { return open; }
+export function closeLtSwitcher() { if (open) { open = false; renderLtSwitcher(); } }
+
+// The trigger toggles the panel; with no lieutenants yet it IS the create
+// affordance (chat.js renders it as "＋ lieutenant"), so it opens the modal.
+trigEl.onclick = () => {
+  if (!lieutenants().length) { openNewLieutenant(); return; }
+  open = !open;
+  renderLtSwitcher();
+};
+// tap-out closes (the trigger's own click toggled already — exclude it)
+document.addEventListener('click', (e) => {
+  if (open && !panelEl.contains(e.target) && !trigEl.contains(e.target)) closeLtSwitcher();
+});
+
+// One row per lieutenant: everything its lane chip used to carry.
+function rowHtml(l) {
+  const mine = cards().filter((c) => c.owner === l.id);
+  const working = mine.filter((c) => c.column === 'working').length;
+  const unread = lieutenantUnread(l);
+  const cur = S.chatMode && S.chatMode.mode === 'lieutenant' && S.chatMode.id === l.id;
+  const owed = targetOwedState('lieutenant:' + l.id);
+  const ind = owedIndHtml(owed, owed && targetOwedStale('lieutenant:' + l.id));
+  const st = l.agentStatus || {};
+  const model = st.model
+    ? '<span class="lts-model">' + esc(st.model) + (st.effort ? ' (' + esc(st.effort) + ')' : '') + '</span>'
+    : '';
+  const av = lieutenantAvatar(l.id);
+  const face = av != null
+    ? '<span class="lt-face" style="border-color:' + esc(lieutenantColor(l.id)) + '">' + avatarHtml(av) + '</span>'
+    : '<span class="lt-dot" style="background:' + esc(lieutenantColor(l.id)) + '"></span>';
+  return '<div class="lts-row' + (cur ? ' on' : '') + '" data-id="' + esc(l.id) + '" role="option"' +
+    (cur ? ' aria-selected="true"' : '') +
+    (l.charter ? ' title="' + esc(l.charter.split('\n')[0].slice(0, 160)) + '"' : '') + '>' +
+    face +
+    '<span class="lts-main">' +
+    '<span class="lts-name">' + esc(l.name || l.id) + ind +
+    (unread ? '<span class="badge-n">' + (unread > 99 ? '99+' : unread) + '</span>' : '') + '</span>' +
+    '<span class="lts-meta">' + model +
+    '<span class="lts-counts">' + mine.length + (working ? ' · 🔨' + working : '') + '</span>' +
+    ctxBarHtml(st) + '</span>' +
+    '</span>' +
+    (cur ? '<span class="lts-cur" title="current conversation">✓</span>' : '') +
+    '<button class="lts-peek" type="button" title="watch this lieutenant\'s terminal live">👁</button>' +
+    '<button class="lts-menu" type="button" title="lieutenant actions">⋯</button>' +
+    '</div>';
+}
+
+// Rendered on every board push while open, so unread/owed/context stay live.
+export function renderLtSwitcher() {
+  trigEl.setAttribute('aria-expanded', open ? 'true' : 'false');
+  panelEl.hidden = !open;
+  if (!open) return;
+  setHtmlIfChanged(panelEl, lieutenants().map(rowHtml).join('') +
+    '<button class="lts-add" type="button">＋ lieutenant</button>');
+}
+
+// Delegated clicks survive the setHtmlIfChanged rebuilds. Every action closes
+// the panel — the switch, the peek overlay, the ⋯ menu, and the modal all take
+// the stage themselves.
+panelEl.addEventListener('click', (e) => {
+  if (e.target.closest('.lts-add')) { closeLtSwitcher(); openNewLieutenant(); return; }
+  const row = e.target.closest('.lts-row');
+  if (!row) return;
+  const id = row.dataset.id;
+  if (e.target.closest('.lts-menu')) {
+    // stop before board.js's document closer would dismiss the menu we just opened
+    e.stopPropagation();
+    closeLtSwitcher();
+    openLtMenu(id, e.clientX, e.clientY);
+    return;
+  }
+  if (e.target.closest('.lts-peek')) { closeLtSwitcher(); openLieutenantPane(id); return; }
+  closeLtSwitcher();
+  openLieutenantChat(id);
+});
+
+// lieutenant ⋯ menu — lieutenant.retire lives here (explicit only, per the DNA:
+// the server refuses while the lieutenant still owns non-archived cards).
+// Shares the #move-menu element, so the board's outside-click closer covers it.
+function openLtMenu(ltId, x, y) {
+  const l = lieutenant(ltId);
+  if (!l) return;
+  menuEl.textContent = '';
+  const head = document.createElement('div');
+  head.className = 'mm-head';
+  head.textContent = l.name || ltId;
+  menuEl.appendChild(head);
+  const appearance = document.createElement('button');
+  appearance.textContent = '🖼 appearance';
+  appearance.onclick = (e) => { e.stopPropagation(); closeMoveMenu(); openAppearancePopover(ltId, x, y); };
+  menuEl.appendChild(appearance);
+  const owned = cards().filter((c) => c.owner === ltId).length;
+  const retire = document.createElement('button');
+  retire.className = 'danger';
+  retire.textContent = '⚓ retire' + (owned ? ' (' + owned + ' card' + (owned > 1 ? 's' : '') + ' in the way)' : '');
+  retire.onclick = async () => {
+    closeMoveMenu();
+    if (!confirm('Retire ' + (l.name || ltId) + '? Its live session is killed and its queue removed.')) return;
+    try { await api.retireLieutenant(ltId); } catch (e) { alert(e.message); }
+  };
+  menuEl.appendChild(retire);
+  menuEl.hidden = false;
+  const r = menuEl.getBoundingClientRect();
+  menuEl.style.left = Math.max(8, Math.min(x, window.innerWidth - r.width - 8)) + 'px';
+  menuEl.style.top = Math.max(8, Math.min(y, window.innerHeight - r.height - 8)) + 'px';
+}
+
+// ---------- appearance popover (⋯ → appearance): avatar + color, each pick
+// PATCHes immediately (mirrors the label manager's recolor-on-change) ----------
+const apEl = document.getElementById('ap-popover');
+const apColor = document.getElementById('ap-color');
+const apGrid = document.getElementById('ap-grid');
+let apLtId = null;
+function openAppearancePopover(ltId, x, y) {
+  const l = lieutenant(ltId);
+  if (!l) return;
+  apLtId = ltId;
+  apColor.value = lieutenantColor(ltId);
+  apGrid.innerHTML = avatarGridHtml(lieutenantAvatar(ltId));
+  wireAvatarGrid(apGrid, async (idx) => {
+    try { await api.updateLieutenant(ltId, { avatar: idx }); } catch (e) { alert(e.message); }
+  });
+  apEl.hidden = false;
+  const r = apEl.getBoundingClientRect();
+  apEl.style.left = Math.max(8, Math.min(x, window.innerWidth - r.width - 8)) + 'px';
+  apEl.style.top = Math.max(8, Math.min(y, window.innerHeight - r.height - 8)) + 'px';
+}
+export function closeAppearancePopover() { apLtId = null; apEl.hidden = true; }
+export function appearancePopoverOpen() { return !apEl.hidden; }
+apColor.onchange = async () => {
+  if (!apLtId) return;
+  try { await api.updateLieutenant(apLtId, { color: apColor.value }); } catch (e) { alert(e.message); }
+};
+document.addEventListener('click', (e) => {
+  if (!apEl.hidden && !apEl.contains(e.target) && !e.target.closest('.lts-menu')) closeAppearancePopover();
+});

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -5,8 +5,9 @@ import { refreshAgoLabels } from './util.js';
 import { trackMessages } from './voice.js';
 import { trackEvents, renderNotifSettings } from './notifysettings.js';
 import { onOpenCard as toastOnOpenCard } from './toast.js';
-import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu, appearancePopoverOpen, closeAppearancePopover } from './board.js';
+import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
+import { renderLtSwitcher, ltSwitcherOpen, closeLtSwitcher, appearancePopoverOpen, closeAppearancePopover } from './ltswitcher.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
@@ -112,6 +113,7 @@ document.addEventListener('keydown', (e) => {
     else if (newLieutenantOpen()) closeNewLieutenant();
     else if (pickerIsOpen()) closeLabelPicker();
     else if (appearancePopoverOpen()) closeAppearancePopover();
+    else if (ltSwitcherOpen()) closeLtSwitcher();
     else if (ownerMenuOpen()) closeOwnerMenu(); // just the menu — keep the detail open
     else if (S.notifOpen) { S.notifOpen = false; render(); }
     else if (!spEl.hidden) { spEl.hidden = true; gearBtn.classList.remove('on'); }
@@ -137,6 +139,7 @@ onRender(() => {
   renderStatusDot();
   renderBoard();
   renderChat();
+  renderLtSwitcher();
   renderDetail();
   renderNotifications();
   renderTabs();

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -115,6 +115,16 @@ export function ctxBarHtml(st) {
     + '<span class="ctx-fill' + cls + '" style="width:' + pct + '%"></span></span>';
 }
 
+// owed-reply indicator (chat header trigger + switcher rows): same tri-state
+// visual language as the tile corner and the chat typing bubble — animated dots
+// (owed, seen), static ⏳ (queued, not picked up), static amber ⚠ (stale).
+export function owedIndHtml(state, stale) {
+  if (!state) return '';
+  if (stale) return '<span class="t-typing stale" title="no response yet — the lieutenant may be stuck">⚠</span>';
+  if (state === 'queued') return '<span class="t-typing queued" title="delivered — not picked up yet">⏳</span>';
+  return '<span class="t-typing" title="owes you a reply"><span class="tdot"></span><span class="tdot"></span><span class="tdot"></span></span>';
+}
+
 // green → yellow (≥60%) → red (≥80%) — the shared context-bar thresholds
 function ctxFillCls(pct) { return pct >= 80 ? ' red' : pct >= 60 ? ' yellow' : ''; }
 function barRowHtml(label, pct, val) {
@@ -133,7 +143,7 @@ function windowLabel(minutes) {
   return minutes + 'min';
 }
 // /status rich reply: model name, context usage as a real progress bar (reusing
-// the lane-chip context-bar visual language), plus rate-limit rows when present
+// the chat-header context-bar visual language), plus rate-limit rows when present
 // (codex). Fed the structured `status` payload the server attaches to the reply.
 export function statusBlockHtml(st) {
   if (!st || typeof st !== 'object') return '';


### PR DESCRIPTION
Removes the lieutenant chip lane above the board and moves lieutenant switching into the chat header, where it works on a phone.

**What**
- `#lane` and all `.lt-card` markup/CSS deleted (not hidden).
- The chat header (lieutenant mode) is now a dropdown trigger carrying the current lieutenant: avatar, name, model (+effort), context bar, owed indicator, and a badge with the *other* lieutenants' unread total.
- The dropdown (`ui/js/ltswitcher.js`, new) lists every lieutenant — avatar, name, model, context bar, card counts, unread/owed — and switches the open chat in place. Current lieutenant marked (✓ + accent). Closes on select, tap-out and Esc.
- Chip controls relocated per row: 👁 watch terminal, ⋯ actions (appearance/retire, moved from board.js verbatim); ＋ lieutenant is the last row. With zero lieutenants the trigger itself becomes the ＋ lieutenant button.
- Card threads keep their plain header (back returns to the lieutenant, where the switcher lives); talk buttons / notification taps unchanged, and notification suppression still keys off `S.chatMode`.

**Why**: switching conversations required leaving the chat for the board lane — painful on mobile, where this UI actually gets used.

Full suite green (299). No console errors. The app is dark-only (fixed palette), so no light-mode variant to check.

| desktop | dropdown | switched | mobile | mobile open | board (no lane) |
|---|---|---|---|---|---|
| ![d](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/desktop-closed.png) | ![o](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/desktop-open.png) | ![s](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/desktop-switched.png) | ![m](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/mobile-closed.png) | ![mo](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/mobile-open.png) | ![mb](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-lieutenant-switcher/shots/mobile-board.png) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
