### PR TITLE
Bell/toast clicks on chat messages land in the lieutenant's chat

### DIFF
--- a/test/state-actor.test.js
+++ b/test/state-actor.test.js
@@ -1,0 +1,46 @@
+'use strict';
+// ui/js/state.js — lieutenantByActor, the seam behind the notification/toast
+// click routing for card-less chat-message items. state.js touches no DOM at
+// import, so it's imported directly (same pattern as notifypolicy.test.js).
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let S, lieutenantByActor;
+test.before(async () => {
+  ({ S, lieutenantByActor } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'state.js')).href));
+});
+
+function withDoc(doc, fn) {
+  const prev = S.doc;
+  S.doc = doc;
+  try { fn(); } finally { S.doc = prev; }
+}
+
+test('lieutenantByActor: matches by id', () => {
+  withDoc({ lieutenants: [{ id: 'spock', name: 'Mr. Spock' }] }, () => {
+    assert.strictEqual(lieutenantByActor('spock').id, 'spock');
+  });
+});
+
+test('lieutenantByActor: matches by name (chat-say events carry the author name)', () => {
+  withDoc({ lieutenants: [{ id: 'spock', name: 'Mr. Spock' }] }, () => {
+    assert.strictEqual(lieutenantByActor('Mr. Spock').id, 'spock');
+  });
+});
+
+test('lieutenantByActor: non-lieutenant actors resolve to nothing', () => {
+  withDoc({ lieutenants: [{ id: 'spock', name: 'Mr. Spock' }] }, () => {
+    for (const actor of ['server', 'user', 'worker', '', null, undefined]) {
+      assert.strictEqual(lieutenantByActor(actor), undefined);
+    }
+  });
+});
+
+test('lieutenantByActor: safe with no board doc', () => {
+  withDoc(null, () => {
+    assert.strictEqual(lieutenantByActor('spock'), undefined);
+  });
+});

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -4,12 +4,12 @@ import { api } from './api.js';
 import { refreshAgoLabels } from './util.js';
 import { trackMessages } from './voice.js';
 import { trackEvents, renderNotifSettings } from './notifysettings.js';
-import { onOpenCard as toastOnOpenCard } from './toast.js';
+import { onOpenCard as toastOnOpenCard, onOpenLieutenant as toastOnOpenLieutenant } from './toast.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderTable } from './table.js';
 import { renderArchive } from './archtable.js';
 import { renderFilterUI, filterPanelOpen, closeFilterPanel } from './filterpop.js';
-import { renderChat, onOpenCard as chatOnOpenCard, openCardConversation } from './chat.js';
+import { renderChat, onOpenCard as chatOnOpenCard, openCardConversation, openLieutenantChat } from './chat.js';
 import { renderLtSwitcher, ltSwitcherOpen, closeLtSwitcher, appearancePopoverOpen, closeAppearancePopover } from './ltswitcher.js';
 import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
@@ -24,6 +24,7 @@ chatOnOpenCard(openDetail);
 // stays behind the filtered header's explicit "open card" button
 notifOnOpenCard(openCardConversation);
 toastOnOpenCard(openDetail);
+toastOnOpenLieutenant(openLieutenantChat); // card-less chat toast → the lieutenant's main chat
 
 // ---------- header: filter ----------
 // Just the text input here — every richer filter lives in the popup

--- a/ui/js/notify.js
+++ b/ui/js/notify.js
@@ -1,7 +1,8 @@
 // notification bell: level-1 filter over the unified event stream, with
 // expandable "· N events ·" dividers revealing the suppressed level-2 events.
-import { S, allEvents, notifItems, notifUnreadCount, card, kindEmoji, render } from './state.js';
+import { S, allEvents, notifItems, notifUnreadCount, card, kindEmoji, lieutenantByActor, render } from './state.js';
 import { api } from './api.js';
+import { openLieutenantChat } from './chat.js';
 
 const bellBtn = document.getElementById('bell');
 const bellN = document.getElementById('bell-n');
@@ -55,7 +56,12 @@ function itemNode(e, lvl2) {
   }
   row.onclick = async () => {
     if (e.level === 1 && !e.read) { try { await api.markNotifRead([e.seq]); } catch (err) {} }
-    if (e.card && card(e.card) && detailOpener) { S.notifOpen = false; detailOpener(e.card); }
+    if (e.card && card(e.card) && detailOpener) { S.notifOpen = false; detailOpener(e.card); return; }
+    // a lieutenant's main-chat message rides a board-level event with an actor
+    // and NO card — land in that lieutenant's conversation instead of a dead
+    // click; actor-less server/system events stay mark-read-only
+    const lt = lieutenantByActor(e.actor);
+    if (lt) { S.notifOpen = false; openLieutenantChat(lt.id); }
   };
   return row;
 }

--- a/ui/js/notifysettings.js
+++ b/ui/js/notifysettings.js
@@ -1,7 +1,7 @@
 // notifysettings.js — persisted notification settings, the "notifications"
 // section of the settings panel, and the driver that turns new board events
 // into toasts/sounds. Mirrors voice.js's localStorage + gesture-unlock pattern.
