### PR TITLE
On-demand machine-load monitoring panel (⚙️ → monitoring)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Env knobs (set on the server process):
 | `BC_TURNEND_URL` | — | default callback URL baked into installed turn-end hooks |
 | `BC_SEND_RETRIES` / `BC_SEND_SLEEP_MS` | `3` / `400` | verified-submit tuning for `harness.send` |
 | `BC_HOOK_TIMEOUT_MS` | `120000` | per-script timeout for workspace lifecycle hooks |
+| `BC_SYSLOAD_MS` | `2000` | monitoring panel (⚙️ → machine load) sample interval; the sampler runs only while the panel is open |
 
 ### Lifecycle hooks
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -116,6 +116,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 | worker stop | — | ⚙️ turn-end | a worker turn-end IS the stop signal: card still Working and no `done` → immediate `worker-stopped` QueueItem to the owner + level-2 event (coalesced — one per stop, not per turn). After `done`, turn-ends only update counters |
 | worker death | — | ⚙️ supervision loop | a worker ref dead without `done` → `worker-died` QueueItem to the owner + level-2 event; the card stays Working, flagged — the owner resumes (`card.start --resume`) or parks it |
 | worker stall | — | ⚙️ supervision loop | a worker alive but silent too long (no signal/turn-end) → `worker-stalled` level-1 event + QueueItem to the owner; re-armed by real activity |
+| `sysload.watch` | `() → stream of samples` | 🤠 | on-demand monitoring (⚙️ → machine load): machine CPU/RAM/disk + per-worker/per-lieutenant process-tree load + container count, over a dedicated stream. A pure, side-effect-free read — samples exist only while someone watches (first subscriber starts the sampler, last disconnect stops it); nothing lands on the board |
 
 ### harness port (internal seam — the multi-harness contract)
 

--- a/server/server.js
+++ b/server/server.js
@@ -57,6 +57,7 @@ const crypto = require('crypto');
 const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '..', 'harness', 'port.js'));
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
 const { runHooks } = require(path.join(__dirname, 'hooks.js'));
+const { createSampler } = require(path.join(__dirname, 'sysload.js'));
 const { workerBrief, PROJECT_MODES } = require(path.join(__dirname, 'brief.js'));
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
@@ -813,6 +814,30 @@ function paneStream(req, res, ref, reason) {
     catch (e) { /* closing a dead pane is a no-op */ }
   });
 }
+
+// ---------- sysload (⚙️ → monitoring: on-demand machine/agent load) ----------
+// Zero cost when closed: the sampler loop (server/sysload.js) exists only
+// while /api/sysload/stream has subscribers — first EventSource starts it,
+// last disconnect stops it. Never rides the board push: samples are per-viewer
+// telemetry, not board state. targets() re-reads the live registries every
+// sample, so rows appear/disappear with workers and lieutenants.
+const SYSLOAD_MS = parseInt(process.env.BC_SYSLOAD_MS, 10) > 0
+  ? parseInt(process.env.BC_SYSLOAD_MS, 10) : 2000;
+function sysloadTargets() {
+  const out = [];
+  for (const w of board.workers) {
+    if (w.done || !isHarnessRef(w.ref)) continue;
+    const card = findCard(w.card);
+    out.push({ kind: 'worker', id: w.card, label: (card && card.title) || w.card,
+      session: w.ref.session, window: w.ref.window || null });
+  }
+  for (const lt of board.lieutenants) {
+    if (!isHarnessRef(lt.ref)) continue;
+    out.push({ kind: 'lieutenant', id: lt.id, label: lt.name, session: lt.ref.session, window: null });
+  }
+  return out;
+}
+const sysload = createSampler({ workspace: WORKSPACE, targets: sysloadTargets, intervalMs: SYSLOAD_MS });
 
 // Named ping (not an SSE comment): comments are invisible to EventSource, so
 // the client's staleness watchdog couldn't see the stream is alive. Pane
