### PR TITLE
Tri-state include/exclude filters for lieutenant + label

### DIFF
--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -1,0 +1,105 @@
+'use strict';
+// ui/js/state.js — the tri-state owner/label filter seams: setFilter (the
+// popup's 3-position switch), toggleFilter (board/table/detail include
+// toggles), and selMatches/cardVisible semantics (excludes drop the card
+// outright; includes are OR within a dimension, AND across). state.js touches
+// no DOM at import, so it's imported directly (state-actor.test.js pattern).
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let S, setFilter, toggleFilter, filterMode, filterSelected, cardVisible, clearFilters, activeFilterCount;
+test.before(async () => {
+  ({ S, setFilter, toggleFilter, filterMode, filterSelected, cardVisible, clearFilters, activeFilterCount } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'state.js')).href));
+});
+
+const CARDS = [
+  { id: 'a', owner: 'monica', labels: ['infra'] },
+  { id: 'b', owner: 'rex', labels: ['ux', 'infra'] },
+  { id: 'c', owner: 'rex', labels: [] },
+  { id: 'd', owner: 'ada', labels: ['ux'] },
+];
+function visible() { return CARDS.filter(cardVisible).map((c) => c.id).join(''); }
+test.beforeEach(() => { S.filters = { text: '', age: '', sel: [], types: [], columns: [] }; });
+
+test('no owner/label selections: everything visible', () => {
+  assert.strictEqual(visible(), 'abcd');
+});
+
+test('include-only: owner include keeps only that owner; two includes OR', () => {
+  setFilter('owner', 'monica', 'in');
+  assert.strictEqual(visible(), 'a');
+  setFilter('owner', 'ada', 'in');
+  assert.strictEqual(visible(), 'ad');
+});
+
+test('include-only: label includes OR within the dimension', () => {
+  setFilter('label', 'infra', 'in');
+  assert.strictEqual(visible(), 'ab');
+  setFilter('label', 'ux', 'in');
+  assert.strictEqual(visible(), 'abd');
+});
+
+test('exclude-only: excluded owner/label cards are dropped, rest untouched', () => {
+  setFilter('owner', 'rex', 'out');
+  assert.strictEqual(visible(), 'ad');
+  setFilter('label', 'ux', 'out');
+  assert.strictEqual(visible(), 'a');
+});
+
+test('mixed: include and exclude compose across dimensions', () => {
+  setFilter('label', 'infra', 'in');
+  setFilter('owner', 'rex', 'out');
+  assert.strictEqual(visible(), 'a'); // infra cards minus rex's
+});
+
+test('mixed within one dimension: include one owner, exclude another', () => {
+  setFilter('owner', 'monica', 'in');
+  setFilter('owner', 'rex', 'out');
+  assert.strictEqual(visible(), 'a');
+});
+
+test('setFilter: direct set, overwrite, and back to dont-care', () => {
+  setFilter('owner', 'rex', 'out');
+  assert.strictEqual(filterMode('owner', 'rex'), 'out');
+  setFilter('owner', 'rex', 'in');
+  assert.strictEqual(filterMode('owner', 'rex'), 'in');
+  assert.strictEqual(S.filters.sel.length, 1); // overwrote, not stacked
+  setFilter('owner', 'rex', '');
+  assert.strictEqual(filterMode('owner', 'rex'), '');
+  assert.strictEqual(S.filters.sel.length, 0);
+});
+
+test('toggleFilter stays a plain include on/off; an exclude flips to include', () => {
+  toggleFilter('label', 'ux');
+  assert.strictEqual(filterMode('label', 'ux'), 'in');
+  toggleFilter('label', 'ux');
+  assert.strictEqual(filterMode('label', 'ux'), '');
+  setFilter('label', 'ux', 'out');
+  toggleFilter('label', 'ux');
+  assert.strictEqual(filterMode('label', 'ux'), 'in');
+});
+
+test('filterSelected means include only; excludes count in the badge', () => {
+  setFilter('owner', 'rex', 'out');
+  assert.strictEqual(filterSelected('owner', 'rex'), false);
+  setFilter('owner', 'monica', 'in');
+  assert.strictEqual(filterSelected('owner', 'monica'), true);
+  assert.strictEqual(activeFilterCount(), 2);
+});
+
+test('mode-less entries (older paths) behave as includes', () => {
+  S.filters.sel.push({ kind: 'owner', value: 'monica' });
+  assert.strictEqual(filterMode('owner', 'monica'), 'in');
+  assert.strictEqual(visible(), 'a');
+});
+
+test('clearFilters wipes includes and excludes', () => {
+  setFilter('owner', 'rex', 'out');
+  setFilter('label', 'infra', 'in');
+  clearFilters();
+  assert.strictEqual(S.filters.sel.length, 0);
+  assert.strictEqual(visible(), 'abcd');
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -1214,15 +1214,23 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
   border: 1px solid var(--line); border-radius: 8px; background: var(--panel);
 }
 .fp-tri {
-  display: flex; align-items: center; gap: 8px; background: none; border: 0; cursor: pointer;
-  color: var(--dim); font-size: 12px; padding: 7px 10px; text-align: left;
+  display: flex; align-items: center; justify-content: space-between; gap: 10px;
+  color: var(--dim); font-size: 12px; padding: 5px 10px;
 }
-.fp-tri:hover { background: var(--accent-soft); }
-.fp-tri .st { flex: none; width: 14px; text-align: center; color: var(--faint); }
 .fp-tri .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.fp-tri.in, .fp-tri.in .st { color: var(--accent); }
-.fp-tri.out, .fp-tri.out .st { color: var(--danger); }
-.fp-tri.out .nm { text-decoration: line-through; opacity: .85; }
+.fp-tri.in .nm { color: var(--ok); }
+.fp-tri.out .nm { color: var(--danger); text-decoration: line-through; opacity: .85; }
+/* the 3-position switch: ⊘ exclude / · don't care / ✓ include, direct tap */
+.fp-sw { flex: none; display: flex; border: 1px solid var(--line); border-radius: 999px; overflow: hidden; }
+.fp-sw button {
+  background: none; border: 0; cursor: pointer; color: var(--faint);
+  font-size: 12px; line-height: 1; padding: 5px 9px;
+}
+.fp-sw button + button { border-left: 1px solid var(--line); }
+.fp-sw button:hover { color: var(--dim); background: var(--panel2); }
+.fp-sw .sw-out.on { background: rgba(239, 100, 97, .22); color: var(--danger); }
+.fp-sw .sw-off.on { background: var(--panel3); color: var(--text); }
+.fp-sw .sw-in.on { background: rgba(62, 207, 142, .2); color: var(--ok); }
 /* exclude chips: same removable chip, visibly negated */
 .fchip.ex { background: #7c2f2e; color: #ffe3e2; }
 .fchip.ex > span:first-child { text-decoration: line-through; }
@@ -1264,8 +1272,9 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
 @media (max-width: 760px) {
   #filter-open { display: inline-flex; }
   #topbar.searching #filter-open { display: none; }
-  /* fatter tri-state rows for thumbs */
-  .fp-tri { padding: 10px 12px; font-size: 13px; }
+  /* fatter tri-state rows + switch targets for thumbs */
+  .fp-tri { padding: 6px 12px; font-size: 13px; }
+  .fp-sw button { padding: 8px 12px; font-size: 13px; }
   .fp-dd-list { max-height: 220px; }
   /* the mode switcher collapses to ONE button — the current mode; tapping it
      opens the #mode-menu dropdown (main.js) */

--- a/ui/app.css
+++ b/ui/app.css
@@ -1194,7 +1194,7 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
 .fp-chips { display: flex; flex-wrap: wrap; gap: 5px; }
 .fp-chips .fchip { cursor: pointer; }
 .fp-row { display: flex; align-items: center; gap: 8px; }
-.fp-lbl { flex: none; width: 58px; font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: .8px; color: var(--faint); }
+.fp-lbl { flex: none; width: 74px; font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: .8px; color: var(--faint); }
 .fp-row select {
   flex: 1; min-width: 0; background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
   color: var(--dim); font-size: 12px; padding: 5px 8px;

--- a/ui/app.css
+++ b/ui/app.css
@@ -1200,6 +1200,33 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
   color: var(--dim); font-size: 12px; padding: 5px 8px;
 }
 .fp-row select:hover, .fp-row select:focus { border-color: var(--accent2); }
+/* tri-state owner/label pickers: trigger + unfolded row list */
+.fp-dd { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.fp-dd-btn {
+  display: flex; justify-content: space-between; align-items: center; gap: 8px;
+  background: var(--panel); border: 1px solid var(--line); border-radius: 8px;
+  color: var(--dim); font-size: 12px; padding: 5px 8px; cursor: pointer; text-align: left;
+}
+.fp-dd-btn:hover, .fp-dd-btn.open { border-color: var(--accent2); }
+.fp-dd-btn .car { color: var(--faint); font-size: 10px; }
+.fp-dd-list {
+  display: flex; flex-direction: column; max-height: 180px; overflow-y: auto;
+  border: 1px solid var(--line); border-radius: 8px; background: var(--panel);
+}
+.fp-tri {
+  display: flex; align-items: center; gap: 8px; background: none; border: 0; cursor: pointer;
+  color: var(--dim); font-size: 12px; padding: 7px 10px; text-align: left;
+}
+.fp-tri:hover { background: var(--accent-soft); }
+.fp-tri .st { flex: none; width: 14px; text-align: center; color: var(--faint); }
+.fp-tri .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fp-tri.in, .fp-tri.in .st { color: var(--accent); }
+.fp-tri.out, .fp-tri.out .st { color: var(--danger); }
+.fp-tri.out .nm { text-decoration: line-through; opacity: .85; }
+/* exclude chips: same removable chip, visibly negated */
+.fchip.ex { background: #7c2f2e; color: #ffe3e2; }
+.fchip.ex > span:first-child { text-decoration: line-through; }
+.fchip.ex:hover { background: var(--danger); color: #fff; }
 .fp-foot { display: flex; justify-content: flex-end; margin-top: 2px; }
 #fp-clear {
   font-size: 12px; color: var(--dim); border: 1px solid var(--line); border-radius: 8px; padding: 4px 10px;
@@ -1237,6 +1264,9 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
 @media (max-width: 760px) {
   #filter-open { display: inline-flex; }
   #topbar.searching #filter-open { display: none; }
+  /* fatter tri-state rows for thumbs */
+  .fp-tri { padding: 10px 12px; font-size: 13px; }
+  .fp-dd-list { max-height: 220px; }
   /* the mode switcher collapses to ONE button — the current mode; tapping it
      opens the #mode-menu dropdown (main.js) */
   #view-seg button { display: none; }

--- a/ui/js/filterpop.js
+++ b/ui/js/filterpop.js
@@ -54,11 +54,14 @@ const AGES = [
   { v: '259200', t: 'last 3 days' }, { v: '604800', t: 'last week' },
 ];
 // a multi-toggle chip group for a small enum dimension (status / type):
-// every option shows, the selected ones light up — OR within the dimension
+// every option shows, the selected ones light up — OR within the dimension.
+// An option with a short form `s` (its emoji) renders that alone, keeping the
+// full text `t` as title/aria-label, so the group fits one line.
 function optChips(dim, list) {
   return '<span class="fp-opts">' + list.map((o) =>
-    '<button type="button" class="fp-opt' + (S.filters[dim].includes(o.v) ? ' on' : '') + '" data-dim="' + dim + '" data-v="' + esc(o.v) + '">' +
-    esc(o.t) + '</button>').join('') + '</span>';
+    '<button type="button" class="fp-opt' + (S.filters[dim].includes(o.v) ? ' on' : '') + '" data-dim="' + dim + '" data-v="' + esc(o.v) + '"' +
+    (o.s ? ' title="' + esc(o.t) + '" aria-label="' + esc(o.t) + '"' : '') + '>' +
+    esc(o.s || o.t) + '</button>').join('') + '</span>';
 }
 // which tri-state dropdown list is unfolded ('owner' | 'label' | null) — kept
 // across repaints so cycling a row doesn't snap the list shut
@@ -95,10 +98,10 @@ function renderFilterPanel() {
     (chips ? '<div class="fp-chips">' + chips + '</div>' : '') +
     (archMode ? '<div class="fp-note">🧊 archived mode — status/updated don\'t apply to frozen snapshots</div>'
       : '<div class="fp-row"><span class="fp-lbl">status</span>' +
-        optChips('columns', columns().map((k) => ({ v: k.id, t: k.title }))) + '</div>') +
+        optChips('columns', columns().map((k) => ({ v: k.id, t: k.title, s: k.title.split(/\s+/)[0] }))) + '</div>') +
     '<div class="fp-row"><span class="fp-lbl">type</span>' +
-    optChips('types', [{ v: 'plan', t: '🧠 plan' }, { v: 'implementation', t: '🔥 impl' }, { v: 'investigation', t: '🕵️ invest' }]) + '</div>' +
-    '<div class="fp-row"><span class="fp-lbl">owner</span>' +
+    optChips('types', [{ v: 'plan', t: '🧠 plan', s: '🧠' }, { v: 'implementation', t: '🔥 impl', s: '🔥' }, { v: 'investigation', t: '🕵️ invest', s: '🕵️' }]) + '</div>' +
+    '<div class="fp-row"><span class="fp-lbl">lieutenant</span>' +
     triDd('owner', lieutenants().map((l) => ({ v: l.id, t: l.name || l.id }))) + '</div>' +
     '<div class="fp-row"><span class="fp-lbl">label</span>' +
     triDd('label', registryLabels().map((l) => ({ v: l.name, t: l.name }))) + '</div>' +

--- a/ui/js/filterpop.js
+++ b/ui/js/filterpop.js
@@ -5,7 +5,7 @@
 // mode shares this state (S.filters) — clicking a label or owner anywhere adds
 // a chip here. In 🧊 archived mode the popup slims down to what makes sense on
 // frozen snapshots (owner/label/type); status and updated hide.
-import { S, lieutenants, columns, render, clearFilters, activeFilterCount, cycleFilter, filterMode, toggleDim } from './state.js';
+import { S, lieutenants, columns, render, clearFilters, activeFilterCount, setFilter, filterMode, toggleDim } from './state.js';
 import { registryLabels } from './labels.js';
 import { esc, setHtmlIfChanged } from './util.js';
 
@@ -63,17 +63,21 @@ function optChips(dim, list) {
 // which tri-state dropdown list is unfolded ('owner' | 'label' | null) — kept
 // across repaints so cycling a row doesn't snap the list shut
 let ddOpen = null;
-// a tri-state picker row set: every option shows its state (· don't care /
-// ✓ include / ⊘ exclude); a click cycles it. The trigger sums up the picks.
+// a tri-state picker row set: every option carries a 3-position switch
+// (⊘ exclude / · don't care / ✓ include) — a tap sets the state directly.
+// The trigger sums up the picks.
 function triDd(kind, list) {
   const nIn = list.filter((o) => filterMode(kind, o.v) === 'in').length;
   const nOut = list.filter((o) => filterMode(kind, o.v) === 'out').length;
   const sum = (nIn ? '✓' + nIn : '') + (nIn && nOut ? ' ' : '') + (nOut ? '⊘' + nOut : '');
   const open = ddOpen === kind;
+  const seg = (kind2, v, m, mode, glyph) =>
+    '<button type="button" class="sw-' + (mode || 'off') + (m === mode ? ' on' : '') +
+    '" data-sw="' + kind2 + '" data-v="' + esc(v) + '" data-m="' + mode + '">' + glyph + '</button>';
   const rows = list.map((o) => {
     const m = filterMode(kind, o.v);
-    return '<button type="button" class="fp-tri' + (m ? ' ' + m : '') + '" data-tri="' + kind + '" data-v="' + esc(o.v) + '">' +
-      '<span class="st">' + (m === 'in' ? '✓' : m === 'out' ? '⊘' : '·') + '</span><span class="nm">' + esc(o.t) + '</span></button>';
+    return '<div class="fp-tri' + (m ? ' ' + m : '') + '"><span class="nm">' + esc(o.t) + '</span>' +
+      '<span class="fp-sw">' + seg(kind, o.v, m, 'out', '⊘') + seg(kind, o.v, m, '', '·') + seg(kind, o.v, m, 'in', '✓') + '</span></div>';
   }).join('');
   return '<div class="fp-dd">' +
     '<button type="button" class="fp-dd-btn' + (open ? ' open' : '') + '" data-dd="' + kind + '">' +
@@ -113,8 +117,8 @@ function wire() {
   for (const b of panel.querySelectorAll('[data-dd]')) {
     b.onclick = () => { ddOpen = ddOpen === b.dataset.dd ? null : b.dataset.dd; panel.__bcHtml = null; renderFilterPanel(); };
   }
-  for (const b of panel.querySelectorAll('.fp-tri')) {
-    b.onclick = () => cycleFilter(b.dataset.tri, b.dataset.v);
+  for (const b of panel.querySelectorAll('[data-sw]')) {
+    b.onclick = () => setFilter(b.dataset.sw, b.dataset.v, b.dataset.m);
   }
   for (const chip of panel.querySelectorAll('.fchip')) {
     chip.onclick = () => {

--- a/ui/js/filterpop.js
+++ b/ui/js/filterpop.js
@@ -5,7 +5,7 @@
 // mode shares this state (S.filters) — clicking a label or owner anywhere adds
 // a chip here. In 🧊 archived mode the popup slims down to what makes sense on
 // frozen snapshots (owner/label/type); status and updated hide.
-import { S, lieutenants, columns, render, clearFilters, activeFilterCount, toggleFilter, toggleDim } from './state.js';
+import { S, lieutenants, columns, render, clearFilters, activeFilterCount, cycleFilter, filterMode, toggleDim } from './state.js';
 import { registryLabels } from './labels.js';
 import { esc, setHtmlIfChanged } from './util.js';
 
@@ -14,7 +14,7 @@ const badge = document.getElementById('filter-btn-n');
 const panel = document.getElementById('filter-panel');
 
 export function filterPanelOpen() { return !panel.hidden; }
-export function closeFilterPanel() { panel.hidden = true; btn.classList.remove('on'); }
+export function closeFilterPanel() { panel.hidden = true; btn.classList.remove('on'); ddOpen = null; }
 export function openFilterPanel() {
   panel.hidden = false;
   btn.classList.add('on');
@@ -31,7 +31,10 @@ btn.onclick = (e) => {
   if (filterPanelOpen()) closeFilterPanel(); else openFilterPanel();
 };
 document.addEventListener('click', (e) => {
-  if (!panel.hidden && !panel.contains(e.target) && !btn.contains(e.target)) closeFilterPanel();
+  // composedPath, not contains: a tri-state row click repaints the panel
+  // synchronously, so by the time the click bubbles here its target is detached
+  const path = e.composedPath ? e.composedPath() : [];
+  if (!panel.hidden && !path.includes(panel) && !path.includes(btn)) closeFilterPanel();
 });
 
 // badge + (when open) panel content — called from the main render pass
@@ -57,11 +60,32 @@ function optChips(dim, list) {
     '<button type="button" class="fp-opt' + (S.filters[dim].includes(o.v) ? ' on' : '') + '" data-dim="' + dim + '" data-v="' + esc(o.v) + '">' +
     esc(o.t) + '</button>').join('') + '</span>';
 }
+// which tri-state dropdown list is unfolded ('owner' | 'label' | null) — kept
+// across repaints so cycling a row doesn't snap the list shut
+let ddOpen = null;
+// a tri-state picker row set: every option shows its state (· don't care /
+// ✓ include / ⊘ exclude); a click cycles it. The trigger sums up the picks.
+function triDd(kind, list) {
+  const nIn = list.filter((o) => filterMode(kind, o.v) === 'in').length;
+  const nOut = list.filter((o) => filterMode(kind, o.v) === 'out').length;
+  const sum = (nIn ? '✓' + nIn : '') + (nIn && nOut ? ' ' : '') + (nOut ? '⊘' + nOut : '');
+  const open = ddOpen === kind;
+  const rows = list.map((o) => {
+    const m = filterMode(kind, o.v);
+    return '<button type="button" class="fp-tri' + (m ? ' ' + m : '') + '" data-tri="' + kind + '" data-v="' + esc(o.v) + '">' +
+      '<span class="st">' + (m === 'in' ? '✓' : m === 'out' ? '⊘' : '·') + '</span><span class="nm">' + esc(o.t) + '</span></button>';
+  }).join('');
+  return '<div class="fp-dd">' +
+    '<button type="button" class="fp-dd-btn' + (open ? ' open' : '') + '" data-dd="' + kind + '">' +
+    '<span>' + (sum || 'any') + '</span><span class="car">' + (open ? '▴' : '▾') + '</span></button>' +
+    (open ? '<div class="fp-dd-list">' + rows + '</div>' : '') + '</div>';
+}
 function renderFilterPanel() {
   const f = S.filters;
   const archMode = S.boardMode === 'archive';
   const chips = f.sel.map((s, i) =>
-    '<span class="fchip" data-i="' + i + '" title="remove this filter"><span>' +
+    '<span class="fchip' + (s.mode === 'out' ? ' ex' : '') + '" data-i="' + i +
+    '" title="remove this filter"><span>' + (s.mode === 'out' ? '⊘ ' : '') +
     (s.kind === 'owner' ? '@' : '') + esc(s.value) + '</span><span class="x">✕</span></span>').join('');
   const html =
     (chips ? '<div class="fp-chips">' + chips + '</div>' : '') +
@@ -70,10 +94,10 @@ function renderFilterPanel() {
         optChips('columns', columns().map((k) => ({ v: k.id, t: k.title }))) + '</div>') +
     '<div class="fp-row"><span class="fp-lbl">type</span>' +
     optChips('types', [{ v: 'plan', t: '🧠 plan' }, { v: 'implementation', t: '🔥 impl' }, { v: 'investigation', t: '🕵️ invest' }]) + '</div>' +
-    '<div class="fp-row"><span class="fp-lbl">owner</span><select data-fp-add="owner">' +
-    opts([{ v: '', t: 'add owner…' }].concat(lieutenants().map((l) => ({ v: l.id, t: l.name || l.id }))), '') + '</select></div>' +
-    '<div class="fp-row"><span class="fp-lbl">label</span><select data-fp-add="label">' +
-    opts([{ v: '', t: 'add label…' }].concat(registryLabels().map((l) => ({ v: l.name, t: l.name }))), '') + '</select></div>' +
+    '<div class="fp-row"><span class="fp-lbl">owner</span>' +
+    triDd('owner', lieutenants().map((l) => ({ v: l.id, t: l.name || l.id }))) + '</div>' +
+    '<div class="fp-row"><span class="fp-lbl">label</span>' +
+    triDd('label', registryLabels().map((l) => ({ v: l.name, t: l.name }))) + '</div>' +
     (archMode ? '' : '<div class="fp-row"><span class="fp-lbl">updated</span><select data-fp="age">' + opts(AGES, f.age) + '</select></div>') +
     '<div class="fp-foot"><button id="fp-clear"' + (activeFilterCount() || f.text ? '' : ' disabled') + '>clear all</button></div>';
   if (!setHtmlIfChanged(panel, html)) return;
@@ -86,13 +110,11 @@ function wire() {
   for (const b of panel.querySelectorAll('.fp-opt')) {
     b.onclick = () => toggleDim(b.dataset.dim, b.dataset.v);
   }
-  // owner/label are multi: choosing adds a chip; the select snaps back to its placeholder
-  for (const sel of panel.querySelectorAll('[data-fp-add]')) {
-    sel.onchange = () => {
-      const v = sel.value;
-      sel.value = '';
-      if (v) toggleFilter(sel.dataset.fpAdd, v);
-    };
+  for (const b of panel.querySelectorAll('[data-dd]')) {
+    b.onclick = () => { ddOpen = ddOpen === b.dataset.dd ? null : b.dataset.dd; panel.__bcHtml = null; renderFilterPanel(); };
+  }
+  for (const b of panel.querySelectorAll('.fp-tri')) {
+    b.onclick = () => cycleFilter(b.dataset.tri, b.dataset.v);
   }
   for (const chip of panel.querySelectorAll('.fchip')) {
     chip.onclick = () => {

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -208,14 +208,13 @@ export function toggleFilter(kind, value) {
   if (!wasIn) S.filters.sel.push({ kind, value, mode: 'in' });
   render();
 }
-// the popup's tri-state rows: don't care → include → exclude → don't care
-export function cycleFilter(kind, value) {
+// the popup's per-item 3-position switch: set the state directly
+// (mode '' = don't care, 'in' = include, 'out' = exclude)
+export function setFilter(kind, value, mode) {
   if (!value) return;
-  const cur = filterMode(kind, value);
   const i = S.filters.sel.findIndex((f) => f.kind === kind && f.value === value);
   if (i >= 0) S.filters.sel.splice(i, 1);
-  if (cur === '') S.filters.sel.push({ kind, value, mode: 'in' });
-  else if (cur === 'in') S.filters.sel.push({ kind, value, mode: 'out' });
+  if (mode === 'in' || mode === 'out') S.filters.sel.push({ kind, value, mode });
   render();
 }
 export function clearFilters() {

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -192,11 +192,30 @@ export function notifItems() {
 export function notifUnreadCount() { return notifItems().filter((e) => !e.read).length; }
 
 // ---------- filters ----------
-export function filterSelected(kind, value) { return S.filters.sel.some((f) => f.kind === kind && f.value === value); }
+// Owner/label selections are tri-state: mode 'in' (include) or 'out' (exclude);
+// absent = don't care. Entries without a mode (older paths) count as 'in'.
+export function filterMode(kind, value) {
+  const f = S.filters.sel.find((x) => x.kind === kind && x.value === value);
+  return f ? f.mode || 'in' : '';
+}
+export function filterSelected(kind, value) { return filterMode(kind, value) === 'in'; }
+// board/table/detail owner+label clicks: plain include on/off (never exclude)
 export function toggleFilter(kind, value) {
   if (!value) return;
   const i = S.filters.sel.findIndex((f) => f.kind === kind && f.value === value);
-  if (i >= 0) S.filters.sel.splice(i, 1); else S.filters.sel.push({ kind, value });
+  const wasIn = i >= 0 && (S.filters.sel[i].mode || 'in') === 'in';
+  if (i >= 0) S.filters.sel.splice(i, 1);
+  if (!wasIn) S.filters.sel.push({ kind, value, mode: 'in' });
+  render();
+}
+// the popup's tri-state rows: don't care → include → exclude → don't care
+export function cycleFilter(kind, value) {
+  if (!value) return;
+  const cur = filterMode(kind, value);
+  const i = S.filters.sel.findIndex((f) => f.kind === kind && f.value === value);
+  if (i >= 0) S.filters.sel.splice(i, 1);
+  if (cur === '') S.filters.sel.push({ kind, value, mode: 'in' });
+  else if (cur === 'in') S.filters.sel.push({ kind, value, mode: 'out' });
   render();
 }
 export function clearFilters() {
@@ -244,12 +263,15 @@ export function cardVisible(c) {
   if (S.filters.columns.length && !S.filters.columns.includes(c.column)) return false;
   return selMatches(c);
 }
-// the owner/label chips: OR within each dimension, AND across them — two
-// owners selected means "either owner", never the impossible "both"
+// the owner/label chips: excludes drop the card outright; includes are OR
+// within each dimension, AND across them — two owners included means "either
+// owner", never the impossible "both"
 export function selMatches(c) {
-  const owners = [], labels = [];
-  for (const f of S.filters.sel) (f.kind === 'owner' ? owners : labels).push(f.value);
-  if (owners.length && !owners.includes(c.owner || '')) return false;
-  if (labels.length && !labels.some((n) => (c.labels || []).includes(n))) return false;
+  const inc = { owner: [], label: [] }, exc = { owner: [], label: [] };
+  for (const f of S.filters.sel) ((f.mode === 'out' ? exc : inc)[f.kind] || []).push(f.value);
+  if (exc.owner.includes(c.owner || '')) return false;
+  if (exc.label.some((n) => (c.labels || []).includes(n))) return false;
+  if (inc.owner.length && !inc.owner.includes(c.owner || '')) return false;
+  if (inc.label.length && !inc.label.some((n) => (c.labels || []).includes(n))) return false;
   return true;
 }


### PR DESCRIPTION
The filter popup's owner/label pickers could only ADD include chips. The captain wants both directions: for each lieutenant and each label, three states — don't care / include / exclude.

- Each lieutenant/label row in the popup now carries a 3-position switch (⊘ red exclude / · gray don't care / ✓ green include); every position is directly tappable and the state is always visible. The native add-selects are gone.
- Semantics in `selMatches`: excludes drop a card outright; includes stay OR-within-dimension, AND-across. Archived mode inherits via the shared seam. Board/table/detail owner+label clicks remain plain include toggles.
- Exclude chips render red with ⊘ prefix + strike-through; include chips unchanged.
- Status/type chips are now emoji-only (full text kept as title/aria-label) so the status group fits one line on a phone; "owner" row renamed "lieutenant".
- Fixed a latent popup bug: a synchronous repaint mid-click detached the target before the document's close-on-outside-click ran, snapping the panel shut (`e.composedPath()` now).

Playground-iterated with the captain (3 rounds, approved). Tests: 11 new state-seam cases (include-only, exclude-only, mixed, toggleFilter compat, clearFilters); full suite 350/350 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)