### PR TITLE
Mobile topbar redesign: ellipsized title w/ status underline, collapsible search, single-mode dropdown

### DIFF
--- a/ui/app.css
+++ b/ui/app.css
@@ -1030,11 +1030,34 @@ a.a-uri { color: var(--accent); }
 /* ---------- mobile ---------- */
 @media (max-width: 760px) {
   /* the notch: pad the header top by the safe-area inset so controls clear it */
-  #topbar { height: auto; min-height: 46px; padding: calc(env(safe-area-inset-top)) 10px 0; gap: 8px; }
+  #topbar { height: auto; min-height: 46px; padding: calc(env(safe-area-inset-top)) 10px 0; gap: 6px; }
   #b-subtitle { display: none; }
-  #filter-wrap { gap: 4px; }
-  #filter { width: 100%; min-width: 60px; padding: 5px 9px; }
+  /* the title yields to the controls and trims with an ellipsis — never overlapped.
+     The status dot's state moves into its underline (green/yellow/red), so the
+     dot itself is hidden here. */
+  #topbar h1 {
+    flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis;
+    text-decoration: underline 2px; text-underline-offset: 4px;
+    text-decoration-color: var(--danger); transition: text-decoration-color .3s;
+  }
+  #topbar h1[data-load="ok"] { text-decoration-color: var(--ok); }
+  #topbar h1[data-load="busy"] { text-decoration-color: var(--warn); }
+  #status-dot { display: none; }
+  /* the text filter collapses to the 🔍; the row is title + icon buttons only */
+  #filter-wrap { flex: none; gap: 4px; }
+  #filter { display: none; }
   #filter-age { display: none; }
+  /* search mode (🔍 tapped): the input takes the whole row — title, mode
+     switcher, dot, bell, gear step aside until ✕ */
+  #topbar.searching h1, #topbar.searching #view-seg, #topbar.searching #status-dot,
+  #topbar.searching #bell, #topbar.searching #gear, #topbar.searching #filter-open { display: none; }
+  #topbar.searching #filter-wrap { flex: 1 1 auto; }
+  #topbar.searching #filter { display: block; flex: 1 1 auto; width: auto; min-width: 0; padding: 5px 9px; }
+  #topbar.searching #filter-close { display: inline-flex; }
+  /* compact the icon cluster so everything sits in one calm row at 390px
+     (the #view-seg / #filter-open sizing lives in the mobile block at the end
+     of this file — their base rules are declared below this one) */
+  #bell, #gear { padding: 4px 8px; font-size: 13px; }
   /* iOS auto-zooms a text field on focus when its font-size is < 16px, which
      blows up the whole layout. Force every focusable text input to 16px on
      mobile so focus never triggers a zoom (the accessible fix; the viewport
@@ -1141,13 +1164,17 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
 .tv td.c-btn { text-align: right; }
 
 /* ---------- the unified filter control: one button, one popup ---------- */
-#filter-btn {
+#filter-btn, #filter-open, #filter-close {
   position: relative; display: inline-flex; align-items: center; justify-content: center;
   border: 1px solid var(--line); border-radius: 8px; color: var(--dim);
   padding: 5px 9px; flex: none; transition: border-color .15s, color .15s;
 }
-#filter-btn svg { display: block; }
-#filter-btn:hover, #filter-btn.on, #filter-btn.active { color: var(--accent); border-color: var(--accent2); }
+#filter-btn svg, #filter-open svg { display: block; }
+#filter-btn:hover, #filter-btn.on, #filter-btn.active,
+#filter-open:hover, #filter-open.on, #filter-close:hover { color: var(--accent); border-color: var(--accent2); }
+/* 🔍 / ✕ are the mobile collapsed-search controls — desktop shows the input itself */
+#filter-open, #filter-close { display: none; }
+#filter-close { font-size: 13px; line-height: 15px; }
 #filter-panel {
   position: fixed; z-index: 60; display: flex; flex-direction: column; gap: 8px;
   background: var(--bg2); border: 1px solid var(--line2); border-radius: 12px; padding: 12px 14px;
@@ -1202,3 +1229,25 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
 .ftm .fta { font-size: 11px; font-weight: 650; color: var(--dim); }
 .ftm .fts { position: absolute; top: 8px; right: 10px; font-size: 10.5px; color: var(--faint); }
 .ftm .ftb { margin-top: 4px; font-size: 13px; }
