### PR TITLE
Unified lieutenant conversation: merged chat stream, card chips, thread filter (playground-promoted)

### DIFF
--- a/dev/fixtures/board.json
+++ b/dev/fixtures/board.json
@@ -87,8 +87,12 @@
       "created": "T-864000", "lastTurnEnd": "T-120", "turns": 342,
       "ref": { "harness": "claude", "session": "bc-lt-monica", "cwd": "/fake/ws" },
       "chat": [
+        { "author": "user", "text": "monica, auth week: you own the oauth refresh and the hooks polish. Small PRs, as always.", "ts": "T-140500" },
+        { "author": "monica", "text": "Copy. Sequencing: hooks polish first (it unblocks the CI hook rex needs), oauth right behind it.", "ts": "T-140400" },
         { "author": "user", "text": "morning — status on the oauth card?", "ts": "T-7200" },
         { "author": "monica", "text": "Worker is mid-flight:\n\n- single-flight refresh **done**\n- retry-once path in progress\n- ETA for review: today\n\nI'll hand off with a PR link.", "ts": "T-7100" },
+        { "author": "user", "text": "nice. and don't let the hooks card rot in review", "ts": "T-6900" },
+        { "author": "monica", "text": "It won't — PR #54 is genuinely small. Ping me after your pass and I'll fold nits the same day.", "ts": "T-6850" },
         { "author": "monica", "text": "heads up — CI is green again ✅ (the coverage gate was counting fixtures, rex fixed the globs)", "ts": "T-300" }
       ]
     },
@@ -163,7 +167,11 @@
       "events": [
         { "seq": 10, "ts": "T-172800", "level": 2, "kind": "created", "text": "card created", "actor": "user" }
       ],
-      "thread": []
+      "thread": [
+        { "author": "user", "text": "when this one starts: keep the wake TTL semantics exactly — the backoff change must be invisible to the queue tests", "ts": "T-96000" },
+        { "author": "monica", "text": "Noted. It stays parked until oauth lands; I'll fold the jitter-cap discussion into the worker brief.", "ts": "T-95500" }
+      ],
+      "threadStart": "T-96000"
     },
     {
       "id": "voice-input-spike", "title": "Spike: voice input for the composer", "type": "investigation",
@@ -236,10 +244,12 @@
         { "seq": 46, "ts": "T-9000", "level": 2, "kind": "hook-ran", "text": "hook fmt-check ran clean", "actor": "bridge" }
       ],
       "thread": [
+        { "author": "user", "text": "brief looks good — remember: no refresh storms. Single-flight or nothing.", "ts": "T-84500" },
+        { "author": "monica", "text": "Single-flight IS the core of it. Worker spawning now on bc/oauth-refresh.", "ts": "T-84000" },
         { "author": "monica", "text": "Worker is mid-flight. Landed so far:\n\n- [x] refresh 5 min before expiry\n- [x] single-flight dedupe\n- [ ] retry-once after refresh\n\nPR #53 is up as a draft.", "ts": "T-15000" },
         { "author": "user", "text": "how's the retry-once path?", "ts": "T-60" }
       ],