-import { S, kindEmoji } from './state.js';
+import { S, kindEmoji, lieutenantByActor } from './state.js';
 import { defaultCategoryPolicy, policyFor, selectNewEvents, selectNewMessages, shouldSuppressChat } from './notifypolicy.js';
 import * as sound from './sound.js';
 import * as toast from './toast.js';
@@ -69,7 +69,8 @@ export function trackEvents(doc) {
   if (firstLoad) { firstLoad = false; return; }
   for (const e of events) {
     const p = policyFor(e.kind, e.level, settings);
-    if (p.toast) toast.push({ emoji: kindEmoji(e.kind), text: e.text, cardTitle: e.cardTitle, actor: e.actor, card: e.card });
+    if (p.toast) toast.push({ emoji: kindEmoji(e.kind), text: e.text, cardTitle: e.cardTitle, actor: e.actor, card: e.card,
+      lieutenant: e.card ? undefined : (lieutenantByActor(e.actor) || {}).id });
     if (p.sound && p.sound !== 'none') sound.play(p.sound);
   }
   for (const m of messages) {
@@ -80,7 +81,10 @@ export function trackEvents(doc) {
       chatVisible: isChatVisible(),
     };
     const p = policyFor('reply', 1, settings);
-    if (p.toast && !shouldSuppressChat(m.scope, ctx)) toast.push({ emoji: '💬', text: m.text, cardTitle: m.cardTitle, actor: m.author, card: m.card });
+    if (p.toast && !shouldSuppressChat(m.scope, ctx)) {
+      const lt = /^lieutenant:(.+)$/.exec(m.scope || ''); // main-chat scope carries the id itself
+      toast.push({ emoji: '💬', text: m.text, cardTitle: m.cardTitle, actor: m.author, card: m.card, lieutenant: lt ? lt[1] : undefined });
+    }
     if (p.sound && p.sound !== 'none') sound.play(p.sound); // ALWAYS — captain: "mantém o som"
   }
 }

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -33,6 +33,13 @@ export function card(id) { return cards().find((c) => c.id === id); }
 export function columns() { return (S.doc && S.doc.columns) || []; }
 export function lieutenants() { return (S.doc && S.doc.lieutenants) || []; }
 export function lieutenant(id) { return lieutenants().find((l) => l.id === id); }
+// The lieutenant behind an event's `actor`, if any. The server stamps chat-say
+// events with the author NAME (not the id — server.js's msg.author), so match
+// both; 'user'/'server'/'worker' actors resolve to nothing.
+export function lieutenantByActor(actor) {
+  if (!actor) return undefined;
+  return lieutenants().find((l) => l.id === actor || l.name === actor);
+}
 export function lieutenantColor(id) {
   const l = lieutenant(id);
   return l && /^#[0-9a-fA-F]{6}$/.test(l.color || '') ? l.color : '#66788a';

--- a/ui/js/toast.js
+++ b/ui/js/toast.js
@@ -7,6 +7,8 @@ const DISMISS_MS = 6000;
 let root = null;
 let openCard = null;
 export function onOpenCard(fn) { openCard = fn; }
+let openLt = null;
+export function onOpenLieutenant(fn) { openLt = fn; }
 
 function ensureRoot() {
   if (root) return root;
@@ -16,7 +18,7 @@ function ensureRoot() {
   return root;
 }
 
-// e: { emoji, text, cardTitle, actor, card }
+// e: { emoji, text, cardTitle, actor, card, lieutenant }
 export function push(e) {
   const stack = ensureRoot();
   const el = document.createElement('div');
@@ -50,7 +52,13 @@ export function push(e) {
   el.onmouseenter = () => clearTimeout(timer);
   el.onmouseleave = arm;
   x.onclick = (ev) => { ev.stopPropagation(); dismiss(); };
-  el.onclick = () => { if (e.card && openCard) openCard(e.card); dismiss(); };
+  // card-less toasts (a lieutenant's main-chat message) land in that
+  // lieutenant's conversation instead of dying on the click
+  el.onclick = () => {
+    if (e.card && openCard) openCard(e.card);
+    else if (e.lieutenant && openLt) openLt(e.lieutenant);
+    dismiss();
+  };
 
   stack.appendChild(el);
   while (stack.children.length > MAX_VISIBLE) stack.firstChild.remove();


### PR DESCRIPTION
Follow-up defect on #54: bell items (and toasts) for a lieutenant's main-chat message were dead clicks — the row only navigated when the event carried a `card`, but main-chat says ride a board-level level-1 event with only an `actor`.

- `ui/js/notify.js`: card-less rows now resolve the actor to a lieutenant and open its main chat (`openLieutenantChat` — chat surface, unfiltered stream, flips the mobile tab, closes the panel). Card rows unchanged; actor-less system events stay mark-read-only.
- `ui/js/state.js`: new `lieutenantByActor(actor)` — matches id **or name**, since the server stamps chat-say events with the author name (`server.js` `msg.author`).
- `ui/js/toast.js` + `notifysettings.js` + `main.js`: same gap existed for card-less toasts — they now carry a `lieutenant` id (from the message scope, or actor-resolved for events) and click through to the main chat.
- `test/state-actor.test.js`: covers the new seam (id match, name match, system actors, no doc). Suite: 338 pass.

UI-only; no server changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)