### PR TITLE
Fix: PR-watch archives a stack card on the first merge

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2007,10 +2007,11 @@ if (Number.isInteger(SUPERVISE_MS) && SUPERVISE_MS > 0) setInterval(superviseTic
 
 // ---------- PR watch (F6: merged PR ⇒ archive + release, no agent turn) ----------
 // Every ~2min: for every card whose `prs` attribute holds an open URL, ask gh.
-// MERGED -> release the worktree (only when clean — uncommitted work is never
-// discarded), archive the card (reason merged: the landed level-1 event), and
-// queue a pr-merged item to the owner. CLOSED (unmerged) -> mark the state and
-// tell the owner; the card stays. gh failures leave state untouched.
+// MERGED -> a pr-merged event + owner item per PR that landed; then, ONLY when
+// no PR of the card is left open (a stack merges one at a time), release the
+// worktree (only when clean — uncommitted work is never discarded) and archive
+// the card (reason merged: the landed level-1 event). CLOSED (unmerged) -> mark
+// the state and tell the owner; the card stays. gh failures leave state untouched.
 const PRWATCH_MS = process.env.BC_PRWATCH_INTERVAL_MS !== undefined
   ? parseInt(process.env.BC_PRWATCH_INTERVAL_MS, 10) : 120000;
 const GH_CMD = process.env.BC_GH_CMD || 'gh'; // injectable for tests
@@ -2030,13 +2031,13 @@ async function prWatchTick() {
     for (const card of [...board.cards]) {
       const prs = card.attributes && card.attributes.prs;
       if (!Array.isArray(prs) || !prs.some((p) => p && p.state === 'open' && p.url)) continue;
-      let merged = null;
+      const merged = []; // every PR of this card that landed in THIS tick
       let changed = false;
       for (const pr of prs) {
         if (!pr || pr.state !== 'open' || !pr.url) continue;
         const st = await ghPrState(pr.url);
         if (!st || !st.state) continue;
-        if (st.state === 'MERGED') { pr.state = 'merged'; merged = pr; changed = true; }
+        if (st.state === 'MERGED') { pr.state = 'merged'; merged.push(pr); changed = true; }
         else if (st.state === 'CLOSED') {
           pr.state = 'closed';
           changed = true;
@@ -2045,12 +2046,20 @@ async function prWatchTick() {
         }
       }
       if (!changed) continue;
-      if (merged) {
+      // one signal per PR that landed — a stack can flip several between polls
+      for (const pr of merged) {
+        card.events.push(mkEvent({ text: 'PR merged: ' + pr.url, actor: 'server' }, { kind: 'pr-merged' }));
+        queuePush(card.owner, { kind: 'pr-merged', card: card.id, text: pr.url });
+      }
+      // a stack card only finishes when nothing is left open: a partial merge
+      // keeps the card on the board, the worktree alive and the hooks unfired.
+      const anyOpenLeft = prs.some((p) => p && p.state === 'open');
+      if (merged.length && !anyOpenLeft) {
         const w = findWorker(card.id);
         const project = findProject(w ? w.project : String((card.attributes && card.attributes.repo) || ''));
         const wtRec = w ? w.worktree
           : (card.attributes && card.attributes.worktree ? { path: card.attributes.worktree, tool: 'git' } : null);
-        let note = merged.url;
+        let note = merged.map((p) => p.url).join(' ');
         // card-archived hooks run — and finish or time out — BEFORE the
         // worktree release: a hook may need paths inside $BC_WORKTREE.
         await fireHooks('card-archived', card, w, { boardLevel: true });
@@ -2061,7 +2070,6 @@ async function prWatchTick() {
             console.error(now() + ' worktree not released for ' + card.id + ': ' + rel.reason);
           }
         }
-        queuePush(card.owner, { kind: 'pr-merged', card: card.id, text: merged.url });
         archiveCard(card, { reason: 'merged', note, actor: 'server' }); // landed — the level-1 bell
       }
       saveBoard(); broadcast();

--- a/test/prwatch.test.js
+++ b/test/prwatch.test.js
@@ -158,6 +158,91 @@ test('merged PR with a DIRTY worktree: card archived, worktree left in place (ne
   } finally { await teardown(); }
 });
 
+// ---------- stacks: a card tracking several PRs finishes only when none is open ----------
+
+function shHook(ws, event, name, script) {
+  const dir = path.join(ws, '.bridge-commander', 'hooks', event);
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(dir, name);
+  fs.writeFileSync(file, '#!/bin/sh\n' + script + '\n');
+  fs.chmodSync(file, 0o755);
+}
+
+const PR_A = 'https://github.com/acme/proj/pull/101';
+const PR_B = 'https://github.com/acme/proj/pull/102';
+
+test('stack card: the first merge does NOT archive — card, worktree and hooks all stay put', async () => {
+  const { s, root, gh, teardown } = await boot();
+  try {
+    const archived = path.join(root, 'archived.out');
+    shHook(s.dir, 'card-archived', 'mark.sh', 'echo fired >> ' + JSON.stringify(archived));
+    await s.api('POST', '/api/cards', withOwner({ title: 'Stack', id: 'stack', attributes: { repo: 'proj' } }));
+    const w = (await s.api('POST', '/api/cards/stack/start', { harness: 'fake' })).body.worker;
+    gh.setState(PR_A, 'OPEN'); gh.setState(PR_B, 'OPEN');
+    await s.api('POST', '/api/cards/stack/worker/done', { outcome: 'PRs: ' + PR_A + ' and ' + PR_B });
+
+    // --- the base PR lands; the tip is still open ---
+    gh.setState(PR_A, 'MERGED');
+    // the event lands at the end of the tick — poll it, not the mid-tick pr.state
+    await until('pr-merged event for the base PR', async () => {
+      const c = (await s.api('GET', '/api/cards/stack')).body;
+      return c.events && c.events.some((e) => e.kind === 'pr-merged');
+    });
+    const card = (await s.api('GET', '/api/cards/stack')).body;
+    assert.strictEqual(card.column, 'working', 'card stays — a PR is still open');
+    assert.strictEqual(card.attributes.prs[0].state, 'merged');
+    assert.strictEqual(card.attributes.prs[1].state, 'open');
+    const ev = card.events.filter((e) => e.kind === 'pr-merged');
+    assert.strictEqual(ev.length, 1, 'one pr-merged event, for the PR that landed');
+    assert.strictEqual(ev[0].level, 2);
+    assert.match(ev[0].text, /pull\/101/);
+    const items = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items;
+    assert.ok(items.some((i) => i.kind === 'pr-merged' && i.card === 'stack' && i.text === PR_A));
+    assert.ok(fs.existsSync(w.worktree.path), 'worktree untouched on a partial merge');
+    assert.strictEqual((await s.api('GET', '/api/status')).body.workers, 1);
+    assert.ok(!fs.existsSync(archived), 'no card-archived hooks on a partial merge');
+
+    // --- the tip lands too: nothing open left, so now it archives ---
+    gh.setState(PR_B, 'MERGED');
+    await until('card archived once the stack is fully merged', async () =>
+      (await s.api('GET', '/api/cards/stack')).status === 404);
+    const rec = (await s.api('GET', '/api/archive')).body.archive.find((r) => r.card.id === 'stack');
+    assert.strictEqual(rec.reason, 'merged');
+    assert.match(rec.note, /pull\/102/);
+    assert.strictEqual(rec.card.events.filter((e) => e.kind === 'pr-merged').length, 2);
+    const b = (await s.api('GET', '/api/board')).body;
+    const landed = b.events.find((e) => e.kind === 'landed' && e.card === 'stack');
+    assert.ok(landed, 'landed event');
+    assert.strictEqual(landed.level, 1);
+    assert.ok(!fs.existsSync(w.worktree.path), 'worktree released once nothing is open');
+    await until('card-archived hooks fired', async () => fs.existsSync(archived));
+  } finally { await teardown(); }
+});
+
+test('stack card: two PRs merging in the same tick — an event each, one archive', async () => {
+  const { s, gh, teardown } = await boot();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Both', id: 'both', attributes: { repo: 'proj' } }));
+    gh.setState(PR_A, 'OPEN'); gh.setState(PR_B, 'OPEN');
+    await s.api('POST', '/api/cards/both/start', { harness: 'fake' });
+    await s.api('POST', '/api/cards/both/worker/done', { outcome: 'PRs: ' + PR_A + ' ' + PR_B });
+    // both flip between two polls
+    gh.setState(PR_A, 'MERGED'); gh.setState(PR_B, 'MERGED');
+
+    await until('card archived', async () => (await s.api('GET', '/api/cards/both')).status === 404);
+    const rec = (await s.api('GET', '/api/archive')).body.archive.find((r) => r.card.id === 'both');
+    assert.strictEqual(rec.reason, 'merged');
+    const ev = rec.card.events.filter((e) => e.kind === 'pr-merged');
+    assert.deepStrictEqual(ev.map((e) => e.text.replace(/^PR merged: /, '')), [PR_A, PR_B]);
+    const items = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items;
+    assert.deepStrictEqual(
+      items.filter((i) => i.kind === 'pr-merged' && i.card === 'both').map((i) => i.text).sort(),
+      [PR_A, PR_B]);
+    const b = (await s.api('GET', '/api/board')).body;
+    assert.strictEqual(b.events.filter((e) => e.kind === 'landed' && e.card === 'both').length, 1);
+  } finally { await teardown(); }
+});
+
 test('gh failure leaves state untouched (no archive, still open)', async () => {
   const { s, teardown } = await boot();
   try {


### PR DESCRIPTION
`prWatchTick` archived the card, released the worktree and fired the `card-archived` hooks as soon as **any** tracked PR merged. A card holding a stack (`attributes.prs` with several entries) was closed out with the other PRs still open — hit for real on `annotation-thumb-stack`, where merging only the base PR archived the whole card.

## Change (`server/server.js`)

- The finish is gated on `anyOpenLeft`, evaluated after the state-refresh loop. Archive + worktree release + `card-archived` hooks run only when nothing is left open.
- A **partial merge** keeps the card on the board, the worktree alive, the hooks unfired.
- `merged` went from "the last PR of the tick" to an array of every PR that landed in it: one `pr-merged` level-2 card event + one `pr-merged` owner queue item **per PR**, in both branches. A stack whose PRs flip between two polls no longer loses signals.
- Archive note joins the URLs that landed.

CLOSED handling, single-PR cards (1 PR merged → nothing open → archives exactly as before) and the `!changed` fast path are untouched.

## Tests (`test/prwatch.test.js`)

- Stack card, base PR merges → card stays in Working, one `pr-merged` event + owner item, worktree present, no `card-archived` hook; then the tip merges → archived (reason merged, `landed` level 1), worktree released, hooks fired.
- Both PRs merging in the same tick → an event and an owner item each, a single archive.

Suite 255 → 257, all green.