-      "threadStart": "T-15000"
+      "threadStart": "T-84500"
     },
     {
       "id": "ci-sharding", "title": "Migrate CI to sharded tests", "type": "implementation",
@@ -311,9 +321,21 @@
         { "seq": 66, "ts": "T-5400", "level": 1, "kind": "handoff", "text": "ready for your review — PR #54", "actor": "monica" }
       ],
       "thread": [
+        { "author": "user", "text": "scope check: extraction only, or is the per-hook timeout in?", "ts": "T-129000" },
+        { "author": "monica", "text": "Both — the timeout is *why* we're extracting. Plan:\n\n1. pull the runner into its own module\n2. per-hook timeout (default 30s)\n3. stderr into the event text", "ts": "T-128500" },
+        { "author": "user", "text": "30s default is generous. make it 10", "ts": "T-127000" },
+        { "author": "monica", "text": "10s it is. Every workspace hook we ship finishes under 2s, so no migration pain.", "ts": "T-126800" },
+        { "author": "monica", "text": "Runner extracted, 14 call sites updated. Suite still green.", "ts": "T-88000" },
+        { "author": "user", "text": "did the worker-died hook keep its fire-and-forget semantics?", "ts": "T-87000" },
+        { "author": "monica", "text": "Yes — kill-path hooks stay detached; only card-lifecycle hooks get the timeout + stderr capture.", "ts": "T-86500" },
+        { "author": "monica", "text": "Timeout wired. A hook that blows the budget now lands a 🧨 hook-failed event carrying the tail of its stderr.", "ts": "T-45000" },
+        { "author": "user", "text": "show me the event text format", "ts": "T-44000" },
+        { "author": "monica", "text": "`hook deploy-notify timed out after 10s — stderr: connect ETIMEDOUT 10.0.0.7:443`\n\nTruncated at 200 chars, mono in the feed.", "ts": "T-43500" },
+        { "author": "user", "text": "good. squash the WIP commits before the PR", "ts": "T-20000" },
+        { "author": "monica", "text": "Squashed to 3 logical commits. Running the full suite once more, then PR.", "ts": "T-19000" },
         { "author": "monica", "text": "PR up: extracted the hook runner, 6 new tests. Screenshot of the new event chips attached. Diff is small, promise 🤞", "ts": "T-5400", "attachments": [{ "id": "att-shot1", "name": "board-screenshot.svg", "mime": "image/svg+xml", "size": 1650 }] }
       ],
