### PR TITLE
Inline video preview in the artifact/attachment viewer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -125,6 +125,7 @@ const ARTIFACT_MIME = {
   '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
   '.webp': 'image/webp', '.svg': 'image/svg+xml', '.bmp': 'image/bmp', '.avif': 'image/avif',
   '.pdf': 'application/pdf',
+  '.mp4': 'video/mp4', '.m4v': 'video/mp4', '.mov': 'video/quicktime', '.webm': 'video/webm',
 };
 
 const DEFAULT_PORT = 4780;
@@ -848,6 +849,27 @@ setInterval(() => {
 }, 25000).unref();
 
 // ---------- helpers ----------
+// Byte serve shared by the raw artifact and attachment routes. Honors a single
+// `Range: bytes=` header (206 + Content-Range) because iOS Safari refuses to
+// play <video> from a server that answers Range requests with a plain 200;
+// anything unparseable falls back to the full 200, unsatisfiable → 416.
+function sendBytes(req, res, data, headers) {
+  const m = /^bytes=(\d*)-(\d*)$/.exec(req.headers.range || '');
+  const base = { ...headers, 'Accept-Ranges': 'bytes' };
+  if (m && (m[1] || m[2])) {
+    const start = m[1] ? parseInt(m[1], 10) : data.length - parseInt(m[2], 10);
+    const end = m[1] && m[2] ? Math.min(parseInt(m[2], 10), data.length - 1) : data.length - 1;
+    if (start < 0 || start > end || start >= data.length) {
+      res.writeHead(416, { 'Content-Range': 'bytes */' + data.length });
+      return res.end();
+    }
+    const chunk = data.subarray(start, end + 1);
+    res.writeHead(206, { ...base, 'Content-Length': chunk.length, 'Content-Range': 'bytes ' + start + '-' + end + '/' + data.length });
+    return res.end(chunk);
+  }
+  res.writeHead(200, { ...base, 'Content-Length': data.length });
+  res.end(data);
+}
 function sendJson(res, code, obj) {
   const body = JSON.stringify(obj);
   res.writeHead(code, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) });