@@ -2085,6 +2110,7 @@ const server = http.createServer(async (req, res) => {
         queue_seq: qseq, queue_pending: pending,
         projects: board.projects.length, workers: board.workers.length,
         pid: process.pid,
+        sysload: sysload.stats(), // the monitoring refcount probe: {subscribers, sampling}
       });
     }
     if (route === 'GET /api/archive') {
@@ -2747,6 +2773,19 @@ const server = http.createServer(async (req, res) => {
         else ref = lt.ref;
       }
       return paneStream(req, res, ref, reason);
+    }
+
+    // ----- sysload stream (⚙️ → monitoring; see the sysload section above) -----
+    // The HTTP connection's lifetime IS the subscription, exactly like the
+    // pane streams: connect to watch, disconnect to release. Each sample lands
+    // as one `sample` event; samples flow every ~2s, so no extra ping rides here.
+    if (route === 'GET /api/sysload/stream') {
+      res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', Connection: 'keep-alive' });
+      const unsubscribe = sysload.subscribe((sample) => {
+        res.write('event: sample\ndata: ' + JSON.stringify(sample) + '\n\n');
+      });
+      req.on('close', unsubscribe);
+      return;
     }
 
     // ----- SSE -----

--- a/server/sysload.js
+++ b/server/sysload.js
@@ -1,0 +1,304 @@
+'use strict';
+// sysload — on-demand machine + per-agent load sampling. Node built-ins only.
+//
+// Zero cost when closed: nothing here runs until the FIRST subscriber arrives
+// (createSampler().subscribe), and the loop stops dead when the LAST one
+// leaves. The server wires this behind a dedicated SSE endpoint
+// (GET /api/sysload/stream) — never the board push.
+//
+// One sample =
+//   { ts, machine: { cpuPct, cores, memUsedBytes, memTotalBytes,
+//                    diskUsedBytes, diskTotalBytes },
+//     entities: [{ kind: 'worker'|'lieutenant', id, label, cpuPct, rssBytes, pids }],
+//     containers: number|null }
+//
+// Machine numbers come straight from /proc/stat + /proc/meminfo + statfs on
+// the workspace volume — Linux-first; anywhere that surface is missing the
+// numbers read as graceful zeros. Entity rows are the headline: for every
+// live worker and lieutenant session the server tracks, the sampler asks tmux
+// for the pane pids (`list-panes -s`), walks the /proc ppid tree to collect
+// each pane's descendants, and sums CPU%+RSS per entity, heaviest first.
+// CPU% is delta-based (two reads of the same counters), so the first sample
+// of a fresh loop reads 0% and truth arrives one interval later.
+//
+// Everything environmental is injectable (procRoot, statfs, execFile impl,
+// targets, interval) so tests run on fixture /proc trees and stubbed tmux —
+// see test/sysload.test.js.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFile } = require('node:child_process');
+
+const USER_HZ = 100; // /proc tick unit (USER_HZ); 100 on every mainstream Linux
+const DEFAULT_INTERVAL_MS = 2000;
+const EXEC_TIMEOUT_MS = 5000;
+
+// ---------- /proc parsing (pure; every reader takes a procRoot) ----------
+
+// Aggregate cpu line of /proc/stat -> { totalTicks, idleTicks, cores }.
+// idle counts idle+iowait; total is the sum of every column (steal included).
+function parseCpuTotals(text) {
+  const out = { totalTicks: 0, idleTicks: 0, cores: 0 };
+  for (const line of String(text || '').split('\n')) {
+    if (/^cpu\d+ /.test(line)) { out.cores++; continue; }
+    if (!/^cpu /.test(line)) continue;
+    const n = line.trim().split(/\s+/).slice(1).map((v) => parseInt(v, 10) || 0);
+    out.totalTicks = n.reduce((a, b) => a + b, 0);
+    out.idleTicks = (n[3] || 0) + (n[4] || 0);
+  }
+  return out;
+}
+function readCpuTotals(procRoot) {
+  try { return parseCpuTotals(fs.readFileSync(path.join(procRoot, 'stat'), 'utf8')); }
+  catch (e) { return { totalTicks: 0, idleTicks: 0, cores: 0 }; }
+}
+
+// /proc/meminfo -> { memTotalBytes, memAvailBytes } (kB lines; zeros when absent).
+function parseMeminfo(text) {
+  const grab = (key) => {
+    const m = new RegExp('^' + key + ':\\s+(\\d+)\\s*kB', 'm').exec(String(text || ''));
+    return m ? parseInt(m[1], 10) * 1024 : 0;
+  };
+  return { memTotalBytes: grab('MemTotal'), memAvailBytes: grab('MemAvailable') };
+}
+function readMeminfo(procRoot) {
+  try { return parseMeminfo(fs.readFileSync(path.join(procRoot, 'meminfo'), 'utf8')); }
+  catch (e) { return { memTotalBytes: 0, memAvailBytes: 0 }; }
+}
+
+// /proc/<pid>/stat -> { ppid, ticks } (utime+stime). The comm field may hold
+// spaces and parens, so fields are parsed AFTER the last ')'.
+function parsePidStat(text) {
+  const s = String(text || '');
+  const i = s.lastIndexOf(')');
+  if (i < 0) return null;
+  const f = s.slice(i + 1).trim().split(/\s+/);
+  // after comm: [0]=state [1]=ppid ... [11]=utime [12]=stime
+  const ppid = parseInt(f[1], 10);
+  const ticks = (parseInt(f[11], 10) || 0) + (parseInt(f[12], 10) || 0);
+  if (!Number.isInteger(ppid)) return null;
+  return { ppid, ticks };
+}
+
+// One pass over <procRoot>: pid -> { ppid, ticks }. RSS is read lazily later —
+// only pids that land in some entity's tree pay for the second file read.
+function readProcTable(procRoot) {
+  const table = new Map();
+  let names;
+  try { names = fs.readdirSync(procRoot); } catch (e) { return table; }
+  for (const name of names) {
+    if (!/^\d+$/.test(name)) continue;
+    let st;
+    try { st = parsePidStat(fs.readFileSync(path.join(procRoot, name, 'stat'), 'utf8')); }
+    catch (e) { continue; } // the process exited mid-scan
+    if (st) table.set(parseInt(name, 10), st);
+  }
+  return table;
+}
+
+// VmRSS of one pid in bytes (0 when gone/unreadable) — /proc/<pid>/status is
+// page-size independent, unlike stat's rss-in-pages.
+function readPidRss(procRoot, pid) {
+  try {
+    const m = /^VmRSS:\s+(\d+)\s*kB/m.exec(fs.readFileSync(path.join(procRoot, pid + '/status'), 'utf8'));
+    return m ? parseInt(m[1], 10) * 1024 : 0;
+  } catch (e) { return 0; }
+}
+
+// rootPids + the full pid table -> the transitive descendant set (roots included).
+function descendants(table, rootPids) {
+  const children = new Map(); // ppid -> [pid]
+  for (const [pid, st] of table) {
+    if (!children.has(st.ppid)) children.set(st.ppid, []);
+    children.get(st.ppid).push(pid);
+  }
+  const out = new Set();
+  const stack = rootPids.filter((p) => table.has(p));
+  while (stack.length) {
+    const pid = stack.pop();
+    if (out.has(pid)) continue;
+    out.add(pid);
+    for (const kid of children.get(pid) || []) stack.push(kid);
+  }
+  return out;
+}
+
+// ---------- sampler ----------
+// createSampler({ workspace, targets, intervalMs?, procRoot?, execFileImpl?, statfs? })
+//   targets()  -> [{ kind, id, label, session, window|null }] — the server's
+//                 live worker/lieutenant registry, re-read every sample so
+//                 rows track the board.
+//   subscribe(fn) -> unsubscribe(). First subscriber starts the loop (and gets
+//                 a sample immediately); last unsubscribe stops it and drops
+//                 all delta state, so a fresh viewer always re-baselines.
+//   stats()    -> { subscribers, sampling } — the refcount probe
+//                 (surfaced on /api/status; tests key off it).
+function createSampler(opts) {
+  const o = opts || {};
+  const procRoot = o.procRoot || '/proc';
+  const diskPath = o.diskPath || o.workspace || '/';
+  const intervalMs = o.intervalMs > 0 ? o.intervalMs : DEFAULT_INTERVAL_MS;
+  const targets = typeof o.targets === 'function' ? o.targets : () => [];
+  const exec = o.execFileImpl || ((cmd, args) => new Promise((resolve, reject) => {
+    execFile(cmd, args, { encoding: 'utf8', timeout: EXEC_TIMEOUT_MS }, (err, stdout) => {
+      if (err) reject(err); else resolve(stdout);
+    });
+  }));
+  const statfs = o.statfs || ((p) => fs.statfsSync(p));
+
+  const subs = new Set();
+  let timer = null;
+  let running = false; // one sampleOnce in flight at a time
+  let last = null;     // latest sample, replayed to late joiners
+  let prev = null;     // { ts, cpu: {totalTicks, idleTicks}, pidTicks: Map }
+
+  function machineSample(cpu) {
+    const mem = readMeminfo(procRoot);
+    let disk = { used: 0, total: 0 };
+    try {
+      const st = statfs(diskPath);
+      disk = { used: (st.blocks - st.bfree) * st.bsize, total: st.blocks * st.bsize };
+    } catch (e) { /* graceful zeros off-Linux / odd mounts */ }
+    let cpuPct = 0;
+    if (prev && cpu.totalTicks > prev.cpu.totalTicks) {
+      const total = cpu.totalTicks - prev.cpu.totalTicks;
+      const idle = cpu.idleTicks - prev.cpu.idleTicks;
+      cpuPct = Math.max(0, Math.min(100, ((total - idle) / total) * 100));
+    }
+    return {
+      cpuPct: Math.round(cpuPct * 10) / 10, cores: cpu.cores,
+      memUsedBytes: Math.max(0, mem.memTotalBytes - mem.memAvailBytes),
+      memTotalBytes: mem.memTotalBytes,
+      diskUsedBytes: disk.used, diskTotalBytes: disk.total,
+    };
+  }
+
+  // tmux pane pids for one session: [{ window, pid }] ([] when tmux/session is gone).
+  async function panePids(session) {
+    let out;
+    try {
+      out = await exec('tmux', ['list-panes', '-s', '-t', session, '-F', '#{window_name}\t#{pane_pid}']);
+    } catch (e) { return []; }
+    const panes = [];
+    for (const line of String(out || '').split('\n')) {
+      const m = /^(.*)\t(\d+)$/.exec(line.trim());
+      if (m) panes.push({ window: m[1], pid: parseInt(m[2], 10) });
+    }
+    return panes;
+  }
+
+  async function containerCount() {
+    try {
+      const out = await exec('docker', ['ps', '-q']);
+      return String(out || '').split('\n').filter(Boolean).length;
+    } catch (e) { return null; } // docker absent/broken -> the row hides
+  }
+
+  // Attribute each session's panes to its entities: a window-granular worker
+  // claims its own window's panes; every unclaimed pane falls to the session's
+  // window-less target (the lieutenant — or a legacy whole-session worker).
+  async function entitySamples(table, elapsedSec) {
+    const list = targets();
+    const bySession = new Map();
+    for (const t of list) {
+      if (!t || !t.session) continue;
+      if (!bySession.has(t.session)) bySession.set(t.session, []);
+      bySession.get(t.session).push(t);
+    }
+    const rootsByTarget = new Map(); // target -> [panePid]
+    for (const [session, ts] of bySession) {
+      const panes = await panePids(session);
+      for (const pane of panes) {
+        const owner = ts.find((t) => t.window && t.window === pane.window)
+          || ts.find((t) => !t.window);
+        if (!owner) continue;
+        if (!rootsByTarget.has(owner)) rootsByTarget.set(owner, []);
+        rootsByTarget.get(owner).push(pane.pid);
+      }
+    }
+    const pidTicks = new Map(); // pid -> ticks now (kept as the next sample's prev)
+    const rows = [];
+    for (const [t, roots] of rootsByTarget) {
+      const pids = descendants(table, roots);
+      // delta only over pids seen in BOTH samples — a pid new to this sample
+      // would otherwise dump its whole-lifetime ticks into one interval
+      let deltaTicks = 0;
+      let rssBytes = 0;
+      for (const pid of pids) {
+        const st = table.get(pid);
+        pidTicks.set(pid, st.ticks);
+        if (prev && prev.pidTicks.has(pid)) deltaTicks += st.ticks - prev.pidTicks.get(pid);
+        rssBytes += readPidRss(procRoot, pid);
+      }
+      let cpuPct = 0;
+      if (prev && elapsedSec > 0 && deltaTicks > 0) {
+        cpuPct = (deltaTicks / USER_HZ / elapsedSec) * 100;
+      }
+      rows.push({
+        kind: t.kind, id: t.id, label: t.label,
+        cpuPct: Math.round(cpuPct * 10) / 10, rssBytes, pids: pids.size,
+      });
+    }
+    rows.sort((a, b) => (b.cpuPct - a.cpuPct) || (b.rssBytes - a.rssBytes));
+    return { rows, pidTicks };
+  }
+
+  async function sampleOnce() {
+    const ts = Date.now();
+    const cpu = readCpuTotals(procRoot);
+    const table = readProcTable(procRoot);
+    const elapsedSec = prev ? (ts - prev.ts) / 1000 : 0;
+    const machine = machineSample(cpu);
+    const [ents, containers] = await Promise.all([
+      entitySamples(table, elapsedSec),
+      containerCount(),
+    ]);
+    prev = { ts, cpu, pidTicks: ents.pidTicks };
+    return {
+      ts: new Date(ts).toISOString(),
+      machine, entities: ents.rows, containers,
+    };
+  }
+
+  function emit(sample) {
+    last = sample;
+    for (const fn of subs) {
+      try { fn(sample); } catch (e) { /* one bad subscriber never stalls the rest */ }
+    }
+  }
+
+  function tick() {
+    if (running || !subs.size) return;
+    running = true;
+    sampleOnce()
+      .then((s) => { if (subs.size) emit(s); })
+      .catch(() => { /* a torn-down /proc read mid-sample — skip this beat */ })
+      .finally(() => {
+        running = false;
+        if (subs.size) timer = setTimeout(tick, intervalMs);
+      });
+  }
+
+  function subscribe(fn) {
+    subs.add(fn);
+    if (subs.size === 1) tick(); // first viewer: sample NOW, then every interval
+    else if (last) { try { fn(last); } catch (e) { /* subscriber's problem */ } }
+    return function unsubscribe() {
+      if (!subs.delete(fn) || subs.size) return;
+      // last viewer gone: stop dead and forget the deltas — zero cost when closed
+      if (timer) { clearTimeout(timer); timer = null; }
+      prev = null;
+      last = null;
+    };
+  }
+
+  function stats() { return { subscribers: subs.size, sampling: !!(subs.size && (timer || running)) }; }
+
+  return { subscribe, stats };
+}
+
+module.exports = {
+  createSampler,
+  // pure pieces, exported for tests
+  parseCpuTotals, parseMeminfo, parsePidStat, readProcTable, readPidRss, descendants,
+};

--- a/test/sysload-server.test.js
+++ b/test/sysload-server.test.js
@@ -1,0 +1,114 @@
+'use strict';
+// /api/sysload/stream — the on-demand monitoring endpoint: samples flow over a
+// dedicated SSE while subscribed; the sampler refcount (visible on /api/status
+// as `sysload`) starts at the first subscriber and stops dead at zero.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { startServer, sleep } = require('./helper');
+
+// Open the stream and read SSE `sample` events until n arrived (or timeout),
+// then cancel the connection (dropping the server-side subscription).
+async function readSamples(base, n, timeoutMs = 5000) {
+  const ctrl = new AbortController();
+  const res = await fetch(base + '/api/sysload/stream', { signal: ctrl.signal });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type'), /text\/event-stream/);
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  const deadline = Date.now() + timeoutMs;
+  let buf = '';
+  const samples = [];
+  while (samples.length < n && Date.now() < deadline) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buf += dec.decode(value, { stream: true });
+    for (;;) {
+      const end = buf.indexOf('\n\n');
+      if (end === -1) break;
+      const frame = buf.slice(0, end);
+      buf = buf.slice(end + 2);
+      if (!/^event: sample$/m.test(frame)) continue;
+      const data = (/^data: (.*)$/m.exec(frame) || [])[1];
+      if (data) samples.push(JSON.parse(data));
+    }
+  }
+  ctrl.abort();
+  return samples;
+}
+
+test('sysload stream serves samples while subscribed; refcount starts/stops the sampler', async () => {
+  const s = await startServer({ env: { BC_SYSLOAD_MS: '50' } });
+  try {
+    // closed panel = zero cost: no subscribers, not sampling
+    let st = (await s.api('GET', '/api/status')).body;
+    assert.deepEqual(st.sysload, { subscribers: 0, sampling: false });
+
+    // subscribe → samples flow, and the probe flips on
+    const streaming = readSamples(s.base, 2);
+    // poll the probe while the stream is open
+    let on = null;
+    for (let i = 0; i < 50 && !(on && on.subscribers === 1); i++) {
+      on = (await s.api('GET', '/api/status')).body.sysload;
+      await sleep(20);
+    }
+    assert.equal(on.subscribers, 1);
+    assert.equal(on.sampling, true);
+
+    const samples = await streaming;
+    assert.ok(samples.length >= 2, 'got ' + samples.length + ' samples');
+    const sm = samples[0];
+    // shape: machine numbers present (real /proc on Linux; graceful zeros
+    // elsewhere), no live agents on a fresh board, containers count or null
+    assert.equal(typeof sm.ts, 'string');
+    assert.equal(typeof sm.machine.cpuPct, 'number');
+    assert.equal(typeof sm.machine.memTotalBytes, 'number');
+    assert.equal(typeof sm.machine.diskTotalBytes, 'number');
+    assert.deepEqual(sm.entities, []);
+    assert.ok(sm.containers === null || typeof sm.containers === 'number');
+
+    // last subscriber gone → the sampler stops (allow the close to propagate)
+    let off = null;
+    for (let i = 0; i < 100 && !(off && off.subscribers === 0); i++) {
+      off = (await s.api('GET', '/api/status')).body.sysload;
+      await sleep(20);
+    }
+    assert.deepEqual(off, { subscribers: 0, sampling: false });
+  } finally {
+    await s.stop();
+  }
+});
+
+test('two subscribers: one sampler; dropping one keeps it, dropping both stops it', async () => {
+  const s = await startServer({ env: { BC_SYSLOAD_MS: '50' } });
+  try {
+    const a = new AbortController();
+    const b = new AbortController();
+    const ra = await fetch(s.base + '/api/sysload/stream', { signal: a.signal });
+    const rb = await fetch(s.base + '/api/sysload/stream', { signal: b.signal });
+    ra.body.getReader(); rb.body.getReader(); // hold the connections open
+    let st = null;
+    for (let i = 0; i < 50 && !(st && st.subscribers === 2); i++) {
+      st = (await s.api('GET', '/api/status')).body.sysload;
+      await sleep(20);
+    }
+    assert.equal(st.subscribers, 2);
+    assert.equal(st.sampling, true);
+
+    a.abort();
+    for (let i = 0; i < 100 && !(st && st.subscribers === 1); i++) {
+      st = (await s.api('GET', '/api/status')).body.sysload;
+      await sleep(20);
+    }
+    assert.equal(st.subscribers, 1);
+    assert.equal(st.sampling, true); // one viewer left — still sampling
+
+    b.abort();
+    for (let i = 0; i < 100 && !(st && st.subscribers === 0); i++) {
+      st = (await s.api('GET', '/api/status')).body.sysload;
+      await sleep(20);
+    }
+    assert.deepEqual(st, { subscribers: 0, sampling: false });
+  } finally {
+    await s.stop();
+  }
+});

