### PR TITLE
Kill the false 'not delivered' red in the composer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2667,7 +2667,12 @@ const server = http.createServer(async (req, res) => {
       const target = String(body.target || '');
       if (!/^(lieutenant:.+|card:.+)$/.test(target)) return sendJson(res, 400, { error: 'bad target' });
       r.threads[target] = body.ts || now();
-      saveBoard(); broadcast();
+      // No broadcast: a read marker only moves the POSTING user's unread/bell
+      // derivation, and that device applies it locally when it POSTs. The
+      // unified stream fires one POST per viewed thread per device — full
+      // board pushes here burst every SSE client. Other devices of the same
+      // user converge on the next real broadcast.
+      saveBoard();
       return sendJson(res, 200, { ok: true });
     }
 

--- a/test/sse.test.js
+++ b/test/sse.test.js
@@ -53,6 +53,70 @@ test('board payload carries a stable per-instance boot id', async () => {
   }
 });
 
+// Keep an SSE stream open and pull frames one at a time; next(ms) resolves the
+// next non-ping event name, or null when the window closes with the stream quiet.
+async function sseReader(base) {
+  const res = await fetch(base + '/api/events');
+  assert.equal(res.status, 200);
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  let pending = null; // a timed-out read stays pending; the next call reuses it
+  async function next(timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const end = buf.indexOf('\n\n');
+      if (end !== -1) {
+        const frame = buf.slice(0, end);
+        buf = buf.slice(end + 2);
+        const event = (/^event: (.*)$/m.exec(frame) || [])[1];
+        if (event === 'ping') continue;
+        return event;
+      }
+      const left = deadline - Date.now();
+      if (left <= 0) return null;
+      if (!pending) pending = reader.read();
+      const r = await Promise.race([
+        pending,
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), left)),
+      ]);
+      if (r === 'timeout') return null;
+      pending = null;
+      if (r.done) return null;
+      buf += dec.decode(r.value, { stream: true });
+    }
+  }
+  return { next, close: () => reader.cancel().catch(() => {}) };
+}
+
+// A thread read marker only moves the POSTING user's own unread derivation —
+// it must persist WITHOUT a board broadcast (the unified stream fires one POST
+// per viewed thread per device; full pushes here burst every client and can
+// drown a composer's own send echo).
+test('POST /api/read persists the marker without broadcasting', async () => {
+  const s = await startServer();
+  const sse = await sseReader(s.base);
+  try {
+    assert.equal(await sse.next(2000), 'board'); // the on-connect hello
+
+    const r = await s.api('POST', '/api/read', { target: 'card:quiet', ts: '2026-01-01T00:00:00.000Z' });
+    assert.equal(r.status, 200);
+    assert.equal(await sse.next(500), null); // stream stays quiet
+
+    // the marker still persisted for the posting user
+    const b = await s.api('GET', '/api/board');
+    assert.equal(b.body.reads.user.threads['card:quiet'], '2026-01-01T00:00:00.000Z');
+
+    // contrast probe: the bell's mark-all STILL broadcasts — proving the
+    // quiet window above was a suppressed push, not a dead stream
+    await s.api('POST', '/api/notifications/read', { all: true });
+    assert.equal(await sse.next(2000), 'board');
+  } finally {
+    sse.close();
+    await s.stop();
+  }
+});
+
 test('boot id changes across a server restart on the same workspace+port', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-boot-'));
   const port = await freePort();

--- a/ui/app.css
+++ b/ui/app.css
@@ -258,6 +258,7 @@ body.resizing { user-select: none; cursor: col-resize; }
 #chat-send-err {
   flex: none; padding: 6px 12px 0; font-size: 12px; color: var(--danger);
 }
