### PR TITLE
Alt-click on owner/label chips = negative filter

### DIFF
--- a/test/filters.test.js
+++ b/test/filters.test.js
@@ -82,6 +82,17 @@ test('toggleFilter stays a plain include on/off; an exclude flips to include', (
   assert.strictEqual(filterMode('label', 'ux'), 'in');
 });
 
+test('toggleFilter with exclude=true (alt-click): exclude on/off; include flips to exclude', () => {
+  toggleFilter('owner', 'rex', true);
+  assert.strictEqual(filterMode('owner', 'rex'), 'out');
+  toggleFilter('owner', 'rex', true);
+  assert.strictEqual(filterMode('owner', 'rex'), '');
+  toggleFilter('owner', 'rex'); // plain click: include
+  toggleFilter('owner', 'rex', true);
+  assert.strictEqual(filterMode('owner', 'rex'), 'out');
+  assert.strictEqual(S.filters.sel.length, 1); // replaced, not stacked
+});
+
 test('filterSelected means include only; excludes count in the badge', () => {
   setFilter('owner', 'rex', 'out');
   assert.strictEqual(filterSelected('owner', 'rex'), false);

--- a/ui/js/archtable.js
+++ b/ui/js/archtable.js
@@ -22,7 +22,7 @@ function rowHtml(row) {
     '<span class="tv-title">' + esc(c.title || c.id) + '</span></td>' +
     '<td class="c-status"><span class="tv-rsn tv-rsn-' + r + '"' + (row.arch.note ? ' title="' + esc(row.arch.note) + '"' : '') + '>' +
     (r === 'merged' ? '🏁 merged' : '🪦 killed') + '</span></td>' +
-    '<td class="c-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) + '" title="filter by lieutenant">' +
+    '<td class="c-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) + '" title="click: filter by lieutenant · alt-click: exclude">' +
     '<span class="dot" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>' + esc((l && l.name) || c.owner) + '</td>' +
     '<td class="c-labels hide-m">' + (c.labels || []).map((n) => labelChipHtml(n, filterSelected('label', n))).join('') + '</td>' +
     '<td class="c-prs hide-m">' + cardPrs(c).map((pr) => prChipHtml(pr)).join('') + '</td>' +
@@ -57,9 +57,9 @@ function wire() {
     tr.onclick = (e) => {
       if (e.target.closest('a')) return;
       const lab = e.target.closest('.label');
-      if (lab) { toggleFilter('label', lab.dataset.label); return; }
+      if (lab) { toggleFilter('label', lab.dataset.label, e.altKey); return; }
       const own = e.target.closest('.c-owner');
-      if (own) { toggleFilter('owner', own.dataset.owner); return; }
+      if (own) { toggleFilter('owner', own.dataset.owner, e.altKey); return; }
       openArchivedDetail(tr.dataset.id); // the frozen snapshot in the card detail
     };
   }

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -71,7 +71,7 @@ function tileHtml(c) {
     (labels || prs || order ? '<div class="t-chips">' + order + labels + prs + '</div>' : '') +
     '<div class="t-foot">' +
     '<span class="t-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) +
-      '" title="filter by lieutenant"><span class="dot" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span>' +
+      '" title="click: filter by lieutenant · alt-click: exclude"><span class="dot" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span>' +
     (repo ? '<span class="t-repo" title="repo">' + esc(repo) + '</span>' : '') +
     hint +
     '<span class="grow"></span>' +
@@ -124,9 +124,9 @@ function wire() {
       const t = e.target;
       if (t.closest('a')) return; // PR chip / link: let the anchor navigate, don't open detail
       if (t.closest('.t-peek')) { openCardPane(el.dataset.id); return; }
-      if (t.classList.contains('label')) { toggleFilter('label', t.dataset.label); return; }
+      if (t.classList.contains('label')) { toggleFilter('label', t.dataset.label, e.altKey); return; }
       const own = t.closest('.t-owner');
-      if (own) { toggleFilter('owner', own.dataset.owner); return; }
+      if (own) { toggleFilter('owner', own.dataset.owner, e.altKey); return; }
       openDetail(el.dataset.id);
     };
     // drag&drop (desktop)

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -484,7 +484,7 @@ export function renderDetail() {
   // data-card keys the markup to THIS card: the chip handlers below close over
   // c, so a same-looking attrs row on another card must not skip the rebuild
   const attrsChanged = setHtmlIfChanged(attrsEl,
-    '<span class="attr attr-owner" data-card="' + esc(c.id) + '" title="filter by lieutenant"><span class="k">lieutenant</span>' +
+    '<span class="attr attr-owner" data-card="' + esc(c.id) + '" title="click: filter by lieutenant · alt-click: exclude"><span class="k">lieutenant</span>' +
     '<span class="v" style="color:' + esc(lieutenantColor(c.owner)) + '">' + esc((lieutenant(c.owner) || {}).name || c.owner) + '</span>' +
     // ✎ only while no worker is bound — mirrors the server guard on owner PATCH.
     // Rendered in the markup (not appended after) so a worker binding/unbinding
@@ -500,7 +500,7 @@ export function renderDetail() {
   const ownerChip = attrsChanged && attrsEl.querySelector('.attr-owner');
   if (ownerChip) {
     ownerChip.style.cursor = 'pointer';
-    ownerChip.onclick = () => toggleFilter('owner', c.owner);
+    ownerChip.onclick = (e) => toggleFilter('owner', c.owner, e.altKey);
     const edit = ownerChip.querySelector('.owner-edit');
     if (edit) edit.onclick = (e) => {
       e.stopPropagation(); // the chip click is the owner filter, not the menu
@@ -521,7 +521,7 @@ export function renderDetail() {
       const chip = document.createElement('span');
       chip.className = 'dlabel';
       chip.innerHTML = labelChipHtml(name, filterSelected('label', name));
-      chip.querySelector('.label').onclick = () => toggleFilter('label', name);
+      chip.querySelector('.label').onclick = (e) => toggleFilter('label', name, e.altKey);
       if (!arch) { // frozen labels filter but never change
         const x = document.createElement('button');
         x.type = 'button'; x.textContent = '✕'; x.title = 'remove label';

--- a/ui/js/labels.js
+++ b/ui/js/labels.js
@@ -12,7 +12,7 @@ export function labelChipHtml(name, active) {
   const col = active ? null : labelColor(name);
   const style = col ? ' style="border-color:' + col + ';color:' + col + '"' : '';
   return '<span class="label' + (active ? ' active' : '') + '" data-label="' + esc(name) + '"' + style +
-    ' title="filter by this label">' + esc(name) + '</span>';
+    ' title="click: filter by this label · alt-click: exclude">' + esc(name) + '</span>';
 }
 
 async function labelApi(body) {

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -199,9 +199,11 @@ export function filterMode(kind, value) {
   return f ? f.mode || 'in' : '';
 }
 export function filterSelected(kind, value) { return filterMode(kind, value) === 'in'; }
-// board/table/detail owner+label clicks: plain include on/off (never exclude)
-export function toggleFilter(kind, value) {
+// board/table/detail owner+label clicks: plain click = include on/off,
+// alt-click (exclude=true) = exclude on/off
+export function toggleFilter(kind, value, exclude) {
   if (!value) return;
+  if (exclude) { setFilter(kind, value, filterMode(kind, value) === 'out' ? '' : 'out'); return; }
   const i = S.filters.sel.findIndex((f) => f.kind === kind && f.value === value);
   const wasIn = i >= 0 && (S.filters.sel[i].mode || 'in') === 'in';
   if (i >= 0) S.filters.sel.splice(i, 1);

--- a/ui/js/table.js
+++ b/ui/js/table.js
@@ -83,7 +83,7 @@ function rowHtml(row) {
     '<td class="c-title">' + titleCellHtml(row) + '</td>' +
     '<td class="c-status">' + statusCellHtml(row) + '</td>' +
     '<td class="c-type hide-m">' + esc(c.type || '') + '</td>' +
-    '<td class="c-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) + '" title="filter by lieutenant">' +
+    '<td class="c-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) + '" title="click: filter by lieutenant · alt-click: exclude">' +
     '<span class="dot" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>' + esc((l && l.name) || c.owner) + '</td>' +
     '<td class="c-labels hide-m">' + (c.labels || []).map((n) => labelChipHtml(n, filterSelected('label', n))).join('') + '</td>' +
     '<td class="c-prs">' + cardPrs(c).map((pr) => prChipHtml(pr)).join('') + '</td>' +
@@ -117,9 +117,9 @@ function wire() {
       if (e.target.closest('a')) return; // PR chip: let the link navigate
       // label / owner clicks feed the shared filter (a chip in the popup)
       const lab = e.target.closest('.label');
-      if (lab) { toggleFilter('label', lab.dataset.label); return; }
+      if (lab) { toggleFilter('label', lab.dataset.label, e.altKey); return; }
       const own = e.target.closest('.c-owner');
-      if (own) { toggleFilter('owner', own.dataset.owner); return; }
+      if (own) { toggleFilter('owner', own.dataset.owner, e.altKey); return; }
       openDetail(tr.dataset.id);
     };
   }


### PR DESCRIPTION
Plain click on an owner/label chip still toggles the include filter; alt-click (option-click on mac) now toggles exclude on the same spot, reusing the tri-state machinery from #59. `toggleFilter` gains an `exclude` flag that routes through `setFilter`; all 8 chip click sites (board, table, archive, detail) pass `e.altKey`, and chip tooltips mention the gesture. Mobile is untouched — exclusion there stays in the filter popup's 3-position switch.

Verified in-browser at desktop width: alt-click owner drops that owner's cards and the popup shows the ⊘ chip; alt-click again clears; plain click unchanged. Full suite green (353).

🤖 Generated with [Claude Code](https://claude.com/claude-code)