--- a/test/sysload.test.js
+++ b/test/sysload.test.js
@@ -1,0 +1,227 @@
+'use strict';
+// sysload module (server/sysload.js): /proc parsing on fixture trees, process-
+// tree attribution + summing, sampler refcount, docker-absent grace. No real
+// /proc, tmux, or docker anywhere — every environmental read is injected.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const {
+  createSampler, parseCpuTotals, parseMeminfo, parsePidStat, readProcTable, descendants,
+} = require('../server/sysload.js');
+
+// ---------- fixture /proc builder ----------
+// procFixture(dir, { cpu: [total ticks split], pids: {pid: {ppid, ticks, rssKb}} })
+// writes stat, meminfo and per-pid stat/status files the module's readers parse.
+function writeProc(dir, opts) {
+  const busy = opts.busyTicks != null ? opts.busyTicks : 1000;
+  const idle = opts.idleTicks != null ? opts.idleTicks : 9000;
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'stat'),
+    'cpu  ' + busy + ' 0 0 ' + idle + ' 0 0 0 0 0 0\n'
+    + 'cpu0 0 0 0 0 0 0 0 0 0 0\ncpu1 0 0 0 0 0 0 0 0 0 0\n'
+    + 'intr 0\nctxt 0\n');
+  fs.writeFileSync(path.join(dir, 'meminfo'),
+    'MemTotal:       16384000 kB\nMemFree:         2000000 kB\nMemAvailable:    8192000 kB\n');
+  for (const [pid, p] of Object.entries(opts.pids || {})) {
+    const d = path.join(dir, pid);
+    fs.mkdirSync(d, { recursive: true });
+    // field layout: pid (comm) state ppid pgrp session tty tpgid flags min cmin maj cmaj utime stime ...
+    fs.writeFileSync(path.join(d, 'stat'),
+      pid + ' (proc with) spaces) S ' + p.ppid + ' 1 1 0 -1 0 0 0 0 0 '
+      + p.ticks + ' 0 0 0 20 0 1 0 100 1000000 500 0\n');
+    fs.writeFileSync(path.join(d, 'status'),
+      'Name:\tx\nPid:\t' + pid + '\nPPid:\t' + p.ppid + '\nVmRSS:\t' + (p.rssKb || 0) + ' kB\n');
+  }
+}
+
+const STATFS = () => ({ bsize: 4096, blocks: 1000000, bfree: 250000, bavail: 250000 });
+
+function tmpProc() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-sysload-'));
+}
+
+// ---------- pure parsers ----------
+
+test('parseCpuTotals: aggregate line + core count', () => {
+  const t = parseCpuTotals('cpu  100 5 50 800 20 0 5 10 0 0\ncpu0 1 2 3 4 5 6 7 8 0 0\ncpu1 1 2 3 4 5 6 7 8 0 0\n');
+  assert.equal(t.totalTicks, 990);
+  assert.equal(t.idleTicks, 820); // idle + iowait
+  assert.equal(t.cores, 2);
+});
+
+test('parseMeminfo: kB lines to bytes; missing keys read zero', () => {
+  const m = parseMeminfo('MemTotal:       1000 kB\nMemAvailable:    400 kB\n');
+  assert.equal(m.memTotalBytes, 1000 * 1024);
+  assert.equal(m.memAvailBytes, 400 * 1024);
+  assert.deepEqual(parseMeminfo(''), { memTotalBytes: 0, memAvailBytes: 0 });
+});
+
+test('parsePidStat: survives spaces and parens in comm', () => {
+  const st = parsePidStat('42 (tmux: server) (x)) R 7 1 1 0 -1 0 0 0 0 0 30 12 0 0 20 0 1 0 100 1 1 0');
+  assert.equal(st.ppid, 7);
+  assert.equal(st.ticks, 42);
+  assert.equal(parsePidStat('garbage'), null);
+});
+
+test('readProcTable + descendants: fabricated tree walks transitively', () => {
+  const dir = tmpProc();
+  try {
+    writeProc(dir, { pids: {
+      100: { ppid: 1, ticks: 10 },
+      101: { ppid: 100, ticks: 20 },
+      102: { ppid: 101, ticks: 30 },
+      200: { ppid: 1, ticks: 40 },
+    } });
+    const table = readProcTable(dir);
+    assert.equal(table.size, 4);
+    const tree = descendants(table, [100]);
+    assert.deepEqual([...tree].sort((a, b) => a - b), [100, 101, 102]); // 200 is unrelated
+    assert.deepEqual([...descendants(table, [999])], []); // dead root: empty, no throw
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+// ---------- sampler ----------
+
+// exec stub: tmux answers with the given pane lines; docker answers (or rejects).
+function execStub({ panes = {}, docker = null } = {}) {
+  const calls = [];
+  const fn = (cmd, args) => {
+    calls.push([cmd, ...args]);
+    if (cmd === 'tmux') {
+      const session = args[args.indexOf('-t') + 1];
+      if (panes[session]) return Promise.resolve(panes[session]);
+      return Promise.reject(new Error('no server running'));
+    }
+    if (cmd === 'docker') {
+      if (docker === null) return Promise.reject(new Error('docker: not found'));
+      return Promise.resolve(docker);
+    }
+    return Promise.reject(new Error('unexpected ' + cmd));
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+function collectSamples(sampler, n) {
+  return new Promise((resolve) => {
+    const got = [];
+    const unsub = sampler.subscribe((s) => {
+      got.push(s);
+      if (got.length >= n) { unsub(); resolve(got); }
+    });
+  });
+}
+
+test('sampler: machine + per-entity CPU/RSS from two samples, heaviest first', async () => {
+  const dir = tmpProc();
+  try {
+    // session bc-x-lt-ada: window main (lieutenant, pid 200), window w-c1
+    // (worker, pid 100 with children 101,102)
+    writeProc(dir, { busyTicks: 1000, idleTicks: 9000, pids: {
+      100: { ppid: 1, ticks: 100, rssKb: 1000 },
+      101: { ppid: 100, ticks: 100, rssKb: 2000 },
+      102: { ppid: 101, ticks: 100, rssKb: 3000 },
+      200: { ppid: 1, ticks: 100, rssKb: 500 },
+    } });
+    const exec = execStub({
+      panes: { 'bc-x-lt-ada': 'main\t200\nw-c1\t100\n' },
+      docker: 'abc\ndef\n',
+    });
+    const sampler = createSampler({
+      procRoot: dir, diskPath: '/', statfs: STATFS, execFileImpl: exec, intervalMs: 40,
+      targets: () => [
+        { kind: 'worker', id: 'c1', label: 'Card One', session: 'bc-x-lt-ada', window: 'w-c1' },
+        { kind: 'lieutenant', id: 'ada', label: 'Ada', session: 'bc-x-lt-ada', window: null },
+      ],
+    });
+
+    // between sample 1 and 2: worker tree burns 100 ticks (1 CPU-second),
+    // lieutenant 10; machine busy +100 of +1000 total
+    const first = new Promise((r) => setTimeout(() => {
+      writeProc(dir, { busyTicks: 1100, idleTicks: 9900, pids: {
+        100: { ppid: 1, ticks: 120, rssKb: 1000 },
+        101: { ppid: 100, ticks: 130, rssKb: 2000 },
+        102: { ppid: 101, ticks: 150, rssKb: 3000 },
+        200: { ppid: 1, ticks: 110, rssKb: 500 },
+      } });
+      r();
+    }, 10));
+    const [s1, s2] = await collectSamples(sampler, 2);
+    await first;
+
+    // sample 1: baseline — everything 0% but structure complete
+    assert.equal(s1.machine.cpuPct, 0);
+    assert.equal(s1.machine.cores, 2);
+    assert.equal(s1.machine.memTotalBytes, 16384000 * 1024);
+    assert.equal(s1.machine.memUsedBytes, (16384000 - 8192000) * 1024);
+    assert.equal(s1.machine.diskTotalBytes, 1000000 * 4096);
+    assert.equal(s1.machine.diskUsedBytes, 750000 * 4096);
+    assert.equal(s1.containers, 2);
+    assert.equal(s1.entities.length, 2);
+
+    // sample 2: real deltas — machine 100 busy / 1000 total = 10%
+    assert.equal(s2.machine.cpuPct, 10);
+    const worker = s2.entities.find((e) => e.kind === 'worker');
+    const lt = s2.entities.find((e) => e.kind === 'lieutenant');
+    assert.equal(worker.id, 'c1');
+    assert.equal(worker.label, 'Card One');
+    assert.equal(worker.pids, 3); // 100 + descendants 101, 102
+    assert.equal(worker.rssBytes, (1000 + 2000 + 3000) * 1024);
+    assert.ok(worker.cpuPct > 0, 'worker burned ticks: ' + worker.cpuPct);
+    assert.equal(lt.pids, 1);
+    assert.equal(lt.rssBytes, 500 * 1024);
+    assert.ok(worker.cpuPct > lt.cpuPct, 'heaviest first');
+    assert.equal(s2.entities[0].kind, 'worker'); // sorted heaviest-first
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('sampler: docker absent → containers null; tmux gone → no entities, no crash', async () => {
+  const dir = tmpProc();
+  try {
+    writeProc(dir, { pids: {} });
+    const sampler = createSampler({
+      procRoot: dir, statfs: STATFS, intervalMs: 40,
+      execFileImpl: execStub({ panes: {}, docker: null }),
+      targets: () => [{ kind: 'lieutenant', id: 'ada', label: 'Ada', session: 'bc-gone', window: null }],
+    });
+    const [s] = await collectSamples(sampler, 1);
+    assert.equal(s.containers, null);
+    assert.deepEqual(s.entities, []);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('sampler refcount: starts on first subscriber, stops at zero', async () => {
+  const dir = tmpProc();
+  try {
+    writeProc(dir, { pids: {} });
+    const sampler = createSampler({
+      procRoot: dir, statfs: STATFS, intervalMs: 20,
+      execFileImpl: execStub({ docker: '' }), targets: () => [],
+    });
+    assert.deepEqual(sampler.stats(), { subscribers: 0, sampling: false });
+
+    let n1 = 0;
+    const unsub1 = sampler.subscribe(() => n1++);
+    assert.equal(sampler.stats().subscribers, 1);
+    assert.equal(sampler.stats().sampling, true);
+    await new Promise((r) => setTimeout(r, 80));
+    assert.ok(n1 >= 2, 'loop is sampling: ' + n1);
+
+    // a second subscriber gets the last sample replayed immediately
+    let n2 = 0;
+    const unsub2 = sampler.subscribe(() => n2++);
+    assert.ok(n2 >= 1, 'late joiner painted from the last sample');
+    assert.equal(sampler.stats().subscribers, 2);
+
+    unsub1();
+    assert.equal(sampler.stats().sampling, true); // one viewer left — keep going
+    unsub2();
+    assert.deepEqual(sampler.stats(), { subscribers: 0, sampling: false });
+    const after = n1 + n2;
+    await new Promise((r) => setTimeout(r, 60));
+    assert.equal(n1 + n2, after, 'no samples after the last unsubscribe');
+    unsub1(); // double-unsubscribe is a harmless no-op
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -902,6 +902,43 @@ a.a-uri { color: var(--accent); }
 .tile .t-peek:hover { color: var(--accent); background: var(--accent-soft); }
 @media (hover: none) { .tile .t-peek { opacity: .6; } } /* touch: always visible */
 
+/* ---------- machine-load monitor (⚙️ → monitoring) ---------- */
+#mon-overlay {
+  position: fixed; inset: 0; z-index: 92; background: rgba(4, 7, 11, .6);
+  display: flex; align-items: center; justify-content: center; backdrop-filter: blur(2px);
+}
+#mon-modal {
+  width: min(440px, calc(100vw - 28px)); max-height: 86vh; display: flex; flex-direction: column;
+  background: var(--bg2); border: 1px solid var(--line2); border-radius: 14px;
+  box-shadow: var(--shadow); animation: pop-in .15s ease-out; overflow: hidden;
+}
+#mon-body { flex: 1; min-height: 0; overflow-y: auto; padding: 12px 14px; display: flex; flex-direction: column; gap: 10px; }
+#mon-machine { display: flex; flex-direction: column; gap: 6px; }
+.mon-row { display: flex; align-items: center; gap: 8px; font-size: 12px; }
+.mon-lbl { flex: none; width: 34px; color: var(--faint); font-size: 10.5px; text-transform: uppercase; letter-spacing: 1px; }
+.mon-bar {
+  flex: 1; min-width: 0; height: 7px; border-radius: 4px; overflow: hidden;
+  background: var(--panel3); border: 1px solid var(--line2);
+}
+.mon-bar .ctx-fill { display: block; height: 100%; border-radius: 3px; background: var(--ok); transition: width .4s ease; }
+.mon-bar .ctx-fill.yellow { background: var(--warn); }
+.mon-bar .ctx-fill.red { background: var(--danger); }
+.mon-val { flex: none; color: var(--dim); font-family: var(--mono); font-size: 11px; white-space: nowrap; }
+.mon-sec { font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px; color: var(--faint); margin-top: 2px; }
+#mon-agents { display: flex; flex-direction: column; gap: 3px; }
+.mon-agent {
+  display: flex; align-items: center; gap: 8px; font-size: 12.5px;
+  padding: 4px 6px; border-radius: 7px; background: var(--panel);
+}
+.mon-kind { flex: none; width: 18px; text-align: center; }
+.mon-name { flex: 1; min-width: 0; color: var(--text); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mon-cpu { flex: none; width: 52px; text-align: right; color: var(--dim); font-family: var(--mono); font-size: 11.5px; }
+.mon-rss { flex: none; width: 52px; text-align: right; color: var(--faint); font-family: var(--mono); font-size: 11.5px; }
+.mon-empty { color: var(--faint); font-size: 12px; text-align: center; padding: 10px 0; }
+#mon-containers { color: var(--dim); font-size: 12px; }
+#mon-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#mon-open:hover { color: var(--accent); border-color: var(--accent2); }
+
 /* context bar (chat header, switcher rows, Working tiles): used ÷ window from agentStatus.
    Green → yellow → red; red ≈ auto-compact territory (~80%). Rendered only
    when status data exists — graceful absence, like avatars. */

--- a/ui/index.html
+++ b/ui/index.html
@@ -57,6 +57,10 @@
     </div>
     <div id="ns-list"></div>
   </div>
+  <div class="sp-title">monitoring</div>
+  <div class="sp-row">
+    <button id="mon-open" title="live machine & per-agent load (samples only while open)">📈 machine load</button>
+  </div>
   <div class="sp-title">labels</div>
   <div id="lm-list"></div>
   <form id="lm-new">
@@ -223,6 +227,24 @@
     </div>
     <pre id="pane-body"></pre>
     <div id="pane-msg" hidden></div>
+  </div>
+</div>
+
+<!-- machine-load monitor (⚙️ → monitoring): on-demand, samples only while open -->
+<div id="mon-overlay" hidden>
+  <div id="mon-modal">
+    <div class="pane-head">
+      <span class="pane-live" id="mon-live" title="not sampling"></span>
+      <span class="pane-live-lbl">live</span>
+      <span class="pane-title">machine load</span>
+      <button id="mon-close" title="close">✕</button>
+    </div>
+    <div id="mon-body">
+      <div id="mon-machine"></div>
+      <div class="mon-sec">agents</div>
+      <div id="mon-agents"></div>
+      <div id="mon-containers" hidden></div>
+    </div>
   </div>
 </div>
 

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -10,6 +10,7 @@ import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
 import { renderLtSwitcher, ltSwitcherOpen, closeLtSwitcher, appearancePopoverOpen, closeAppearancePopover } from './ltswitcher.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
+import { openMonitor, closeMonitor, monitorOpen } from './monitor.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import './resize.js'; // draggable side-panel widths
@@ -79,6 +80,12 @@ document.addEventListener('click', (e) => {
     gearBtn.classList.remove('on');
   }
 });
+// ⚙️ → monitoring: the settings row hands off to the monitor panel
+document.getElementById('mon-open').onclick = () => {
+  spEl.hidden = true;
+  gearBtn.classList.remove('on');
+  openMonitor();
+};
 
 // ---------- mobile tabs ----------
 const tabChat = document.getElementById('tab-chat');
@@ -109,6 +116,7 @@ document.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
     if (artifactOpen()) closeArtifact();
     else if (paneOpen()) closePane();
+    else if (monitorOpen()) closeMonitor();
     else if (newCardOpen()) closeNewCard();
     else if (newLieutenantOpen()) closeNewLieutenant();
     else if (pickerIsOpen()) closeLabelPicker();

--- a/ui/js/monitor.js
+++ b/ui/js/monitor.js
@@ -1,0 +1,92 @@
+// monitor.js — the ⚙️ → monitoring panel: live machine + per-agent load.
+// On-demand by design: opening the panel opens an EventSource on
+// /api/sysload/stream (a dedicated per-viewer SSE — never the board push);
+// the server samples only while someone is subscribed. Closing the panel —
+// ✕ / Esc / tap-out — closes the EventSource and the refcount drops; a hidden
+// tab drops it too (visibilitychange) and reconnects when the tab returns.
+import { esc } from './util.js';
+
+const overlay = document.getElementById('mon-overlay');
+const liveEl = document.getElementById('mon-live');
+const machineEl = document.getElementById('mon-machine');
+const agentsEl = document.getElementById('mon-agents');
+const containersEl = document.getElementById('mon-containers');
+let es = null;
+
+function setLive(on) {
+  liveEl.classList.toggle('on', on);
+  liveEl.title = on ? 'sampling every ~2s' : 'not sampling';
+}
+
+// bytes → short human size, GB-aware (RAM/disk live up there)
+function gb(n) {
+  n = Number(n) || 0;
+  if (n >= 1024 ** 3) return (n / 1024 ** 3).toFixed(n < 10 * 1024 ** 3 ? 1 : 0) + 'G';
+  if (n >= 1024 ** 2) return Math.round(n / 1024 ** 2) + 'M';
+  return Math.round(n / 1024) + 'K';
+}
+function pctCls(pct) { return pct >= 80 ? ' red' : pct >= 60 ? ' yellow' : ''; }
+function barHtml(label, pct, val) {
+  const p = Math.max(0, Math.min(100, Math.round(pct)));
+  return '<div class="mon-row"><span class="mon-lbl">' + esc(label) + '</span>'
+    + '<span class="mon-bar"><span class="ctx-fill' + pctCls(p) + '" style="width:' + p + '%"></span></span>'
+    + '<span class="mon-val">' + esc(val) + '</span></div>';
+}
+
+function render(s) {
+  const m = s.machine || {};
+  const memPct = m.memTotalBytes ? (m.memUsedBytes / m.memTotalBytes) * 100 : 0;
+  const diskPct = m.diskTotalBytes ? (m.diskUsedBytes / m.diskTotalBytes) * 100 : 0;
+  machineEl.innerHTML =
+    barHtml('cpu', m.cpuPct || 0, (m.cpuPct || 0).toFixed(0) + '%' + (m.cores ? ' · ' + m.cores + ' cores' : ''))
+    + barHtml('ram', memPct, gb(m.memUsedBytes) + ' / ' + gb(m.memTotalBytes))
+    + barHtml('disk', diskPct, gb(m.diskUsedBytes) + ' / ' + gb(m.diskTotalBytes));
+
+  const ents = s.entities || [];
+  agentsEl.innerHTML = !ents.length
+    ? '<div class="mon-empty">no live workers or lieutenants</div>'
+    : ents.map((e) =>
+      '<div class="mon-agent"><span class="mon-kind">' + (e.kind === 'worker' ? '🔨' : '🎖️') + '</span>'
+      + '<span class="mon-name" title="' + esc(e.label) + ' · ' + e.pids + ' process' + (e.pids === 1 ? '' : 'es') + '">' + esc(e.label) + '</span>'
+      + '<span class="mon-cpu">' + (e.cpuPct || 0).toFixed(1) + '%</span>'
+      + '<span class="mon-rss">' + gb(e.rssBytes) + '</span></div>').join('');
+
+  // container count: docker absent → null → the row stays hidden
+  containersEl.hidden = !(typeof s.containers === 'number');
+  if (typeof s.containers === 'number') {
+    containersEl.textContent = '🐳 ' + s.containers + ' container' + (s.containers === 1 ? '' : 's') + ' running';
+  }
+}
+
+function stop() { if (es) { es.close(); es = null; } setLive(false); }
+function connect() {
+  stop();
+  es = new EventSource('/api/sysload/stream');
+  es.addEventListener('sample', (e) => {
+    let s;
+    try { s = JSON.parse(e.data); } catch (err) { return; }
+    render(s);
+    setLive(true);
+  });
+  es.onerror = () => setLive(false); // EventSource reconnects on its own
+}
+
+export function openMonitor() {
+  machineEl.innerHTML = '<div class="mon-empty">sampling…</div>';
+  agentsEl.innerHTML = '';
+  containersEl.hidden = true;
+  overlay.hidden = false;
+  connect();
+}
+export function closeMonitor() { stop(); overlay.hidden = true; }
+export function monitorOpen() { return !overlay.hidden; }
+
+// a hidden tab must not keep the server sampling — drop the stream, resume on return
+document.addEventListener('visibilitychange', () => {
+  if (!monitorOpen()) return;
+  if (document.hidden) stop();
+  else connect();
+});
+
+document.getElementById('mon-close').onclick = closeMonitor;
+overlay.onclick = (e) => { if (e.target === overlay) closeMonitor(); };


### PR DESCRIPTION
An on-demand monitoring panel opened from inside the ⚙️ settings panel (a "monitoring" row — no new topbar button). Core principle: **zero cost when closed** — no sampling loop exists until a viewer opens the panel; when the last viewer disconnects, sampling stops server-side.

## What's in the panel
1. **Machine**: CPU% (aggregate, /proc/stat delta) · RAM used/total (/proc/meminfo) · disk used/total for the workspace volume (statfs). Zero deps, Linux-first, graceful zeros elsewhere.
2. **Per-agent rows** (the headline): for each live worker and lieutenant session, tmux pane pids → /proc ppid-tree descendants → summed CPU% + VmRSS, heaviest first.
3. **Container count**: `docker ps -q` via execFile; docker absent → row hidden.

Read-only and dumb — no thresholds, alerts, history, or kill buttons (out of v1 per spec).

## How
- `server/sysload.js` — sampling + process-tree walk, server.js wiring stays thin. Every environmental read (procRoot, statfs, execFile, targets, interval) is injectable, so tests run on fixture /proc trees and stubbed tmux/docker.
- `GET /api/sysload/stream` — dedicated SSE (never the board push), refcounted: first subscriber starts the ~2s loop (`BC_SYSLOAD_MS` tunes), last disconnect stops it and drops delta state. Probe on `/api/status` as `sysload: {subscribers, sampling}`.
- CPU% is delta-based; pids new to a sample contribute 0 that round (no whole-lifetime spikes).
- `ui/js/monitor.js` + modal in the pane-drawer visual language; ✕ / Esc / tap-out closes the EventSource, and a hidden tab drops the stream too (reconnects on return).

## Screenshots
| desktop | mobile 390px |
|---|---|
| ![desktop](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-machine-load-monitor/shots/monitor-desktop.png) | ![mobile](https://raw.githubusercontent.com/tonylampada/bridge-commander/shots/bc-machine-load-monitor/shots/monitor-mobile.png) |

(worker row at 82% is a synthetic CPU burner in a `w-…` tmux window — verified live end-to-end: open → sampling:true, samples flow with real attribution; close → subscribers 0, sampling stops)

## Tests
`node --test test/*.test.js harness/test/*.test.js` → **323 pass** (314 before, +9 new: /proc parsers on fixtures, process-tree summing + attribution, sampler refcount start/stop, docker-absent grace, SSE endpoint + refcount probe black-box).

Note: static UI files carry no cache headers — hard-refresh the board after restarting the server to pick up the new panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)