### PR TITLE
Copy button on chat messages + artifact viewer

### DIFF
--- a/test/copytext.test.js
+++ b/test/copytext.test.js
@@ -1,0 +1,73 @@
+'use strict';
+// copyText (ui/js/md.js) — the one clipboard helper behind every copy
+// affordance. The load-bearing claim: over plain HTTP (tailnet phone) there is
+// no navigator.clipboard, and the execCommand fallback must then run
+// SYNCHRONOUSLY inside the click call — execCommand outside a user gesture is
+// a silent no-op on mobile Safari. Node lets us pin exactly that ordering with
+// stub navigator/document globals.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const mdMod = import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'md.js')).href);
+
+// navigator exists as a global getter in modern Node — replace via defineProperty
+function setNavigator(v) {
+  Object.defineProperty(globalThis, 'navigator', { value: v, configurable: true, writable: true });
+}
+// minimal DOM for the textarea fallback; records the execCommand call
+function stubDocument(execResult) {
+  const calls = { exec: 0, value: null, appended: 0, removed: 0, selected: 0 };
+  const ta = {
+    style: {},
+    value: null,
+    select() { calls.selected++; },
+    remove() { calls.removed++; },
+  };
+  globalThis.document = {
+    createElement: () => ta,
+    body: { appendChild(n) { calls.appended++; calls.value = n.value; } },
+    execCommand(cmd) { assert.strictEqual(cmd, 'copy'); calls.exec++; return execResult; },
+  };
+  return calls;
+}
+
+test('no navigator.clipboard (insecure context): execCommand runs synchronously in the call', async () => {
+  setNavigator({}); // plain-HTTP browser: clipboard is undefined
+  const calls = stubDocument(true);
+  const { copyText } = await mdMod;
+  const p = copyText('hello board');
+  // asserted BEFORE awaiting: the fallback fired inside the click's own call
+  assert.strictEqual(calls.exec, 1);
+  assert.strictEqual(calls.value, 'hello board');
+  assert.strictEqual(calls.selected, 1);
+  assert.strictEqual(calls.removed, 1); // textarea cleaned up
+  assert.strictEqual(await p, true);
+});
+
+test('fallback reports failure honestly when execCommand returns false', async () => {
+  setNavigator({});
+  stubDocument(false);
+  const { copyText } = await mdMod;
+  assert.strictEqual(await copyText('x'), false);
+});
+
+test('secure context: navigator.clipboard.writeText is used, no textarea', async () => {
+  let written = null;
+  setNavigator({ clipboard: { writeText: (t) => { written = t; return Promise.resolve(); } } });
+  const calls = stubDocument(true);
+  const { copyText } = await mdMod;
+  assert.strictEqual(await copyText('via clipboard api'), true);
+  assert.strictEqual(written, 'via clipboard api');
+  assert.strictEqual(calls.exec, 0);
+});
+
+test('writeText rejection (focus/permission) falls back to execCommand', async () => {
+  setNavigator({ clipboard: { writeText: () => Promise.reject(new Error('denied')) } });
+  const calls = stubDocument(true);
+  const { copyText } = await mdMod;
+  assert.strictEqual(await copyText('fallback text'), true);
+  assert.strictEqual(calls.exec, 1);
+  assert.strictEqual(calls.value, 'fallback text');
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -165,6 +165,19 @@ body.resizing { user-select: none; cursor: col-resize; }
 .msg-speak:hover { opacity: 1; color: var(--text); border-color: var(--faint); }
 .msg-speak.speaking { opacity: 1; color: var(--accent); border-color: var(--accent2); }
 @media (hover: none) { .msg-speak { opacity: .6; } } /* touch: always visible, small */
+/* per-message copy button, same family — BOTH sides; on agent bubbles it sits
+   left of the 🔊 (one tap → clipboard → the phone's read-aloud shortcut) */
+.msg.user { position: relative; }
+.msg-copy {
+  position: absolute; right: 4px; bottom: 3px; padding: 1px 5px; line-height: 1;
+  font-size: 12px; border-radius: 6px; background: var(--panel2); border: 1px solid var(--line);
+  color: var(--dim); cursor: pointer; opacity: 0; transition: opacity .12s;
+}
+.msg.agent .msg-copy { right: 32px; }
+.msg:hover .msg-copy, .msg-copy:focus-visible { opacity: .85; }
+.msg-copy:hover { opacity: 1; color: var(--text); border-color: var(--faint); }
+.msg-copy.ok { opacity: 1; color: var(--ok); border-color: var(--ok); }
+@media (hover: none) { .msg-copy { opacity: .6; } } /* touch: always visible, small */
 
 /* slash-command request+reply: the SYSTEM speaking, not a lieutenant. Full-width
    console block — monospace, dim palette, subtle border, a small ⌘ affordance —
@@ -991,6 +1004,10 @@ a.a-uri { color: var(--accent); }
 #av-src { flex: none; color: var(--dim); font-size: 12px; font-family: var(--mono); padding: 2px 6px; border: 1px solid transparent; border-radius: 6px; }
 #av-src:hover { color: var(--text); }
 #av-src.on { color: var(--accent); border-color: var(--accent2); }
+/* head copy button (text artifacts only): copies the FULL source, whichever view is up */
+#av-copy { flex: none; color: var(--dim); font-size: 14px; padding: 2px 6px; }
+#av-copy:hover { color: var(--text); }
+#av-copy.ok { color: var(--ok); }
 #av-body {
   flex: 1; min-height: 60px; overflow: auto; padding: 12px 16px; margin: 0;
   font-family: var(--mono); font-size: 12px; line-height: 1.5; white-space: pre-wrap; overflow-wrap: anywhere;

--- a/ui/index.html
+++ b/ui/index.html
@@ -281,7 +281,7 @@
 <!-- artifact viewer -->
 <div id="av-overlay" hidden>
   <div id="av-modal">
-    <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-src" title="toggle rendered / source" hidden>&lt;/&gt;</button><button id="av-expand" title="expand">⛶</button><button id="av-close" title="close">✕</button></div>
+    <div class="av-head"><span class="av-name" id="av-name"></span><a id="av-download" title="download" hidden>⬇</a><button id="av-copy" title="copy full source" aria-label="copy full source to clipboard" hidden>⧉</button><button id="av-src" title="toggle rendered / source" hidden>&lt;/&gt;</button><button id="av-expand" title="expand">⛶</button><button id="av-close" title="close">✕</button></div>
     <pre id="av-body"></pre>
     <div id="av-img-wrap" hidden><img id="av-img" alt=""></div>
     <div id="av-video-wrap" hidden><video id="av-video" controls playsinline preload="metadata"></video></div>

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -5,7 +5,7 @@
 import { S, card, cards, lieutenants, lieutenant, lieutenantColor, lieutenantName, lieutenantAvatar, lieutenantUnread, cardStatus, cardActivityTs, render, threadUnread, targetOwedState, targetOwedStale, USER } from './state.js';
 import { api } from './api.js';
 import { esc, hhmm, dayLabel, cardEmoji, setHtmlIfChanged, fmtSize, isImageMime, statusBlockHtml, ctxBarHtml, owedIndHtml } from './util.js';
-import { md, mdEnhance } from './md.js';
+import { md, mdEnhance, copyText } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
 import { openAttachment } from './detail.js';
 import { avatarHtml } from './avatars.js';
@@ -173,13 +173,19 @@ function msgHtml(m, promote, avatarIdx) {
   // speak button only on lieutenant bubbles; 🔊 icon, no message text in markup
   const speakBtn = mine ? '' :
     '<button class="msg-speak" type="button" data-speak title="read this message aloud" aria-label="read this message aloud">🔊</button>';
+  // copy button on BOTH sides: puts the raw markdown source on the clipboard
+  // (one tap → the iPhone Action-button shortcut reads it aloud). Delegated on
+  // the feed via data-copy — deliberately NOT a second index-mapped wiring pass
+  // like the speak buttons, so it can't desync that mapping.
+  const copyBtn = !hasText ? '' :
+    '<button class="msg-copy" type="button" data-copy="' + esc(m.text) + '" title="copy message text" aria-label="copy message text">⧉</button>';
   // face sits inside the bubble, top-left — same face for every agent bubble in
   // this feed (a card thread's interlocutor is always the owning lieutenant,
   // so even a worker's stamped-as-owner say gets its face)
   const hasAvatar = !mine && avatarIdx != null;
   const face = hasAvatar ? avatarHtml(avatarIdx, 'msg-face') : '';
   return '<div class="msg ' + (mine ? 'user' : 'agent') + (hasAvatar ? ' has-avatar' : '') + '">' + face + chipHtml(m) + body + atts +
-    '<span class="ts">' + who + hhmm(m.ts) + '</span>' + speakBtn + '</div>';
+    '<span class="ts">' + who + hhmm(m.ts) + '</span>' + copyBtn + speakBtn + '</div>';
 }
 // empty-conversation placeholder: the lieutenant's face (or its colored dot,
 // same fallback rule as everywhere else) above the "no messages yet" text
@@ -489,6 +495,19 @@ feedEl.addEventListener('click', (e) => {
   if (chip) {
     e.stopPropagation();
     openCardConversation(chip.dataset.chipCard);
+    return;
+  }
+  // bubble copy button: message source travels in data-copy (esc()'d in the
+  // markup, unescaped back by dataset) — copyText is called synchronously from
+  // the gesture so the insecure-context execCommand fallback works.
+  const cp = e.target.closest('.msg-copy');
+  if (cp) {
+    e.stopPropagation();
+    copyText(cp.dataset.copy || '').then((ok) => {
+      cp.textContent = ok ? '✓' : '✗';
+      cp.classList.toggle('ok', ok);
+      setTimeout(() => { cp.textContent = '⧉'; cp.classList.remove('ok'); }, 1500);
+    });
     return;
   }
   const pin = e.target.closest('.att-pin');

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -1,7 +1,7 @@
 // card detail: attributes header + markdown body + event timeline (chat lives in the chat panel)
 import { S, card, lieutenant, lieutenants, lieutenantColor, cardStatus, cardActivityTs, cardRecency, kindEmoji, render, toggleFilter, filterSelected } from './state.js';
 import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename, setHtmlIfChanged, isImageMime } from './util.js';
-import { md, mdEnhance } from './md.js';
+import { md, mdEnhance, copyText } from './md.js';
 import { api } from './api.js';
 import { labelChipHtml, openLabelPicker, saveCardLabels } from './labels.js';
 import { openCardThread, syncChatToMain } from './chat.js';
@@ -194,6 +194,7 @@ const avFrame = document.getElementById('av-frame');
 const avExpand = document.getElementById('av-expand');
 const avDownload = document.getElementById('av-download');
 const avSrcBtn = document.getElementById('av-src');
+const avCopyBtn = document.getElementById('av-copy');
 const MD_EXT = /\.(md|markdown)$/i;
 const HTML_EXT = /\.html?$/i;
 // Reset the shared overlay to a clean text-mode state (used by both openers).
@@ -215,6 +216,10 @@ function avReset(name, uri) {
   avShowSrc = false;
   avSrcBtn.hidden = true;
   avSrcBtn.classList.remove('on');
+  avText = null;
+  avCopyBtn.hidden = true;
+  avCopyBtn.textContent = '⧉';
+  avCopyBtn.classList.remove('ok');
   avModal.classList.remove('expanded'); // each open starts at the default size
   avOverlay.hidden = false;
 }
@@ -222,9 +227,20 @@ function avReset(name, uri) {
 // head). avMd holds the raw text while a markdown preview is up; the toggle
 // re-renders in place, so it also survives expand/restore.
 let avMd = null, avShowSrc = false;
+// The full text source currently in the viewer (markdown or plain) — what the
+// head ⧉ copies, regardless of the rendered ⇄ source toggle. Text-only: image /
+// video / iframe / download states never set it, so the button stays hidden there.
+let avText = null;
+function avCopyable(text) { avText = text; avCopyBtn.hidden = false; }
+avCopyBtn.onclick = () => copyText(avText == null ? '' : avText).then((ok) => {
+  avCopyBtn.textContent = ok ? '✓' : '✗';
+  avCopyBtn.classList.toggle('ok', ok);
+  setTimeout(() => { avCopyBtn.textContent = '⧉'; avCopyBtn.classList.remove('ok'); }, 1500);
+});
 function showMarkdown(text) {
   avMd = text;
   avSrcBtn.hidden = false;
+  avCopyable(text);
   renderAvMd();
 }
 function renderAvMd() {
@@ -293,6 +309,7 @@ async function openArtifact(uri) {
     } else {
       avBody.className = '';
       avBody.textContent = r.content; // non-markdown: plain preformatted text
+      avCopyable(r.content);
     }
   } catch (e) {
     offerDownload('⚠ no preview — ' + e.message + ' (use ⬇ to download)'); // binary / too large / unreadable
@@ -319,7 +336,7 @@ export async function openAttachment(att) {
   const showVideo = () => { avBody.hidden = true; avVideoWrap.hidden = false; avVideo.src = url; };
   const showText = (text) => {
     if (isMdArtifact(att, name)) showMarkdown(text);
-    else { avBody.className = ''; avBody.textContent = text; }
+    else { avBody.className = ''; avBody.textContent = text; avCopyable(text); }
   };
   const mime = String(att.mime || '');
   // Decide from mime/extension when possible; a promoted artifact carries only

--- a/ui/js/md.js
+++ b/ui/js/md.js
@@ -86,6 +86,33 @@ export function mdEnhance(root) {
   }
 }
 
+// ---------- clipboard ----------
+// The one copy helper behind every copy affordance (code blocks, message
+// bubbles, artifact viewer). navigator.clipboard requires a secure context —
+// over plain HTTP (tailnet IP) it is undefined, so the hidden-textarea
+// execCommand path is the one that actually runs there. execCommand only works
+// inside a real user gesture, so that branch must reach it synchronously from
+// the click: the clipboard check throws no await in the way.
+export function copyText(text) {
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    return navigator.clipboard.writeText(text).then(() => true, () => execCopy(text));
+  }
+  return Promise.resolve(execCopy(text));
+}
+function execCopy(text) {
+  try {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.style.position = 'fixed';
+    ta.style.opacity = '0';
+    document.body.appendChild(ta);
+    ta.select();
+    const done = document.execCommand('copy');
+    ta.remove();
+    return done;
+  } catch (e) { return false; }
+}
+
 // ---------- code blocks: copy button ----------
 // The button lives in a position:relative wrapper AROUND the pre (not inside
 // it) so it stays put when the code scrolls horizontally. Hover-reveal on
@@ -101,31 +128,11 @@ function addCopyButton(pre, code) {
   btn.className = 'copy-btn';
   btn.textContent = 'copy';
   btn.setAttribute('aria-label', 'copy code to clipboard');
-  btn.onclick = async () => {
-    const text = code.textContent;
-    let done = false;
-    try {
-      if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(text);
-        done = true;
-      }
-    } catch (e) { /* focus/permission issue — fall through to execCommand */ }
-    if (!done) {
-      try {
-        const ta = document.createElement('textarea');
-        ta.value = text;
-        ta.style.position = 'fixed';
-        ta.style.opacity = '0';
-        document.body.appendChild(ta);
-        ta.select();
-        done = document.execCommand('copy');
-        ta.remove();
-      } catch (e) { /* both paths failed */ }
-    }
+  btn.onclick = () => copyText(code.textContent).then((done) => {
     btn.textContent = done ? '✓ copied' : 'failed';
     btn.classList.toggle('ok', done);
     setTimeout(() => { btn.textContent = 'copy'; btn.classList.remove('ok'); }, 1500);
-  };
+  });
   wrap.appendChild(btn);
 }
 


### PR DESCRIPTION
One tap puts a whole message (raw markdown source) or a text artifact's full source on the clipboard, so the iPhone Action-button shortcut can read it aloud — no more hand-selecting text on mobile.

- **Message bubbles**: ⧉ on both sides, same visual family as the 🔊 speak button. Delegated click on the feed reading `data-copy` (esc()'d), so the speak buttons' index-mapped wiring stays untouched.
- **Artifact viewer**: ⧉ in the head row, text/markdown artifacts only; always copies the full source whether the rendered or `</>` view is up. Hidden for image/video/iframe/download states via `avReset`.
- **Shared helper**: the code-block copy logic is extracted into one exported `copyText()` in md.js; all three call sites use it. The execCommand fallback (the path that actually runs over plain-HTTP tailnet, where `navigator.clipboard` is undefined) stays synchronous with the click gesture.
- Feedback: ✓ for ~1.5s, ✗ on failure.
- `test/copytext.test.js` pins the fallback ordering and both clipboard paths. Full suite: 357 green.

Verified in-browser at 390×844: bubble copy puts the raw markdown on the clipboard; the viewer head button copies the whole source in both views; hidden for images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)