### PR TITLE
Card-lifecycle hooks: deterministic per-workspace scripts on lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Env knobs (set on the server process):
 | `BC_GH_CMD` | `gh` | gh binary used by the PR watch |
 | `BC_TURNEND_URL` | — | default callback URL baked into installed turn-end hooks |
 | `BC_SEND_RETRIES` / `BC_SEND_SLEEP_MS` | `3` / `400` | verified-submit tuning for `harness.send` |
+| `BC_HOOK_TIMEOUT_MS` | `120000` | per-script timeout for workspace lifecycle hooks |
+
+### Lifecycle hooks
+
+The workspace can react to card/worker lifecycle events with its own scripts: every
+executable file in `.bridge-commander/hooks/<event>/` runs on that event (alphabetical,
+sequential, cwd = workspace root) with context in env — `BC_EVENT`, `BC_CARD`, `BC_REPO`,
+`BC_WORKTREE`, `BC_BRANCH`. Events: `worker-done`, `worker-died`, `card-archived` (fires
+before the worktree is released). Hooks are fire-and-forget — a failure or timeout never
+blocks the lifecycle; results land on the card timeline (`hook-ran` / `hook-failed`).
+Typical use: tearing down infrastructure a worker left running (dev containers, compose
+stacks) when its card finishes.
 
 ### Network exposure
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -183,6 +183,23 @@ session status):
 | worker session dies without `done` | `worker-died` QueueItem to the owner + level-2 event; card stays Working, flagged |
 | lieutenant session dies | server auto-respawn (resume when possible; else relaunch with charter + owned cards + pending queue as the prompt), level-1 event, drain nudge; 3 failed attempts → level-1 needs-captain |
 | level-1 event / owed reply | captain's bell: unseen = level-1 events ∪ unseen lieutenant thread replies, per user, cleared by reading — bridge semantics |