@@ -2184,24 +2206,22 @@ const server = http.createServer(async (req, res) => {
         const ctype = isHtml ? 'text/html; charset=utf-8'
           : am ? (attMime || 'application/octet-stream')
           : (ARTIFACT_MIME[ext] || 'application/octet-stream');
-        // Images, pdf, and rendered html show inline in the browser; other
+        // Images, video, pdf, and rendered html show inline in the browser; other
         // binaries download. Same hardening as the attachments serve: nosniff pins
         // the Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
-        // is navigated to as a document (inline <img> subresources unaffected).
-        const inline = isHtml || /^image\//.test(ctype) || ctype === 'application/pdf';
+        // is navigated to as a document (inline <img>/<video> subresources unaffected).
+        const inline = isHtml || /^(image|video)\//.test(ctype) || ctype === 'application/pdf';
         const csp = isHtml ? 'sandbox allow-scripts' : 'sandbox';
         let data;
         try { data = fs.readFileSync(file); }
         catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
-        res.writeHead(200, {
+        return sendBytes(req, res, data, {
           'Content-Type': ctype,
-          'Content-Length': data.length,
           'Cache-Control': 'private, max-age=31536000, immutable',
           'X-Content-Type-Options': 'nosniff',
           'Content-Security-Policy': csp,
           'Content-Disposition': (inline ? 'inline' : 'attachment') + '; filename="' + name.replace(/["\\\r\n]/g, '_') + '"',
         });
-        return res.end(data);
       }
       let data;
       try { data = fs.readFileSync(file); }
@@ -2243,15 +2263,13 @@ const server = http.createServer(async (req, res) => {
       // Uploaded bytes are untrusted content served from the board's own origin.
       // nosniff pins the stored Content-Type (no MIME sniffing into executable
       // types); the sandbox CSP neutralizes scripts if an HTML/SVG upload is
-      // navigated to as a document — inline <img> subresources are unaffected.
-      res.writeHead(200, {
+      // navigated to as a document — inline <img>/<video> subresources are unaffected.
+      return sendBytes(req, res, data, {
         'Content-Type': meta.mime || 'application/octet-stream',
-        'Content-Length': data.length,
         'Cache-Control': 'private, max-age=31536000, immutable',
         'X-Content-Type-Options': 'nosniff',
         'Content-Security-Policy': 'sandbox',
       });
-      return res.end(data);
     }
 
     // ----- lieutenants -----

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -47,6 +47,40 @@ test('raw=1 for a listed image → 200, image Content-Type, hardening headers, e
   }
 });
 
+test('raw=1 for a listed .mp4 → video/mp4, inline, Accept-Ranges; Range → 206 slice', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const vid = path.join(s.dir, 'demo.mp4');
+    fs.writeFileSync(vid, 'FAKE-MP4-BYTES-0123456789'); // headers/range only — no real codec needed
+    const { uri } = await cardWithArtifact(s, vid, 'worker demo video');
+    const raw = s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1';
+
+    const res = await fetch(raw);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'video/mp4');
+    assert.match(res.headers.get('content-disposition') || '', /^inline/);
+    assert.strictEqual(res.headers.get('accept-ranges'), 'bytes');
+    assert.strictEqual(res.headers.get('x-content-type-options'), 'nosniff');
+
+    // iOS Safari probes with a tiny Range and refuses to play on a plain 200
+    const r2 = await fetch(raw, { headers: { Range: 'bytes=0-1' } });
+    assert.strictEqual(r2.status, 206);
+    assert.strictEqual(r2.headers.get('content-range'), 'bytes 0-1/25');
+    assert.strictEqual(await r2.text(), 'FA');
+
+    const r3 = await fetch(raw, { headers: { Range: 'bytes=15-' } });
+    assert.strictEqual(r3.status, 206);
+    assert.strictEqual(r3.headers.get('content-range'), 'bytes 15-24/25');
+    assert.strictEqual(await r3.text(), '0123456789');
+
+    const r4 = await fetch(raw, { headers: { Range: 'bytes=999-' } });
+    assert.strictEqual(r4.status, 416);
+    assert.strictEqual(r4.headers.get('content-range'), 'bytes */25');
+  } finally {
+    await s.stop();
+  }
+});
+
 test('raw=1 for a uri NOT listed on any card → 404 (auth guard holds for raw too)', async () => {
   const s = await startServerWithLieutenant();
   try {

--- a/test/attachments.test.js
+++ b/test/attachments.test.js
@@ -40,6 +40,25 @@ test('upload → stored + served with the right Content-Type and correct size', 
   }
 });
 
+test('video attachment serve honors Range (206 slice) for <video> playback', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const up = await s.api('POST', '/api/attachments', { name: 'clip.mp4', mime: 'video/mp4', dataBase64: b64('FAKE-MP4-BYTES') });
+    assert.strictEqual(up.status, 200);
+    const url = s.base + '/api/attachments/' + up.body.id;
+    const full = await fetch(url);
+    assert.strictEqual(full.status, 200);
+    assert.strictEqual(full.headers.get('accept-ranges'), 'bytes');
+    const r = await fetch(url, { headers: { Range: 'bytes=5-7' } });
+    assert.strictEqual(r.status, 206);
+    assert.strictEqual(r.headers.get('content-range'), 'bytes 5-7/14');
+    assert.strictEqual(r.headers.get('content-type'), 'video/mp4');
+    assert.strictEqual(await r.text(), 'MP4');
+  } finally {
+    await s.stop();
+  }
+});
+
 test('over-cap upload → 413', async () => {
   const s = await startServerWithLieutenant({ env: { BC_UPLOAD_MAX_BYTES: '64' } });
   try {

--- a/ui/app.css
+++ b/ui/app.css
@@ -999,8 +999,8 @@ a.a-uri { color: var(--accent); }
    so .md block styles (from the shared markdown section) apply as on a card body */
 #av-body.md { font-family: var(--sans); font-size: 15px; white-space: normal; }
 /* image attachment preview (shares the av-overlay) */
-#av-img-wrap { flex: 1; min-height: 60px; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
-#av-img { max-width: 100%; max-height: 76vh; object-fit: contain; border-radius: 6px; }
+#av-img-wrap, #av-video-wrap { flex: 1; min-height: 60px; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
+#av-img, #av-video { max-width: 100%; max-height: 76vh; object-fit: contain; border-radius: 6px; }
 /* rendered html artifact (shares the av-overlay) — fills the body; white backdrop
    so a self-contained page renders on its own canvas, not the board's dark bg */
 #av-frame { flex: 1; min-height: 60px; width: 100%; border: 0; background: #fff; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -284,6 +284,7 @@
     <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-src" title="toggle rendered / source" hidden>&lt;/&gt;</button><button id="av-expand" title="expand">⛶</button><button id="av-close" title="close">✕</button></div>
     <pre id="av-body"></pre>
     <div id="av-img-wrap" hidden><img id="av-img" alt=""></div>
+    <div id="av-video-wrap" hidden><video id="av-video" controls playsinline preload="metadata"></video></div>
     <iframe id="av-frame" sandbox="allow-scripts" hidden></iframe>
   </div>
 </div>

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -188,6 +188,8 @@ const avName = document.getElementById('av-name');
 const avBody = document.getElementById('av-body');
 const avImgWrap = document.getElementById('av-img-wrap');
 const avImg = document.getElementById('av-img');
+const avVideoWrap = document.getElementById('av-video-wrap');
+const avVideo = document.getElementById('av-video');
 const avFrame = document.getElementById('av-frame');
 const avExpand = document.getElementById('av-expand');
 const avDownload = document.getElementById('av-download');
@@ -200,6 +202,10 @@ function avReset(name, uri) {
   avName.title = uri || name;
   avImgWrap.hidden = true;
   avImg.removeAttribute('src');
+  avVideoWrap.hidden = true;
+  avVideo.pause();
+  avVideo.removeAttribute('src');
+  avVideo.load(); // actually drop the previous stream (removeAttribute alone doesn't)
   avFrame.hidden = true;
   avFrame.removeAttribute('src'); // drop the previous page so it can't linger
   avBody.hidden = false;
@@ -260,6 +266,12 @@ async function openArtifact(uri) {
     avBody.hidden = true; avImgWrap.hidden = false; avImg.src = rawUrl; avImg.alt = title;
     return;
   }
+  if (VIDEO_EXT.test(name)) {
+    // Inline player fed by the same raw serve the ⬇ button uses. No autoplay.
+    avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
+    avBody.hidden = true; avVideoWrap.hidden = false; avVideo.src = rawUrl;
+    return;
+  }
   if (HTML_EXT.test(name)) {
     // A rendered .html/.htm page (teach-me, report): show it live in a sandboxed
     // iframe (allow-scripts, no same-origin) fed by the raw serve, which sends a
@@ -291,9 +303,11 @@ async function openArtifact(uri) {
 // (never /api/artifact — an attachment need not be a promoted card artifact).
 const TEXTY_MIME = /^(text\/|application\/(json|xml|javascript|x-sh|x-yaml|yaml|csv|x-www-form-urlencoded)|image\/svg)/;
 const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i;
+const VIDEO_EXT = /\.(mp4|mov|webm|m4v)$/i;
+const isVideoMime = (m) => /^video\//.test(String(m || ''));
 const TEXT_EXT = /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i;
 // Known binaries — never worth a text preview; offer a download straight away.
-const BIN_EXT = /\.(pdf|zip|gz|tgz|tar|xlsx?|docx?|pptx?|bin|exe|dmg|iso|mp4|mov|webm|mp3|wav|ogg|flac|woff2?|ttf|otf|parquet|pkl|npz|so|dll|wasm|class|jar)$/i;
+const BIN_EXT = /\.(pdf|zip|gz|tgz|tar|xlsx?|docx?|pptx?|bin|exe|dmg|iso|mp3|wav|ogg|flac|woff2?|ttf|otf|parquet|pkl|npz|so|dll|wasm|class|jar)$/i;
 export async function openAttachment(att) {
   const url = '/api/attachments/' + encodeURIComponent(att.id);
   const name = att.name || '';
@@ -302,6 +316,7 @@ export async function openAttachment(att) {
   avDownload.setAttribute('download', name || 'file');
   avDownload.hidden = false;
   const showImage = () => { avBody.hidden = true; avImgWrap.hidden = false; avImg.src = url; avImg.alt = name; };
+  const showVideo = () => { avBody.hidden = true; avVideoWrap.hidden = false; avVideo.src = url; };
   const showText = (text) => {
     if (isMdArtifact(att, name)) showMarkdown(text);
     else { avBody.className = ''; avBody.textContent = text; }
@@ -311,6 +326,7 @@ export async function openAttachment(att) {
   // {uri, label}, so its mime may be unknown — then consult the served
   // Content-Type before falling back to a download.
   if (isImageMime(mime) || (!mime && IMG_EXT.test(name))) return showImage();
+  if (isVideoMime(mime) || (!mime && VIDEO_EXT.test(name))) return showVideo();
   if (TEXTY_MIME.test(mime) || (!mime && TEXT_EXT.test(name))) {
     avBody.textContent = 'loading…';
     try {
@@ -329,6 +345,7 @@ export async function openAttachment(att) {
     if (!r.ok) throw new Error('HTTP ' + r.status);
     const ct = (r.headers.get('content-type') || '').split(';')[0];
     if (isImageMime(ct)) return showImage();
+    if (isVideoMime(ct)) return showVideo();
     if (TEXTY_MIME.test(ct)) return showText(await r.text());
     avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
   } catch (e) { avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)'; }
@@ -338,7 +355,7 @@ export async function openAttachment(att) {
 // state.js onRender: a setter avoids a circular import back into main.js.
 let onCloseFn = () => {};
 export function onArtifactClose(fn) { onCloseFn = fn; }
-export function closeArtifact() { avOverlay.hidden = true; onCloseFn(); }
+export function closeArtifact() { avOverlay.hidden = true; avVideo.pause(); onCloseFn(); }
 export function artifactOpen() { return !avOverlay.hidden; }
 document.getElementById('av-close').onclick = closeArtifact;
 // Maximize / restore the viewer (pure CSS class toggle — see #av-modal.expanded).


### PR DESCRIPTION
Captain had to download worker-generated videos to watch them. Now `mp4|mov|webm|m4v` render an inline `<video controls>` player in the viewer, both for card artifacts (`openArtifact`, extension dispatch) and chat attachments (`openAttachment`, mime dispatch + served-Content-Type fallthrough). Same raw URL as the ⬇ download button (which stays visible), no autoplay, `playsinline` for the phone, sized like the image preview.

Server side, two things the `<video>` tag actually needed:
- `ARTIFACT_MIME` had no video entries, so the raw serve sent `application/octet-stream` + nosniff + `Content-Disposition: attachment` — unplayable. Added the four video types and made `video/*` inline.
- Neither byte serve honored Range requests; iOS Safari probes with `Range: bytes=0-1` and refuses to play from a server that answers 200. Added a small shared `sendBytes` helper (single-range 206, 416 on unsatisfiable, `Accept-Ranges: bytes`) used by both `/api/artifact?raw=1` and `/api/attachments/:id`.

Verified in Chrome against a real ffmpeg-generated mp4: inline playback in the modal from both the artifact and attachment paths, correct headers (`video/mp4`, inline, 206 slices). Full suite green: 341 tests (339 + 2 new covering video content-type/disposition and Range on both serves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)