+#chat-send-err.sync { color: var(--dim); }
 /* pending-attachment chips (composer, before send) */
 #chat-atts { flex: none; display: flex; flex-wrap: wrap; gap: 6px; padding: 8px 12px 0; }
 .att-chip {

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -431,10 +431,24 @@ export function renderChat() {
 // One POST per target per newest-activity ts: the `marked` map remembers what
 // was already sent, and a failed POST forgets it so the next render retries.
 const marked = new Map(); // target -> newest ts already POSTed
+let readRepaint = 0; // one coalesced repaint per burst of markRead calls
 function markRead(target, ts) {
   if (marked.get(target) === ts) return;
   marked.set(target, ts);
   api.markThreadRead(target).catch(() => marked.delete(target));
+  // The server persists the marker WITHOUT broadcasting (a read only moves
+  // this user's own derivation), so apply it locally: the reads map feeds
+  // threadUnread/bell, the card's server-derived status.unread feeds the
+  // board dot. The next real broadcast carries the same state.
+  const reads = S.doc.reads || (S.doc.reads = {});
+  const u = reads[USER] || (reads[USER] = { notifSeq: 0, notifSeqs: [], threads: {} });
+  const threads = u.threads || (u.threads = {});
+  if (!threads[target] || threads[target] < ts) threads[target] = ts;
+  const m = /^card:(.+)$/.exec(target);
+  const c = m && card(m[1]);
+  if (c && c.status) c.status.unread = false;
+  // markRead fires from inside render; repaint dots/bell on the next tick
+  if (!readRepaint) readRepaint = setTimeout(() => { readRepaint = 0; render(); }, 0);
 }
 // A card target uses the server-derived card.status.unread (unread also derives
 // from level-1 EVENTS, not just thread messages — message gating alone would
@@ -633,30 +647,54 @@ document.addEventListener('click', (e) => {
   if (slash.open && !composerEl.contains(e.target)) closeSlash();
 });
 
-// The POST already triggered a broadcast, so the echo normally arrives over SSE
-// within a beat; poll the local state for it, with one direct refetch as a
-// fallback (e.g. the SSE stream is stale and hasn't been reaped yet).
+// Delivery is the POST 200 (the QueueItem lands write-ahead, server-side); the
+// echo normally paints over SSE within a beat. A missing echo means the LOCAL
+// view is stale, not that the message was lost — so the watchdog is soft: it
+// polls with one direct refetch as a fallback, shows a muted "syncing" hint
+// after a generous window (never red, never blocks the composer), and clears
+// the hint when the echo lands. A newer send supersedes the running watchdog.
 function threadMsgs(target) {
   const m = /^card:(.+)$/.exec(target);
   if (m) { const c = card(m[1]); return (c && c.thread) || []; }
   const l = lieutenant(target.replace(/^lieutenant:/, ''));
   return (l && l.chat) || [];
 }
-async function waitForEcho(target, text) {
+let echoWatch = 0;
+async function watchEcho(target, text) {
+  const token = ++echoWatch;
   const seen = () => threadMsgs(target).some((m) => m.author === USER && m.text === text);
-  for (let i = 0; i < 20; i++) {
-    if (seen()) return true;
-    if (i === 10) api.board().then((doc) => { S.doc = doc; trackMessages(doc); render(); }).catch(() => {});
-    await new Promise((r) => setTimeout(r, 150));
+  for (let i = 0; i < 120; i++) { // 250ms steps: refetch at 3s, hint at 10s, give up at 30s
+    if (token !== echoWatch) return;
+    if (seen()) { clearSyncHint(); return; }
+    if (i === 12) api.board().then((doc) => { if (token === echoWatch) { S.doc = doc; trackMessages(doc); render(); } }).catch(() => {});
+    if (i === 40) setSyncHint();
+    await new Promise((r) => setTimeout(r, 250));
   }
-  return seen();
+  console.warn('bc: no echo yet for a delivered message on ' + target);
+}
+let syncHinted = false;
+function setSyncHint() {
+  syncHinted = true;
+  sendErrEl.classList.add('sync');
+  sendErrEl.textContent = 'delivered — syncing…';
+  sendErrEl.hidden = false;
+}
+function clearSyncHint() {
+  if (!syncHinted) return;
+  syncHinted = false;
+  sendErrEl.classList.remove('sync');
+  sendErrEl.hidden = true;
 }
 function setSendError(msg) {
+  syncHinted = false;
+  sendErrEl.classList.remove('sync');
   inputEl.classList.add('send-fail');
   sendErrEl.textContent = '⚠ not delivered — ' + msg + '. Your message is still below; try again.';
   sendErrEl.hidden = false;
 }
 function clearSendError() {
+  syncHinted = false;
+  sendErrEl.classList.remove('sync');
   inputEl.classList.remove('send-fail');
   sendErrEl.hidden = true;
 }
@@ -680,15 +718,16 @@ async function send() {
     // (the server re-resolves them authoritatively by id).
     const metas = await Promise.all(atts.map((p) => api.uploadAttachment(p.file)));
     await api.feedback(target, text, metas);
-    // With text, wait for its echo; attachments-only has no text to match, so the
-    // 200 is the confirmation (the SSE board push renders the bubble a beat later).
-    if (text && !(await waitForEcho(target, text))) throw new Error('sent, but no echo from the server');
+    // The 200 IS delivery (write-ahead queue) — clear the composer now. The
+    // soft watchdog only flags a stalled echo; attachments-only has no text
+    // to match, so the 200 alone confirms it.
     inputEl.value = '';
     closeSlash();
     pendingAtts = [];
     renderPendingAtts();
+    if (text) watchEcho(target, text);
   } catch (e) {
-    setSendError(e.message);
+    setSendError(e.message); // a real POST failure: red + input preserved
   } finally {
     sending = false;
     sendBtn.disabled = false;


### PR DESCRIPTION
## Problem

Recurring `⚠ not delivered — sent, but no echo from the server` on messages that WERE delivered. PR #54's unified read fires `POST /api/read` per viewed thread per device, and every one triggered a FULL board broadcast to every SSE client. With phone + desktop open, the broadcast bursts could delay the composer's own echo past its hard 3s watchdog → false red.

## Fix (both layers)

**Server** — `/api/read` persists the marker with `saveBoard()` but no `broadcast()`. A read marker only moves the posting user's own unread/bell derivation, and that device applies it locally. Other devices of the same user converge on the next real broadcast. The SSE layer has no per-user connection identity, so a targeted push wasn't available; skipping is the lighter, sufficient option. The bell routes (`/api/notifications/read` mark-all + per-item) still broadcast — they're single deliberate clicks (never bursts) and their UI relies on the round-trip.

**Composer** (`ui/js/chat.js`) — the POST 200 IS delivery (write-ahead queue), so the input clears immediately on 200. The watchdog is now soft: board refetch at 3s, muted `delivered — syncing…` hint at 10s (cleared when the echo lands), console warning at 30s — never red, never blocks. A real POST failure (network/5xx) keeps today's red + preserved input. `markRead` now applies the marker optimistically to local state (reads map, card `status.unread`) with one coalesced repaint, since no broadcast echoes it back.

## Tests

New: `POST /api/read persists the marker without broadcasting` (test/sse.test.js) — SSE stream stays quiet after the read POST, marker persists in the board payload, and a contrast probe (mark-all) confirms the stream is alive, not dead. Full suite: **339/339 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)