+| `worker.done` · worker death · card archived | lifecycle hooks: the workspace's own executable scripts in `.bridge-commander/hooks/<event>/` run (see below) |
+
+### Lifecycle hooks
+
+The workspace owns deterministic teardown: every executable file in
+`.bridge-commander/hooks/<event>/` runs on that lifecycle event — alphabetical, sequential,
+cwd = workspace root, context via env (`BC_EVENT`, `BC_CARD`, `BC_REPO`, `BC_WORKTREE`,
+`BC_BRANCH`; empty when N/A). Events v1: `worker-done`, `worker-died`, `card-archived`.
+Missing dir = no-op; non-executables are skipped.
+
+Hooks are fire-and-forget — they never block or fail the lifecycle outcome they observe
+(per-hook timeout ~120s, `BC_HOOK_TIMEOUT_MS` overrides, then kill; output captured and
+capped). The ONE ordering guarantee: `card-archived` hooks finish (or time out) BEFORE the
+worktree release, so a hook can still reach paths inside `$BC_WORKTREE`. Each run lands on
+the timeline: `hook-ran` level 2 per success, `hook-failed` level 1 (the captain's bell) with
+filename + exit detail + trimmed output; an archived card's events land on the board stream
+with a card reference, and failures also queue to the owner.
 
 ## Memory
 

--- a/server/hooks.js
+++ b/server/hooks.js
@@ -1,0 +1,137 @@
+'use strict';
+// hooks — deterministic per-workspace lifecycle hook scripts. Node built-ins only.
+//
+// The workspace owns its hooks: every EXECUTABLE file in
+// <workspace>/.bridge-commander/hooks/<event>/ runs on that lifecycle event,
+// alphabetical order, sequentially, cwd = the workspace root. A missing dir or
+// an empty one is a no-op; a non-executable file is skipped silently. Scripts
+// carry their own shebang — they are spawned directly, not through a shell.
+//
+// Fire-and-forget semantics live at the CALL SITE (server.js fireHooks): a
+// hook never blocks or fails the lifecycle outcome it observes. This module's
+// only job is to run the scripts and report what happened — it never throws
+// for a hook's sake (a broken interpreter, a non-zero exit, a timeout are all
+// RESULTS, not errors).
+//
+// Context reaches the script via env (empty string when not applicable):
+//   BC_EVENT     the event name (worker-done | worker-died | card-archived)
+//   BC_CARD      card id
+//   BC_REPO      project repo path (the registered clone)
+//   BC_WORKTREE  absolute worker worktree path
+//   BC_BRANCH    worker branch
+//
+// Per-hook timeout (default ~120s) then SIGKILL; stdout+stderr are captured
+// together, capped at a few KB.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { spawn } = require('node:child_process');
+
+const HOOKS_DIRNAME = 'hooks'; // under <workspace>/.bridge-commander/
+const DEFAULT_TIMEOUT_MS = 120000;
+const OUTPUT_CAP = 4096; // combined stdout+stderr bytes kept per hook
+
+// Executable regular files in the event's hook dir, alphabetical. Anything
+// else (subdirs, non-executables, unreadables) is skipped silently.
+function listHooks(workspace, event) {
+  const dir = path.join(workspace, '.bridge-commander', HOOKS_DIRNAME, event);
+  let names;
+  try { names = fs.readdirSync(dir); } catch (e) { return []; }
+  const out = [];
+  for (const name of names.sort()) {
+    const file = path.join(dir, name);
+    try {
+      if (!fs.statSync(file).isFile()) continue;
+      fs.accessSync(file, fs.constants.X_OK);
+    } catch (e) { continue; }
+    out.push(file);
+  }
+  return out;
+}
+
+// Run one hook script -> result (never rejects).
+//   { hook, ok, code, signal, timedOut, error?, output, truncated }
+// ok ⇔ exited 0 within the timeout. A spawn/interpreter failure ('error'
+// event: broken shebang, EACCES...) is ok:false with `error` set.
+function runOne(file, env, cwd, timeoutMs) {
+  return new Promise((resolve) => {
+    const hook = path.basename(file);
+    let output = '';
+    let truncated = false;
+    let timedOut = false;
+    let settled = false;
+    const done = (res) => { if (!settled) { settled = true; resolve(res); } };
+    let child;
+    try {
+      // detached: the hook gets its own process group, so the timeout kill
+      // reaches the whole tree (a shebang shell's children inherit the stdio
+      // pipes — killing only the direct child would leave them running AND
+      // holding our pipes open).
+      child = spawn(file, [], { cwd, env, stdio: ['ignore', 'pipe', 'pipe'], detached: true });
+    } catch (e) {
+      return done({ hook, ok: false, code: null, signal: null, timedOut: false,
+        error: String((e && e.message) || e), output: '', truncated: false });
+    }
+    const collect = (chunk) => {
+      if (output.length >= OUTPUT_CAP) { truncated = true; return; }
+      output += chunk.toString('utf8');
+      if (output.length > OUTPUT_CAP) { output = output.slice(0, OUTPUT_CAP); truncated = true; }
+    };
+    child.stdout.on('data', collect);
+    child.stderr.on('data', collect);
+    const killTree = () => {
+      try { process.kill(-child.pid, 'SIGKILL'); } // the whole group
+      catch (e) { try { child.kill('SIGKILL'); } catch (e2) {} }
+    };
+    const timer = setTimeout(() => { timedOut = true; killTree(); }, timeoutMs);
+    let graceTimer = null;
+    const finish = (code, signal) => {
+      clearTimeout(timer);
+      clearTimeout(graceTimer);
+      done({ hook, ok: code === 0 && !timedOut, code, signal, timedOut,
+        output: output.trim(), truncated });
+    };
+    child.on('error', (e) => {
+      clearTimeout(timer);
+      clearTimeout(graceTimer);
+      done({ hook, ok: false, code: null, signal: null, timedOut,
+        error: String((e && e.message) || e), output: output.trim(), truncated });
+    });
+    // 'close' (exit + stdio drained) is the normal end. But a process the hook
+    // leaked can inherit our pipes and hold 'close' hostage long after the hook
+    // itself exited — so 'exit' arms a short grace, after which the streams are
+    // destroyed and the result reported with whatever output arrived.
+    child.on('exit', (code, signal) => {
+      graceTimer = setTimeout(() => {
+        try { child.stdout.destroy(); child.stderr.destroy(); } catch (e) {}
+        finish(code, signal);
+      }, 2000);
+    });
+    child.on('close', finish);
+  });
+}
+
+// runHooks(event, ctx, opts?) -> Promise<results[]> — run every hook for the
+// event, sequentially in alphabetical order. ctx = { workspace, card, repo,
+// worktree, branch } (all but workspace optional — empty string when N/A).
+// opts.timeoutMs overrides the per-hook timeout (tests). Never rejects for a
+// hook's outcome; only a truly broken call (no workspace) throws.
+async function runHooks(event, ctx, opts) {
+  const workspace = ctx && ctx.workspace;
+  if (!workspace) throw new Error('runHooks: ctx.workspace required');
+  const timeoutMs = (opts && opts.timeoutMs > 0) ? opts.timeoutMs : DEFAULT_TIMEOUT_MS;
+  const env = Object.assign({}, process.env, {
+    BC_EVENT: String(event || ''),
+    BC_CARD: String((ctx && ctx.card) || ''),
+    BC_REPO: String((ctx && ctx.repo) || ''),
+    BC_WORKTREE: String((ctx && ctx.worktree) || ''),
+    BC_BRANCH: String((ctx && ctx.branch) || ''),
+  });
+  const results = [];
+  for (const file of listHooks(workspace, event)) {
+    results.push(await runOne(file, env, workspace, timeoutMs));
+  }
+  return results;
+}
+
+module.exports = { runHooks, listHooks, DEFAULT_TIMEOUT_MS };

--- a/server/server.js
+++ b/server/server.js
@@ -56,6 +56,7 @@ const crypto = require('crypto');
 // drags in no tmux/claude machinery until a ref is actually dispatched.
 const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '..', 'harness', 'port.js'));
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
+const { runHooks } = require(path.join(__dirname, 'hooks.js'));
 const { workerBrief, PROJECT_MODES } = require(path.join(__dirname, 'brief.js'));
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
@@ -294,6 +295,8 @@ const BUILTIN_KINDS = {
   signal: { emoji: '📡', level: 2 },
   'worker-done': { emoji: '✅', level: 2 },
   'worker-died': { emoji: '💀', level: 2 },
+  'hook-ran': { emoji: '🪝', level: 2 },
+  'hook-failed': { emoji: '🧨', level: 1 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
   'worker-stalled': { emoji: '🐢', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },
@@ -1426,6 +1429,69 @@ function ownerSession(card) {
 function workerName(ref) { return ref.window ? ref.session + ':' + ref.window : ref.session; }
 function findWorker(cardId) { return board.workers.find((w) => w.card === cardId); }
 
+// ---------- lifecycle hooks (workspace-owned scripts; server/hooks.js) ----------
+// Events v1: worker-done, worker-died, card-archived. Fire-and-forget — a hook
+// never blocks or fails the lifecycle outcome it observes. The ONE ordering
+// guarantee: card-archived hooks are AWAITED before the worktree release (the
+// PR-watch path), so a hook can still reach paths inside $BC_WORKTREE.
+const HOOK_TIMEOUT_MS = parseInt(process.env.BC_HOOK_TIMEOUT_MS, 10) > 0
+  ? parseInt(process.env.BC_HOOK_TIMEOUT_MS, 10) : 0; // 0 = the module default (~120s)
+
+// Hook env context: prefer the live worker record, fall back to the card's
+// own attributes (the worker registry entry may already be gone on archive).
+function hookContext(card, w) {
+  const attrs = (card && card.attributes) || {};
+  const project = findProject(String((w && w.project) || attrs.repo || ''));
+  return {
+    workspace: WORKSPACE,
+    card: card.id,
+    repo: project ? project.path : '',
+    worktree: (w && w.worktree && w.worktree.path) || String(attrs.worktree || ''),
+    branch: (w && w.branch) || String(attrs.branch || ''),
+  };
+}
+
+// fireHooks(event, card, w, opts) — run the workspace's hooks for a lifecycle
+// event and land each result as a timeline event: hook-ran (level 2, routine)
+// per success, hook-failed (level 1 — the captain's bell) per failure, text =
+// filename + exit detail + trimmed output. Failures also queuePush to the
+// owner. Never throws (so every call site can stay fire-and-forget); the
+// returned promise resolves after the events landed, which is what lets the
+// card-archived call site await it BEFORE releasing the worktree.
+//
+// An ARCHIVED card can't take timeline events — it left the board and its
+// archive.jsonl snapshot is already frozen — so when the card is gone (or the
+// call site knows it is leaving: opts.boardLevel) the events land on the
+// board-level stream with a card reference instead of being dropped.
+async function fireHooks(event, card, w, opts) {
+  try {
+    const results = await runHooks(event, hookContext(card, w),
+      HOOK_TIMEOUT_MS ? { timeoutMs: HOOK_TIMEOUT_MS } : undefined);
+    if (!results.length) return;
+    const live = (opts && opts.boardLevel) ? null : findCard(card.id);
+    for (const r of results) {
+      const detail = r.timedOut ? 'timed out'
+        : r.error ? String(r.error)
+        : 'exit ' + r.code;
+      const text = event + ' hook ' + r.hook + (r.ok ? ' ok' : ' FAILED') + ' (' + detail + ')'
+        + (r.output ? ': ' + r.output : '');
+      const ev = mkEvent({ text, actor: 'server' }, { kind: r.ok ? 'hook-ran' : 'hook-failed' });
+      if (live) {
+        live.events.push(ev);
+        live.updated = now();
+      } else {
+        ev.card = card.id;
+        ev.cardTitle = card.title;
+        board.events.push(ev);
+      }
+      if (!r.ok) queuePush(card.owner, { kind: 'hook-failed', card: card.id, text: text.slice(0, 2000) });
+    }
+    saveBoard(); broadcast();
+  } catch (e) {
+    console.error(now() + ' ' + event + ' hooks for ' + card.id + ' failed: ' + String((e && e.message) || e));
+  }
+}
+
 // The system move into Working — card.start is the ONE way in (invariant:
 // Working ⇔ live worker). Clears any pendingOrder (a start-order just executed).
 function enterWorking(card, text) {
@@ -1904,6 +1970,7 @@ async function superviseTick() {
           kind: 'worker-died', card: card.id,
           text: 'worker session ' + workerName(w.ref) + ' died without reporting done',
         });
+        fireHooks('worker-died', card, w); // fire-and-forget
       }
     }
     if (changed) { saveBoard(); broadcast(); }
@@ -1959,6 +2026,9 @@ async function prWatchTick() {
         const wtRec = w ? w.worktree
           : (card.attributes && card.attributes.worktree ? { path: card.attributes.worktree, tool: 'git' } : null);
         let note = merged.url;
+        // card-archived hooks run — and finish or time out — BEFORE the
+        // worktree release: a hook may need paths inside $BC_WORKTREE.
+        await fireHooks('card-archived', card, w, { boardLevel: true });
         if (wtRec && project) {
           const rel = await releaseWorktree(wtRec, project.path);
           if (!rel.released) {
@@ -2325,6 +2395,7 @@ const server = http.createServer(async (req, res) => {
         const r = workerDone(card, JSON.parse(await readBody(req) || '{}'));
         if (r.error) return sendJson(res, 400, { error: r.error });
         saveBoard(); broadcast();
+        fireHooks('worker-done', card, findWorker(card.id)); // fire-and-forget
         return sendJson(res, 200, { ok: true, event: r.event, card: publicCard(card, 'user') });
       }
       if (!sub && req.method === 'GET') return sendJson(res, 200, publicCard(card, url.searchParams.get('user') || 'user'));
@@ -2356,9 +2427,13 @@ const server = http.createServer(async (req, res) => {
         return sendJson(res, 200, { ok: true, event: ev });
       }
       if (sub === 'archive' && req.method === 'POST') {
+        const w = findWorker(card.id); // captured BEFORE archiveCard drops the registry entry
         const r = archiveCard(card, JSON.parse(await readBody(req) || '{}'));
         if (r.error) return sendJson(res, 400, { error: r.error });
         saveBoard(); broadcast();
+        // Fire-and-forget is safe here: this path never releases the worktree,
+        // so the hooks-before-release ordering holds trivially.
+        fireHooks('card-archived', card, w, { boardLevel: true });
         return sendJson(res, 200, r);
       }
       // promote-to-artifact — the deliberate tool. POST adds, DELETE removes an

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -1,0 +1,338 @@
+'use strict';
+// Card-lifecycle hooks — the workspace's own executable scripts in
+// .bridge-commander/hooks/<event>/ run on worker-done / worker-died /
+// card-archived, alphabetical, sequential, context via BC_* env, fire-and-
+// forget (per-hook timeout then kill). Results land as timeline events:
+// hook-ran (level 2) / hook-failed (level 1 — the bell). The one ordering
+// guarantee: card-archived hooks finish BEFORE the worktree release.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { runHooks } = require('../server/hooks.js');
+const { startServerWithLieutenant, startServer, withOwner, sleep, LT } = require('./helper');
+
+function writeHook(ws, event, name, body, mode = 0o755) {
+  const dir = path.join(ws, '.bridge-commander', 'hooks', event);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, body);
+  fs.chmodSync(file, mode);
+  return file;
+}
+function shHook(ws, event, name, script, mode) {
+  return writeHook(ws, event, name, '#!/bin/sh\n' + script + '\n', mode);
+}
+
+async function until(what, fn, ms = 6000) {
+  const deadline = Date.now() + ms;
+  for (;;) {
+    const v = await fn();
+    if (v) return v;
+    if (Date.now() > deadline) throw new Error('timeout waiting for: ' + what);
+    await sleep(50);
+  }
+}
+
+// ---------- unit: runHooks against a scratch workspace ----------
+
+function scratchWs() { return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-hooks-')); }
+
+test('runHooks: missing hooks dir is a no-op', async () => {
+  const ws = scratchWs();
+  try {
+    assert.deepStrictEqual(await runHooks('worker-done', { workspace: ws }), []);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: happy run — BC_* env visible, exit 0, output captured, cwd = workspace', async () => {
+  const ws = scratchWs();
+  try {
+    shHook(ws, 'worker-done', 'env.sh',
+      'echo "$BC_EVENT|$BC_CARD|$BC_REPO|$BC_WORKTREE|$BC_BRANCH" > env.out\necho hello');
+    const results = await runHooks('worker-done',
+      { workspace: ws, card: 'c1', repo: '/r', worktree: '/w', branch: 'bc/c1' });
+    assert.strictEqual(results.length, 1);
+    assert.deepStrictEqual(
+      { hook: results[0].hook, ok: results[0].ok, code: results[0].code, output: results[0].output },
+      { hook: 'env.sh', ok: true, code: 0, output: 'hello' });
+    // env.out written relative to cwd — the workspace root
+    assert.strictEqual(fs.readFileSync(path.join(ws, 'env.out'), 'utf8').trim(),
+      'worker-done|c1|/r|/w|bc/c1');
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: empty string for N/A context fields', async () => {
+  const ws = scratchWs();
+  try {
+    shHook(ws, 'card-archived', 'env.sh', 'printf "%s|%s" "$BC_WORKTREE" "$BC_BRANCH" > env.out');
+    await runHooks('card-archived', { workspace: ws, card: 'c1' });
+    assert.strictEqual(fs.readFileSync(path.join(ws, 'env.out'), 'utf8'), '|');
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: alphabetical order, sequential; non-executable skipped silently', async () => {
+  const ws = scratchWs();
+  try {
+    // written in non-alphabetical order on purpose
+    shHook(ws, 'worker-done', '20-second.sh', 'echo second >> order.out');
+    shHook(ws, 'worker-done', '10-first.sh', 'echo first >> order.out');
+    shHook(ws, 'worker-done', '15-skipme.sh', 'echo NEVER >> order.out', 0o644); // not executable
+    const results = await runHooks('worker-done', { workspace: ws, card: 'c1' });
+    assert.deepStrictEqual(results.map((r) => r.hook), ['10-first.sh', '20-second.sh']);
+    assert.strictEqual(fs.readFileSync(path.join(ws, 'order.out'), 'utf8'), 'first\nsecond\n');
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: failing hook reports ok:false + exit code, later hooks still run', async () => {
+  const ws = scratchWs();
+  try {
+    shHook(ws, 'worker-done', '1-bad.sh', 'echo boom >&2\nexit 3');
+    shHook(ws, 'worker-done', '2-good.sh', 'exit 0');
+    const results = await runHooks('worker-done', { workspace: ws, card: 'c1' });
+    assert.deepStrictEqual(results.map((r) => [r.hook, r.ok, r.code]),
+      [['1-bad.sh', false, 3], ['2-good.sh', true, 0]]);
+    assert.strictEqual(results[0].output, 'boom'); // stderr captured too
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: broken interpreter is a failed result, not a crash', async () => {
+  const ws = scratchWs();
+  try {
+    writeHook(ws, 'worker-done', 'broken.sh', '#!/no/such/interpreter\necho hi\n');
+    const results = await runHooks('worker-done', { workspace: ws, card: 'c1' });
+    assert.strictEqual(results.length, 1);
+    assert.strictEqual(results[0].ok, false);
+    assert.ok(results[0].error || results[0].code !== 0, 'spawn failure surfaced');
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: timeout kills the hook (injectable timeoutMs)', async () => {
+  const ws = scratchWs();
+  try {
+    shHook(ws, 'worker-done', 'hang.sh', 'sleep 30');
+    const t0 = Date.now();
+    const results = await runHooks('worker-done', { workspace: ws, card: 'c1' }, { timeoutMs: 300 });
+    assert.ok(Date.now() - t0 < 5000, 'did not wait for the sleep');
+    assert.strictEqual(results[0].ok, false);
+    assert.strictEqual(results[0].timedOut, true);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+test('runHooks: output capped at a few KB', async () => {
+  const ws = scratchWs();
+  try {
+    shHook(ws, 'worker-done', 'noisy.sh', 'i=0; while [ $i -lt 2000 ]; do echo aaaaaaaaaaaaaaaa; i=$((i+1)); done');
+    const results = await runHooks('worker-done', { workspace: ws, card: 'c1' });
+    assert.strictEqual(results[0].ok, true);
+    assert.ok(results[0].output.length <= 4096, 'capped');
+    assert.strictEqual(results[0].truncated, true);
+  } finally { fs.rmSync(ws, { recursive: true, force: true }); }
+});
+
+// ---------- integration: the server fires hooks on lifecycle events ----------
+
+function makeRepo(root) {
+  const repo = path.join(root, 'srcrepo');
+  fs.mkdirSync(repo, { recursive: true });
+  execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+  fs.writeFileSync(path.join(repo, 'README.md'), 'hi\n');
+  execFileSync('git', ['-C', repo, 'add', '.'], { stdio: ['ignore', 'pipe', 'pipe'] });
+  execFileSync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init'],
+    { stdio: ['ignore', 'pipe', 'pipe'] });
+  return repo;
+}
+
+async function bootWithProject(extraEnv = {}) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-hooks-int-'));
+  const repo = makeRepo(root);
+  const s = await startServerWithLieutenant({
+    env: Object.assign({
+      BC_FAKE_STATE: path.join(root, 'fake'), BC_WORKTREE_TOOL: 'git',
+      BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
+    }, extraEnv),
+  });
+  await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'direct-PR' });
+  const teardown = async () => { await s.stop(); fs.rmSync(root, { recursive: true, force: true }); };
+  return { s, root, teardown };
+}
+
+test('worker-done hooks: env context from the worker record, hook-ran level-2 card event', async () => {
+  const { s, root, teardown } = await bootWithProject();
+  try {
+    const out = path.join(root, 'wd-env.out');
+    shHook(s.dir, 'worker-done', 'capture.sh',
+      'echo "$BC_EVENT|$BC_CARD|$BC_REPO|$BC_WORKTREE|$BC_BRANCH" > ' + JSON.stringify(out) + '\necho swept');
+    await s.api('POST', '/api/cards', withOwner({ title: 'Hooked', id: 'hooked', attributes: { repo: 'proj' } }));
+    const w = (await s.api('POST', '/api/cards/hooked/start', { harness: 'fake' })).body.worker;
+    await s.api('POST', '/api/cards/hooked/worker/done', { outcome: 'all done' });
+
+    const ev = await until('hook-ran event on the card', async () => {
+      const c = (await s.api('GET', '/api/cards/hooked')).body;
+      return (c.events || []).find((e) => e.kind === 'hook-ran');
+    });
+    assert.strictEqual(ev.level, 2);
+    assert.match(ev.text, /capture\.sh/);
+    assert.match(ev.text, /exit 0/);
+    assert.match(ev.text, /swept/); // trimmed output included
+    const project = path.join(s.dir, 'projects', 'proj');
+    assert.strictEqual(fs.readFileSync(out, 'utf8').trim(),
+      'worker-done|hooked|' + project + '|' + w.worktree.path + '|bc/hooked');
+  } finally { await teardown(); }
+});
+
+test('worker-done failing hook: hook-failed level-1 card event + hook-failed QueueItem to the owner', async () => {
+  const { s, teardown } = await bootWithProject();
+  try {
+    shHook(s.dir, 'worker-done', 'bad.sh', 'echo teardown exploded >&2\nexit 7');
+    await s.api('POST', '/api/cards', withOwner({ title: 'Bad hook', id: 'bad-hook', attributes: { repo: 'proj' } }));
+    await s.api('POST', '/api/cards/bad-hook/start', { harness: 'fake' });
+    await s.api('POST', '/api/cards/bad-hook/worker/done', { outcome: 'done anyway' });
+
+    const ev = await until('hook-failed event on the card', async () => {
+      const c = (await s.api('GET', '/api/cards/bad-hook')).body;
+      return (c.events || []).find((e) => e.kind === 'hook-failed');
+    });
+    assert.strictEqual(ev.level, 1, 'the bell — the captain must see hook failures');
+    assert.match(ev.text, /bad\.sh/);
+    assert.match(ev.text, /exit 7/);
+    assert.match(ev.text, /teardown exploded/);
+    const items = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items;
+    assert.ok(items.some((i) => i.kind === 'hook-failed' && i.card === 'bad-hook'));
+  } finally { await teardown(); }
+});
+
+test('worker-done with no hooks dir: lifecycle unaffected, no hook events', async () => {
+  const { s, teardown } = await bootWithProject();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Plain', id: 'plain', attributes: { repo: 'proj' } }));
+    await s.api('POST', '/api/cards/plain/start', { harness: 'fake' });
+    const r = await s.api('POST', '/api/cards/plain/worker/done', { outcome: 'fin' });
+    assert.strictEqual(r.status, 200);
+    await sleep(400);
+    const c = (await s.api('GET', '/api/cards/plain')).body;
+    assert.ok(!c.events.some((e) => e.kind === 'hook-ran' || e.kind === 'hook-failed'));
+    assert.ok(c.events.some((e) => e.kind === 'worker-done'));
+  } finally { await teardown(); }
+});
+
+test('hook timeout: BC_HOOK_TIMEOUT_MS override, hook-failed says timed out, lifecycle unharmed', async () => {
+  const { s, teardown } = await bootWithProject({ BC_HOOK_TIMEOUT_MS: '300' });
+  try {
+    shHook(s.dir, 'worker-done', 'hang.sh', 'sleep 30');
+    await s.api('POST', '/api/cards', withOwner({ title: 'Hang', id: 'hang', attributes: { repo: 'proj' } }));
+    await s.api('POST', '/api/cards/hang/start', { harness: 'fake' });
+    await s.api('POST', '/api/cards/hang/worker/done', { outcome: 'fin' });
+    const ev = await until('timed-out hook-failed event', async () => {
+      const c = (await s.api('GET', '/api/cards/hang')).body;
+      return (c.events || []).find((e) => e.kind === 'hook-failed');
+    });
+    assert.match(ev.text, /hang\.sh/);
+    assert.match(ev.text, /timed out/);
+  } finally { await teardown(); }
+});
+
+test('worker-died hooks fire from the supervision loop', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-hooks-died-'));
+  const nowIso = new Date().toISOString();
+  const wt = path.join(root, 'wt');
+  fs.mkdirSync(wt, { recursive: true });
+  const s = await startServer({
+    env: { BC_FAKE_STATE: path.join(root, 'fake'), BC_SUPERVISE_INTERVAL_MS: '150', BC_PRWATCH_INTERVAL_MS: '0' },
+    seed: (dir) => {
+      const sd = path.join(dir, '.bridge-commander');
+      fs.mkdirSync(sd, { recursive: true });
+      fs.writeFileSync(path.join(sd, 'board.json'), JSON.stringify({
+        title: 'seeded', seq: 0, labels: [], reads: {}, kinds: {}, events: [],
+        lieutenants: [{ id: 'ada', name: 'Ada', color: '#58b6ff', charter: '', chat: [], created: nowIso }],
+        projects: [{ name: 'proj', path: path.join(root, 'proj'), mode: 'direct-PR', added: nowIso }],
+        cards: [{
+          id: 'doomed', title: 'Doomed', type: 'implementation', owner: 'ada', column: 'working',
+          labels: [], attributes: { repo: 'proj' }, body: '', created: nowIso, updated: nowIso,
+          threadStart: null, pendingOrder: null, events: [], thread: [],
+        }],
+        // no fake session marker exists -> dead on the first tick
+        workers: [{ card: 'doomed', ref: { harness: 'fake', session: 'bc-w-doomed', cwd: '/tmp', resumeId: 'x' },
+          worktree: { path: wt, tool: 'git' }, branch: 'bc/doomed', project: 'proj', spawnedAt: nowIso, done: false }],
+      }, null, 2));
+    },
+  });
+  try {
+    const out = path.join(root, 'died-env.out');
+    shHook(s.dir, 'worker-died', 'capture.sh',
+      'echo "$BC_EVENT|$BC_CARD|$BC_WORKTREE|$BC_BRANCH" > ' + JSON.stringify(out));
+    const ev = await until('hook-ran after worker-died', async () => {
+      const c = (await s.api('GET', '/api/cards/doomed')).body;
+      return (c.events || []).find((e) => e.kind === 'hook-ran');
+    });
+    assert.match(ev.text, /worker-died hook capture\.sh ok/);
+    assert.ok((await s.api('GET', '/api/cards/doomed')).body.events.some((e) => e.kind === 'worker-died'));
+    assert.strictEqual(fs.readFileSync(out, 'utf8').trim(), 'worker-died|doomed|' + wt + '|bc/doomed');
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('card-archived hooks (manual archive): board-level events with a card ref; worktree untouched', async () => {
+  const { s, root, teardown } = await bootWithProject();
+  try {
+    const out = path.join(root, 'arch-env.out');
+    shHook(s.dir, 'card-archived', 'capture.sh',
+      'if [ -d "$BC_WORKTREE" ]; then echo "worktree-present"; else echo "worktree-gone"; fi > ' + JSON.stringify(out));
+    await s.api('POST', '/api/cards', withOwner({ title: 'Kill me', id: 'kill-me', attributes: { repo: 'proj' } }));
+    const w = (await s.api('POST', '/api/cards/kill-me/start', { harness: 'fake' })).body.worker;
+    const r = await s.api('POST', '/api/cards/kill-me/archive', { reason: 'killed', actor: 'user' });
+    assert.strictEqual(r.status, 200);
+
+    // the archived card can't take timeline events — they land on the board
+    // stream with a card reference instead of being dropped
+    const ev = await until('board-level hook-ran', async () => {
+      const b = (await s.api('GET', '/api/board')).body;
+      return b.events.find((e) => e.kind === 'hook-ran' && e.card === 'kill-me');
+    });
+    assert.strictEqual(ev.cardTitle, 'Kill me');
+    assert.match(ev.text, /card-archived hook capture\.sh ok/);
+    // manual archive never releases the worktree; the hook saw it in place
+    assert.strictEqual(fs.readFileSync(out, 'utf8').trim(), 'worktree-present');
+    assert.ok(fs.existsSync(w.worktree.path));
+  } finally { await teardown(); }
+});
+
+test('card-archived hooks run BEFORE the worktree release on the merged-PR path', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-hooks-merge-'));
+  const repo = makeRepo(root);
+  // gh stub: every PR is MERGED
+  const stub = path.join(root, 'gh-stub');
+  fs.writeFileSync(stub, '#!/usr/bin/env node\nconsole.log(JSON.stringify({ state: "MERGED", mergedAt: "2026-01-01T00:00:00Z" }));\n');
+  fs.chmodSync(stub, 0o755);
+  const s = await startServerWithLieutenant({
+    env: {
+      BC_FAKE_STATE: path.join(root, 'fake'), BC_WORKTREE_TOOL: 'git',
+      BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '200', BC_GH_CMD: stub,
+    },
+  });
+  try {
+    await s.api('POST', '/api/projects', { source: repo, name: 'proj', mode: 'direct-PR' });
+    const out = path.join(root, 'wt-check.out');
+    shHook(s.dir, 'card-archived', 'check.sh',
+      'if [ -d "$BC_WORKTREE" ]; then echo "worktree-present"; else echo "worktree-gone"; fi > ' + JSON.stringify(out));
+    await s.api('POST', '/api/cards', withOwner({ title: 'Merge me', id: 'merge-me', attributes: { repo: 'proj' } }));
+    const w = (await s.api('POST', '/api/cards/merge-me/start', { harness: 'fake' })).body.worker;
+    await s.api('POST', '/api/cards/merge-me/worker/done',
+      { outcome: 'PR: https://github.com/acme/proj/pull/1' });
+
+    await until('card archived on merge', async () =>
+      (await s.api('GET', '/api/cards/merge-me')).status === 404);
+    // the hook ran while the worktree still existed; the release still happened after
+    assert.strictEqual(fs.readFileSync(out, 'utf8').trim(), 'worktree-present');
+    assert.ok(!fs.existsSync(w.worktree.path), 'worktree released after the hooks');
+    const b = (await s.api('GET', '/api/board')).body;
+    assert.ok(b.events.some((e) => e.kind === 'hook-ran' && e.card === 'merge-me'));
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/test/kinds.test.js
+++ b/test/kinds.test.js
@@ -22,6 +22,8 @@ const BUILTINS = {
   signal: { emoji: '📡', level: 2 },
   'worker-done': { emoji: '✅', level: 2 },
   'worker-died': { emoji: '💀', level: 2 },
+  'hook-ran': { emoji: '🪝', level: 2 },
+  'hook-failed': { emoji: '🧨', level: 1 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
   'worker-stalled': { emoji: '🐢', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },


### PR DESCRIPTION
Generic hooks system: the server runs the workspace's own executable scripts on card/worker lifecycle events, so teardown of anything a worker left running (dev containers, compose stacks) becomes deterministic — with zero project-isms in this repo.

## How it works

- **Hooks dir**: every executable file in `<workspace>/.bridge-commander/hooks/<event>/` runs on the event — alphabetical, sequential, cwd = workspace root, spawned directly (scripts carry their own shebang). Missing dir / non-executables = silent no-op.
- **Events v1**: `worker-done` (worker reported done), `worker-died` (supervision found the session dead), `card-archived` (manual archive + the merged-PR path).
- **Context via env** (empty string when N/A): `BC_EVENT`, `BC_CARD`, `BC_REPO`, `BC_WORKTREE`, `BC_BRANCH`.
- **Fire-and-forget**: a hook never blocks or fails the lifecycle outcome. Per-hook timeout ~120s (`BC_HOOK_TIMEOUT_MS` overrides) then a process-group SIGKILL; stdout+stderr captured, capped at 4KB. The ONE ordering guarantee: `card-archived` hooks finish (or time out) BEFORE the worktree release, so a hook can still reach paths inside `$BC_WORKTREE`.
- **Timeline**: `hook-ran` level 2 per success, `hook-failed` level 1 (the captain's bell), text = filename + exit detail + trimmed output. An archived card can't take timeline events, so its hook events land on the board stream with a card reference; failures also queuePush to the owner.

## Implementation

- New `server/hooks.js` (node built-ins only): `runHooks(event, ctx, opts) -> results[]`. Hooks spawn detached in their own process group — the timeout kill reaches the whole tree, and a leaked grandchild holding our pipes can't wedge the server (post-exit grace, then streams destroyed).
- `server/server.js`: `fireHooks()` helper + four call sites (worker/done route, supervise died path, archive route, PR-watch merged path — awaited there, before `releaseWorktree`). `hook-ran`/`hook-failed` registered in the builtin kinds map.

## Tests

`test/hooks.test.js` — 15 new tests: unit (env contract, alphabetical order, failing hook, broken shebang, timeout kill, output cap, no-dir no-op) + integration (hook-ran/hook-failed events and queue items on worker-done, worker-died via supervision, card-archived on both paths, worktree-present-during-hook asserted on the merged-PR path, BC_HOOK_TIMEOUT_MS). Full suite: 314/314 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)