+
+/* ---------- mobile topbar: collapsed search + compact controls ----------
+   Lives at the end of the file so it wins the cascade over the #view-seg and
+   #filter-open/#filter-close base rules declared above. */
+@media (max-width: 760px) {
+  #filter-open { display: inline-flex; }
+  #topbar.searching #filter-open { display: none; }
+  /* the mode switcher collapses to ONE button — the current mode; tapping it
+     opens the #mode-menu dropdown (main.js) */
+  #view-seg button { display: none; }
+  #view-seg button.on { display: inline-flex; padding: 5px 9px; font-size: 13px; border-left: none; }
+}
+
+/* mobile board-mode dropdown — the move menu's look, anchored under the switcher */
+#mode-menu {
+  position: fixed; z-index: 80; min-width: 150px; display: flex; flex-direction: column;
+  background: var(--bg2); border: 1px solid var(--line2); border-radius: 10px; padding: 5px;
+  box-shadow: var(--shadow); animation: pop-in .12s ease-out;
+}
+#mode-menu button { text-align: left; font-size: 13px; padding: 8px 12px; border-radius: 7px; }
+#mode-menu button:hover { background: var(--panel2); }
+#mode-menu button.cur { color: var(--accent); }

--- a/ui/index.html
+++ b/ui/index.html
@@ -13,6 +13,15 @@
   <h1 id="b-title">bridge command</h1>
   <div id="b-subtitle"></div>
   <span id="filter-wrap">
+    <!-- mobile only: the text filter collapses to this 🔍; tapping it expands
+         the input over the whole row (desktop shows the input directly) -->
+    <button id="filter-open" title="search cards">
+      <svg viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor"
+           stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <circle cx="11" cy="11" r="7"></circle>
+        <line x1="21" y1="21" x2="16" y2="16"></line>
+      </svg>
+    </button>
     <input id="filter" placeholder="filter ( / )" autocomplete="off">
     <!-- the richer filters live in a popup; the badge counts what's active in there -->
     <button id="filter-btn" title="filters">
@@ -22,6 +31,8 @@
       </svg>
       <span id="filter-btn-n" class="badge-n" hidden></span>
     </button>
+    <!-- mobile only: leaves search mode (the filter itself stays applied) -->
+    <button id="filter-close" title="done">✕</button>
   </span>
   <!-- board ⇄ table over the live cards; 🧊 is the archived cards' own mode -->
   <span id="view-seg" role="group" aria-label="board view">
@@ -36,6 +47,10 @@
 
 <!-- filter popup (filterpop.js renders its content) -->
 <div id="filter-panel" hidden></div>
+
+<!-- mobile board-mode dropdown: the collapsed ▦☰🧊 switcher opens this
+     (main.js renders the three modes, current one marked) -->
+<div id="mode-menu" hidden></div>
 
 <!-- notifications dropdown -->
 <div id="notif-panel" hidden>

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -31,8 +31,18 @@ toastOnOpenLieutenant(openLieutenantChat); // card-less chat toast → the lieut
 // (filterpop.js), behind the one button with the active-count badge.
 const filterInput = document.getElementById('filter');
 filterInput.oninput = () => { S.filters.text = filterInput.value; render(); };
+// Mobile collapses the input to a 🔍 button; tapping it puts the topbar in
+// "search mode" (the input over the whole row) until ✕. Desktop never shows
+// either button and the .searching class is inert there.
+const topbarEl = document.getElementById('topbar');
+const filterOpenBtn = document.getElementById('filter-open');
+document.getElementById('filter-close').onclick = () => topbarEl.classList.remove('searching');
+filterOpenBtn.onclick = () => { topbarEl.classList.add('searching'); filterInput.focus(); };
+function searchModeOn() { return topbarEl.classList.contains('searching'); }
 function syncFilterInputs() {
   if (filterInput.value !== S.filters.text) filterInput.value = S.filters.text;
+  // collapsed 🔍 lights up while a text filter is applied
+  filterOpenBtn.classList.toggle('on', !!S.filters.text);
 }
 
 // ---------- header: status dot ----------
@@ -43,6 +53,11 @@ function renderStatusDot() {
   el.title = !S.connected ? 'disconnected — reconnecting…'
     : owed ? 'a lieutenant owes a reply on ' + owed + ' conversation' + (owed > 1 ? 's' : '')
     : 'connected — all quiet';
+  // mobile hides the dot and wears the same state as a colored underline on
+  // the title (the dot had no tap action, so the underline is passive too)
+  const titleEl = document.getElementById('b-title');
+  titleEl.dataset.load = !S.connected ? 'down' : owed ? 'busy' : 'ok';
+  titleEl.title = el.title;
 }
 
 // ---------- settings panel ----------
@@ -83,8 +98,37 @@ function setBoardMode(mode) {
   }
   render();
 }