-      "threadStart": "T-5400"
+      "threadStart": "T-129000"
     },
     {
       "id": "archive-sweep-cron", "title": "Archive sweep cron", "type": "implementation",
@@ -363,6 +385,8 @@
         "lieutenant:monica": "T-200",
         "lieutenant:rex": "T-49000",
         "card:voice-input-spike": "T-6000",
+        "card:refactor-queue-backoff": "T-90000",
+        "card:lifecycle-hooks-polish": "T-6000",
         "card:mega-spec": "T-100000",
         "card:oauth-token-refresh": "T-10000",
         "card:fix-flaky-sysload": "T-1000",

--- a/ui/app.css
+++ b/ui/app.css
@@ -129,6 +129,18 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg.user { align-self: flex-end; background: var(--user-bubble); border: 1px solid var(--user-line); border-bottom-right-radius: 4px; }
 .msg .ts { display: block; color: var(--faint); font-size: 11px; margin-top: 4px; font-family: var(--mono); }
 .msg .pre { white-space: pre-wrap; overflow-wrap: anywhere; }
+/* the card chip on a unified-stream bubble: which card thread this message
+   came from; clicking filters the chat to that thread + opens the card */
+.msg-chip {
+  display: block; width: fit-content; max-width: 100%; margin: 0 0 6px;
+  padding: 2px 9px; border-radius: 999px; border: 1px solid var(--line2);
+  background: var(--bg); color: var(--dim); font-size: 11px; line-height: 1.6;
+  cursor: pointer; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.msg-chip:hover { color: var(--text); border-color: var(--accent2); }
+.msg.cmd .msg-chip { flex: none; margin: 0; align-self: center; }
+.msg.typing .msg-chip { margin: 0 0 0 6px; }
+
 .msg.typing { display: flex; align-items: center; gap: 4px; }
 .msg.typing .tdot { width: 6px; height: 6px; border-radius: 50%; background: var(--dim); animation: typing-blink 1.2s infinite; }
 .msg.typing .tdot:nth-child(2) { animation-delay: .2s; }
@@ -391,6 +403,12 @@ body.resizing { user-select: none; cursor: col-resize; }
 .tile.worker-idle::after { background: var(--faint); } /* dim slate, solid */
 @keyframes worker-pulse { 0%, 100% { opacity: .4; } 50% { opacity: 1; } }
 .tile.open { border-color: var(--accent); }
+/* transient "this one" pulse when a chat card chip points at the tile */
+.tile.flash { animation: tile-flash 1.6s ease-out; }
+@keyframes tile-flash {
+  0%, 55% { border-color: var(--accent); box-shadow: 0 0 0 3px rgba(88, 182, 255, .35); }
+  100% { box-shadow: 0 0 0 3px rgba(88, 182, 255, 0); }
+}
 .tile.dragging { opacity: .45; }
 .tile .t-row1 { display: flex; gap: 6px; align-items: flex-start; }
 .tile .t-emoji { flex: none; font-size: 15px; line-height: 1.35; }

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -81,6 +81,17 @@ export function syncChatToMain() {
 export function backToMain() { syncChatToMain(); }
 backBtn.onclick = backToMain;
 
+// Land the user IN a card's conversation: the chat filters to the card's
+// thread and becomes/stays the visible surface (on mobile it flips to the chat
+// tab), while the board tile is only pointed at — the detail panel never opens
+// over the chat. The one action behind the message card chips AND notification
+// row clicks, so both navigate identically.
+export function openCardConversation(id) {
+  if (!card(id)) return;
+  openCardThread(id);
+  flashBoardTile(id);
+}
+
 // Point at a card on the board without opening its detail: scroll its tile
 // into view and pulse it. A no-op when the board isn't showing the tile
 // (mobile chat tab, filtered-out card, table/archive mode) — the chat filter
@@ -463,11 +474,7 @@ feedEl.addEventListener('click', (e) => {
   const chip = e.target.closest('[data-chip-card]');
   if (chip) {
     e.stopPropagation();
-    const id = chip.dataset.chipCard;
-    if (card(id)) {
-      openCardThread(id);
-      flashBoardTile(id);
-    }
+    openCardConversation(chip.dataset.chipCard);
     return;
   }
   const pin = e.target.closest('.att-pin');

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -416,23 +416,38 @@ export function renderChat() {
   maybeMarkRead(isCard ? c : null, target);
 }
 
-// mark the visible thread read (server-persisted) — debounced, loop-safe.
-// Card unread also derives from level-1 EVENTS, not just thread messages, so a
-// card target uses the server-derived card.status.unread (and the shared
-// cardActivityTs dedupe key); message-based gating alone would leave an
-// event-only unread dotted forever. Lieutenant main chats keep the message rule.
-let lastMarked = { target: '', ts: '' };
+// mark the visible conversation read (server-persisted) — debounced, loop-safe.
+// One POST per target per newest-activity ts: the `marked` map remembers what
+// was already sent, and a failed POST forgets it so the next render retries.
+const marked = new Map(); // target -> newest ts already POSTed
+function markRead(target, ts) {
+  if (marked.get(target) === ts) return;
+  marked.set(target, ts);
+  api.markThreadRead(target).catch(() => marked.delete(target));
+}
+// A card target uses the server-derived card.status.unread (unread also derives
+// from level-1 EVENTS, not just thread messages — message gating alone would
+// leave an event-only unread dotted forever) and the shared cardActivityTs
+// dedupe key. The unified stream marks the lieutenant's main chat AND every
+// merged card thread read — the captain just read those messages here, so
+// their dots/bell items must not linger. Cards are gated on MESSAGE unread
+// only: an event-only unread (a question/handoff dot) never rendered in the
+// stream, so it survives until the card itself is opened.
 function maybeMarkRead(c, target) {
   if (document.hidden) return;
   if (window.innerWidth <= 760 && S.view !== 'chat') return; // thread not visible
-  const isCard = !!c;
-  const msgs = isCard ? (c.thread || []) : mainFeedMsgs();
-  const unread = isCard ? !!cardStatus(c).unread : threadUnread(target, msgs);
-  if (!unread) return;
-  const lastTs = isCard ? cardActivityTs(c) : (msgs.length ? msgs[msgs.length - 1].ts : '');
-  if (lastMarked.target === target && lastMarked.ts === lastTs) return; // already sent
-  lastMarked = { target, ts: lastTs };
-  api.markThreadRead(target).catch(() => { lastMarked = { target: '', ts: '' }; });
+  if (c) {
+    if (cardStatus(c).unread) markRead(target, cardActivityTs(c));
+    return;
+  }
+  const l = lieutenant(target.replace(/^lieutenant:/, ''));
+  if (!l) return;
+  const chat = l.chat || [];
+  if (threadUnread(target, chat)) markRead(target, chat[chat.length - 1].ts);
+  for (const cc of cards()) {
+    if (cc.owner !== l.id) continue;
+    if (threadUnread('card:' + cc.id, cc.thread)) markRead('card:' + cc.id, cardActivityTs(cc));
+  }
 }
 
 // ---------- attachment interaction (delegated on the feed) ----------

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -2,7 +2,7 @@
 // the lieutenant's main chat or one of its card threads (a card thread's
 // interlocutor is always the owning lieutenant). Whole-window mode switch,
 // premium composer.
-import { S, card, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, lieutenantUnread, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
+import { S, card, cards, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, lieutenantUnread, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
 import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime, statusBlockHtml, ctxBarHtml, owedIndHtml } from './util.js';
 import { md, mdEnhance } from './md.js';
@@ -80,6 +80,19 @@ export function syncChatToMain() {
 }
 export function backToMain() { syncChatToMain(); }
 backBtn.onclick = backToMain;
+
+// Point at a card on the board without opening its detail: scroll its tile
+// into view and pulse it. A no-op when the board isn't showing the tile
+// (mobile chat tab, filtered-out card, table/archive mode) — the chat filter
+// itself already communicates which card the conversation narrowed to.
+function flashBoardTile(id) {
+  const sel = '.tile[data-id="' + (window.CSS && CSS.escape ? CSS.escape(id) : id) + '"]';
+  const el = document.querySelector('#board ' + sel);
+  if (!el) return;
+  el.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+  el.classList.add('flash');
+  setTimeout(() => el.classList.remove('flash'), 1600);
+}
 openBtn.onclick = () => { if (S.chatMode && S.chatMode.mode === 'card' && detailOpener) detailOpener(S.chatMode.id); };
 
 // ---------- feed rendering ----------
@@ -107,6 +120,18 @@ function attachmentsHtml(atts, promote) {
       '</span>' + pin + '</div>';
   }).join('') + '</div>';
 }
+// The card chip: a message that came from a card thread carries a small
+// clickable pill (card emoji + title) on its bubble. Clicking it filters the
+// conversation down to that card's thread — the CHAT stays the active surface;
+// the board tile is only highlighted, never covered by the detail panel (that
+// is the filtered header's explicit "open card" action). Delegated on the feed
+// — see the chip branch of the click listener below. Main-chat messages carry none.
+function chipHtml(m) {
+  if (!m._card) return '';
+  return '<button type="button" class="msg-chip" data-chip-card="' + esc(m._card) + '"' +
+    ' title="show only this card’s conversation">' +
+    esc((m._cardEmoji ? m._cardEmoji + ' ' : '') + m._cardTitle) + '</button>';
+}
 // A slash command's request+reply are the SYSTEM, not the lieutenant: they get a
 // full-width console block (monospace, subtle border, dim palette, a small "⌘"
 // affordance) — no avatar, no speak button — so they never read as an agent bubble.
@@ -114,7 +139,7 @@ function cmdMsgHtml(m) {
   const ts = '<span class="ts">' + hhmm(m.ts) + '</span>';
   if (!m.cmd.reply) {
     // the request: a console prompt line echoing exactly what was typed
-    return '<div class="msg cmd cmd-req"><span class="cmd-glyph">⌘</span>' +
+    return '<div class="msg cmd cmd-req">' + chipHtml(m) + '<span class="cmd-glyph">⌘</span>' +
       '<span class="cmd-line">' + esc(m.text) + '</span>' + ts + '</div>';
   }
   // the reply: /status renders a rich model+context block; everything else is
@@ -123,7 +148,7 @@ function cmdMsgHtml(m) {
     ? statusBlockHtml(m.status)
     : '<div class="cmd-out md">' + md(m.text) + '</div>';
   const badge = '<span class="cmd-badge">⌘ ' + esc(m.cmd.name || '') + '</span>';
-  return '<div class="msg cmd cmd-reply">' + badge + body + ts + '</div>';
+  return '<div class="msg cmd cmd-reply">' + chipHtml(m) + badge + body + ts + '</div>';
 }
 function msgHtml(m, promote, avatarIdx) {
   if (m.cmd && typeof m.cmd === 'object') return cmdMsgHtml(m);
@@ -142,7 +167,7 @@ function msgHtml(m, promote, avatarIdx) {
   // so even a worker's stamped-as-owner say gets its face)
   const hasAvatar = !mine && avatarIdx != null;
   const face = hasAvatar ? avatarHtml(avatarIdx, 'msg-face') : '';
-  return '<div class="msg ' + (mine ? 'user' : 'agent') + (hasAvatar ? ' has-avatar' : '') + '">' + face + body + atts +
+  return '<div class="msg ' + (mine ? 'user' : 'agent') + (hasAvatar ? ' has-avatar' : '') + '">' + face + chipHtml(m) + body + atts +
     '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
 }
 // empty-conversation placeholder: the lieutenant's face (or its colored dot,
@@ -155,7 +180,7 @@ function emptyFeedHtml(lt) {
     : '<span class="chat-empty-dot" style="background:' + esc(lieutenantColor(lt.id)) + '"></span>';
   return '<div class="empty">' + face + 'no messages yet</div>';
 }
-function typingHtml(state, name) {
+function typingHtml(state, name, chip) {
   // the "owes you a reply" balloon (card.status.owedState / the main-chat rule),
   // one visual per state so queued-unseen never masquerades as being worked on:
   // 'stale'  = owed past the threshold: a DISTINCT "may be stuck" state, static
@@ -163,24 +188,39 @@ function typingHtml(state, name) {
   // 'queued' = delivered to the durable inbox but NOT drained yet — static
   //            hourglass, "waiting to be picked up", no typing animation
   // 'seen'   = drained; the lieutenant owes the reply for real — animated dots
+  const src = chip || ''; // unified stream: which card thread this owed reply lives in
   if (state === 'stale') {
     return '<div class="msg agent typing stale" title="no response for a while — the message may not have reached ' + esc(name) + '">' +
       '<span class="twarn">⚠</span>' +
-      '<span class="lbl">no response yet — ' + esc(name) + ' may be stuck</span></div>';
+      '<span class="lbl">no response yet — ' + esc(name) + ' may be stuck</span>' + src + '</div>';
   }
   if (state === 'queued') {
     return '<div class="msg agent typing queued" title="delivered — ' + esc(name) + ' hasn\'t picked it up yet">' +
       '<span class="tcheck">⏳</span>' +
-      '<span class="lbl">delivered — waiting for ' + esc(name) + ' to pick it up</span></div>';
+      '<span class="lbl">delivered — waiting for ' + esc(name) + ' to pick it up</span>' + src + '</div>';
   }
   return '<div class="msg agent typing" title="' + esc(name) + ' owes you a reply here">' +
     '<span class="tdot"></span><span class="tdot"></span><span class="tdot"></span>' +
-    '<span class="lbl">' + esc(name) + ' owes you a reply…</span></div>';
+    '<span class="lbl">' + esc(name) + ' owes you a reply…</span>' + src + '</div>';
 }
 function mainFeedMsgs() {
-  // the current lieutenant's main-chat messages; card threads live in their own card view
+  // the UNIFIED stream: the lieutenant's main-chat messages PLUS every thread
+  // message of the cards it owns, merged chronologically. A conversation with a
+  // lieutenant is really ONE conversation — the card threads are just slices of
+  // it, so the main chat shows it whole. Thread messages are annotated with
+  // their source card (_card/_cardTitle/_cardEmoji) so the bubble renders the
+  // clickable chip; main-chat messages carry none.
   const l = S.chatMode && S.chatMode.mode === 'lieutenant' ? lieutenant(S.chatMode.id) : null;
   const msgs = ((l && l.chat) || []).slice();
+  if (l) {
+    for (const c of cards()) {
+      if (c.owner !== l.id) continue;
+      const emoji = cardEmoji(c);
+      for (const m of c.thread || []) {
+        msgs.push(Object.assign({}, m, { _card: c.id, _cardTitle: c.title || c.id, _cardEmoji: emoji }));
+      }
+    }
+  }
   msgs.sort((a, b) => (a.ts < b.ts ? -1 : a.ts > b.ts ? 1 : 0));
   return msgs;
 }
@@ -321,8 +361,21 @@ export function renderChat() {
     if (hidden) blocks.push({ html: '<button class="feed-expand" type="button">show earlier messages (' + hidden + ')</button>' });
     for (const m of msgs.slice(hidden)) push(m);
   }
+  // owed tails: the filtered view shows its own target's; the unified stream
+  // also surfaces every owed CARD thread of this lieutenant (chip-labeled), so
+  // an owed reply is never invisible just because it lives in a card slice
+  let tail = '';
+  if (!isCard && lt) {
+    for (const cc of cards()) {
+      if (cc.owner !== lt.id) continue;
+      const st = targetOwedState('card:' + cc.id);
+      if (!st) continue;
+      const chip = chipHtml({ _card: cc.id, _cardTitle: cc.title || cc.id, _cardEmoji: cardEmoji(cc) });
+      tail += typingHtml(targetOwedStale('card:' + cc.id) ? 'stale' : st, ltName, chip);
+    }
+  }
   const owedState = targetOwedState(target);
-  const tail = owedState ? typingHtml(targetOwedStale(target) ? 'stale' : owedState, ltName) : '';
+  if (owedState) tail += typingHtml(targetOwedStale(target) ? 'stale' : owedState, ltName);
 
   const prev = feed;
   feed = { key: target, blocks, tail };
@@ -387,6 +440,21 @@ function maybeMarkRead(c, target) {
 // the open card's artifacts. Delegation survives the append/rebuild fast-path
 // without any per-message re-wiring.
 feedEl.addEventListener('click', (e) => {
+  // card chip on a unified-stream bubble: filter the conversation down to that
+  // card's thread, keeping the CHAT front and visible (critical on narrow
+  // layouts, where the detail panel would take the whole screen). The card is
+  // pointed at on the board with a scroll + flash — the detail itself only
+  // opens via the filtered header's explicit "open card" button.
+  const chip = e.target.closest('[data-chip-card]');
+  if (chip) {
+    e.stopPropagation();
+    const id = chip.dataset.chipCard;
+    if (card(id)) {
+      openCardThread(id);
+      flashBoardTile(id);
+    }
+    return;
+  }
   const pin = e.target.closest('.att-pin');
   if (pin) {
     e.stopPropagation();

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -9,7 +9,7 @@ import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieu
 import { renderTable } from './table.js';
 import { renderArchive } from './archtable.js';
 import { renderFilterUI, filterPanelOpen, closeFilterPanel } from './filterpop.js';
-import { renderChat, onOpenCard as chatOnOpenCard } from './chat.js';
+import { renderChat, onOpenCard as chatOnOpenCard, openCardConversation } from './chat.js';
 import { renderLtSwitcher, ltSwitcherOpen, closeLtSwitcher, appearancePopoverOpen, closeAppearancePopover } from './ltswitcher.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
@@ -19,7 +19,10 @@ import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from
 import './resize.js'; // draggable side-panel widths
 
 chatOnOpenCard(openDetail);
-notifOnOpenCard(openDetail);
+// a notification is about a conversation — clicking it lands IN the chat,
+// filtered to the card (same action as the message card chips); the detail
+// stays behind the filtered header's explicit "open card" button
+notifOnOpenCard(openCardConversation);
 toastOnOpenCard(openDetail);
 
 // ---------- header: filter ----------


### PR DESCRIPTION
Born on the UI dev playground (interactive iterations with the captain), now promoted.

## The problem

Conversations with a lieutenant were sharded across card threads — the captain couldn't remember which card held which exchange, and they're really ONE conversation with that lieutenant.

## What's in

**Unified stream** — a lieutenant's main chat now merges its main-chat messages with every owned card's thread messages, chronologically. Thread-sourced bubbles carry a small clickable chip (card emoji + title); main-chat bubbles carry none. Owed card replies surface in the stream as chip-labeled typing bubbles.

**Chip → filtered chat, never a detail takeover** (captain-iterated): clicking a chip filters the chat to that card's thread and keeps the chat as the visible surface — critical on narrow layouts, where the detail used to cover everything. The board tile just gets a scroll + pulse; the detail stays behind the filtered header's explicit "open card" button. The card-thread header (← + title) marks the filtered state; ← returns to the full stream. Sending while filtered targets the card's thread (unchanged behavior). An earlier "showing only…" filter bar was tried and dropped — the header already says it.

**Unified read semantics** (captain's call): viewing the unified stream marks the main chat AND every merged card thread with unread messages read — dots/bell items clear as they're read in the stream. Event-only unread (question/handoff) never rendered there, so it survives until the card is opened.

**Notification fix**: notif rows were wired to openDetail — on narrow the full-screen detail covered everything and the chat never surfaced. They now use the same action as the chips: land in the chat, filtered to the card.

## Notes

- No server changes: the board payload already carries every thread the merge reads. Fixture enrichment (interleaved timestamps, long thread, owed message) rides along for the playground.
- Archived cards' threads are NOT merged (live cards only) — possible follow-up.
- Full suite green: 334/334.

🤖 Generated with [Claude Code](https://claude.com/claude-code)