+// Mobile collapses the switcher to just the active mode's button; tapping it
+// opens a small dropdown of the three modes. Desktop shows all three buttons,
+// where clicking the active one was always a no-op — so the dropdown branch
+// can never fire there.
+const modeMenuEl = document.getElementById('mode-menu');
+const MODE_LABEL = { board: '▦ kanban', table: '☰ table', archive: '🧊 archived' };
+function modeMenuIsOpen() { return !modeMenuEl.hidden; }
+function closeModeMenu() { modeMenuEl.hidden = true; }
+function openModeMenu(anchor) {
+  modeMenuEl.textContent = '';
+  for (const m of Object.keys(MODE_BTN)) {
+    const b = document.createElement('button');
+    b.textContent = (m === S.boardMode ? '● ' : '') + MODE_LABEL[m];
+    if (m === S.boardMode) b.className = 'cur';
+    b.onclick = () => { closeModeMenu(); setBoardMode(m); };
+    modeMenuEl.appendChild(b);
+  }
+  modeMenuEl.hidden = false;
+  const ar = anchor.getBoundingClientRect(), r = modeMenuEl.getBoundingClientRect();
+  modeMenuEl.style.left = Math.max(8, Math.min(ar.right - r.width, window.innerWidth - r.width - 8)) + 'px';
+  modeMenuEl.style.top = Math.min(ar.bottom + 6, window.innerHeight - r.height - 8) + 'px';
+}
+document.addEventListener('click', (e) => { if (modeMenuIsOpen() && !modeMenuEl.contains(e.target)) closeModeMenu(); });
 for (const [m, id] of Object.entries(MODE_BTN)) {
-  document.getElementById(id).onclick = () => setBoardMode(m);
+  document.getElementById(id).onclick = (e) => {
+    if (m === S.boardMode && matchMedia('(max-width: 760px)').matches) {
+      e.stopPropagation(); // keep the document click-away handler out of this tap
+      if (modeMenuIsOpen()) closeModeMenu();
+      else openModeMenu(e.currentTarget);
+    } else setBoardMode(m);
+  };
 }
 try { setBoardMode(localStorage.getItem('bc-board-mode') || 'board'); } catch (e) {}
 
@@ -113,7 +157,12 @@ function renderTabs() {
 document.addEventListener('keydown', (e) => {
   const active = document.activeElement;
   const inField = /^(INPUT|TEXTAREA|SELECT)$/.test((active && active.tagName) || '');
-  if (e.key === '/' && !inField) { e.preventDefault(); filterInput.focus(); return; }
+  if (e.key === '/' && !inField) {
+    e.preventDefault();
+    if (matchMedia('(max-width: 760px)').matches) topbarEl.classList.add('searching');
+    filterInput.focus();
+    return;
+  }
   if (e.key === 'Escape') {
     if (artifactOpen()) closeArtifact();
     else if (paneOpen()) closePane();
@@ -122,12 +171,14 @@ document.addEventListener('keydown', (e) => {
     else if (newLieutenantOpen()) closeNewLieutenant();
     else if (pickerIsOpen()) closeLabelPicker();
     else if (appearancePopoverOpen()) closeAppearancePopover();
+    else if (modeMenuIsOpen()) closeModeMenu();
     else if (filterPanelOpen()) closeFilterPanel();
     else if (ltSwitcherOpen()) closeLtSwitcher();
     else if (ownerMenuOpen()) closeOwnerMenu(); // just the menu — keep the detail open
     else if (S.notifOpen) { S.notifOpen = false; render(); }
     else if (!spEl.hidden) { spEl.hidden = true; gearBtn.classList.remove('on'); }
     else if (detailOpen()) closeDetail();
+    else if (searchModeOn()) topbarEl.classList.remove('searching'); // collapse first, filters survive
     else if (filtersActive()) { clearFilters(); syncFilterInputs(); }
     closeMoveMenu();
   }


### PR DESCRIPTION
Mobile-only (≤760px) topbar rework — captain-approved via the :4790 playground. Desktop layout untouched.

- Title flexes into free space and trims with ellipsis (was overlapped by the filter input). The status dot hides on mobile; its state becomes the title's underline color (green ok / yellow owed-reply / red disconnected), same tooltip.
- Text filter collapses to a 🔍 button; tap (or `/`) expands it over the whole row with funnel + ✕. ✕ collapses without losing the filter; 🔍 stays accent-lit while a text filter is applied; Esc collapses first, then clears.
- ▦☰🧊 switcher collapses to one button showing the current mode; tapping opens a small dropdown (current marked, click-away/Esc close).
- Bell/gear compact padding — everything sits in one row at 390px.

UI-only (index.html / app.css / js/main.js), zero-dep. Suite 338/338 green. Verified at 390px + 420px and 1280px desktop regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)