### PR TITLE
Play audio artifacts inline in the card viewer

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -119,13 +119,16 @@ const UPLOAD_MAX_BYTES = parseInt(process.env.BC_UPLOAD_MAX_BYTES, 10) > 0
 // preview cap; over-cap → 413.
 const ARTIFACT_MAX_BYTES = parseInt(process.env.BC_ARTIFACT_MAX_BYTES, 10) > 0
   ? parseInt(process.env.BC_ARTIFACT_MAX_BYTES, 10) : 25 * 1024 * 1024;
-// Extension → Content-Type for raw artifact byte serving. Images render inline
-// in the viewer; pdf may render inline; everything else downloads.
+// Extension → Content-Type for raw artifact byte serving. Images, video, and
+// audio render inline in the viewer; pdf may render inline; everything else
+// downloads.
 const ARTIFACT_MIME = {
   '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg', '.gif': 'image/gif',
   '.webp': 'image/webp', '.svg': 'image/svg+xml', '.bmp': 'image/bmp', '.avif': 'image/avif',
   '.pdf': 'application/pdf',
   '.mp4': 'video/mp4', '.m4v': 'video/mp4', '.mov': 'video/quicktime', '.webm': 'video/webm',
+  '.mp3': 'audio/mpeg', '.m4a': 'audio/mp4', '.aac': 'audio/aac', '.wav': 'audio/wav',
+  '.ogg': 'audio/ogg', '.oga': 'audio/ogg', '.opus': 'audio/ogg', '.flac': 'audio/flac',
 };
 
 const DEFAULT_PORT = 4780;
@@ -2206,11 +2209,11 @@ const server = http.createServer(async (req, res) => {
         const ctype = isHtml ? 'text/html; charset=utf-8'
           : am ? (attMime || 'application/octet-stream')
           : (ARTIFACT_MIME[ext] || 'application/octet-stream');
-        // Images, video, pdf, and rendered html show inline in the browser; other
-        // binaries download. Same hardening as the attachments serve: nosniff pins
-        // the Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
+        // Images, video, audio, pdf, and rendered html show inline in the browser;
+        // other binaries download. Same hardening as the attachments serve: nosniff
+        // pins the Content-Type; the sandbox CSP neutralizes an uploaded SVG/HTML if it
         // is navigated to as a document (inline <img>/<video> subresources unaffected).
-        const inline = isHtml || /^(image|video)\//.test(ctype) || ctype === 'application/pdf';
+        const inline = isHtml || /^(image|video|audio)\//.test(ctype) || ctype === 'application/pdf';
         const csp = isHtml ? 'sandbox allow-scripts' : 'sandbox';
         let data;
         try { data = fs.readFileSync(file); }

--- a/test/artifact.test.js
+++ b/test/artifact.test.js
@@ -81,6 +81,31 @@ test('raw=1 for a listed .mp4 → video/mp4, inline, Accept-Ranges; Range → 20
   }
 });
 
+test('raw=1 for a listed .mp3 → audio/mpeg, inline, Accept-Ranges; Range → 206 slice', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const aud = path.join(s.dir, 'reply.mp3');
+    fs.writeFileSync(aud, 'FAKE-MP3-BYTES-0123456789'); // headers/range only — no real codec needed
+    const { uri } = await cardWithArtifact(s, aud, 'worker voice reply');
+    const raw = s.base + '/api/artifact?uri=' + encodeURIComponent(uri) + '&raw=1';
+
+    const res = await fetch(raw);
+    assert.strictEqual(res.status, 200);
+    assert.strictEqual(res.headers.get('content-type'), 'audio/mpeg');
+    assert.match(res.headers.get('content-disposition') || '', /^inline/);
+    assert.strictEqual(res.headers.get('accept-ranges'), 'bytes');
+    assert.strictEqual(res.headers.get('x-content-type-options'), 'nosniff');
+
+    // <audio> seeking rides the same Range path that makes iOS Safari play <video>
+    const r2 = await fetch(raw, { headers: { Range: 'bytes=0-1' } });
+    assert.strictEqual(r2.status, 206);
+    assert.strictEqual(r2.headers.get('content-range'), 'bytes 0-1/25');
+    assert.strictEqual(await r2.text(), 'FA');
+  } finally {
+    await s.stop();
+  }
+});
+
 test('raw=1 for a uri NOT listed on any card → 404 (auth guard holds for raw too)', async () => {
   const s = await startServerWithLieutenant();
   try {

--- a/test/av-dispatch.test.js
+++ b/test/av-dispatch.test.js
@@ -1,0 +1,46 @@
+'use strict';
+// ui/js/detail.js viewer dispatch — the extension-regex seams that route an
+// artifact/attachment name to a media branch. detail.js binds DOM at import
+// time, so pin the decision at the source level: extract the regex literals
+// and assert an audio name picks the audio branch, not the known-binary
+// download (BIN_EXT used to include mp3|wav|ogg|flac and stole the case).
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const src = fs.readFileSync(path.join(__dirname, '..', 'ui', 'js', 'detail.js'), 'utf8');
+function extractRegex(name) {
+  const m = new RegExp('const ' + name + ' = /(.+)/(\\w*);').exec(src);
+  assert.ok(m, name + ' regex literal found in detail.js');
+  return new RegExp(m[1], m[2]);
+}
+const AUDIO_EXT = extractRegex('AUDIO_EXT');
+const VIDEO_EXT = extractRegex('VIDEO_EXT');
+const BIN_EXT = extractRegex('BIN_EXT');
+
+test('audio extensions match AUDIO_EXT and are out of BIN_EXT', () => {
+  for (const ext of ['mp3', 'wav', 'm4a', 'aac', 'ogg', 'oga', 'opus', 'flac']) {
+    const name = 'reply.' + ext;
+    assert.ok(AUDIO_EXT.test(name), name + ' picks the audio branch');
+    assert.ok(!BIN_EXT.test(name), name + ' no longer falls into the download branch');
+  }
+});
+
+test('AUDIO_EXT does not steal video, text, or binary names', () => {
+  for (const name of ['demo.mp4', 'clip.mov', 'notes.txt', 'report.md', 'bundle.zip']) {
+    assert.ok(!AUDIO_EXT.test(name), name + ' is not audio');
+  }
+  assert.ok(VIDEO_EXT.test('demo.mp4') && BIN_EXT.test('bundle.zip'), 'other branches intact');
+});
+
+test('openArtifact checks AUDIO_EXT before the BIN_EXT download fallback', () => {
+  const audioAt = src.indexOf('AUDIO_EXT.test(name)');
+  const binAt = src.indexOf('BIN_EXT.test(name)');
+  assert.ok(audioAt > -1 && binAt > -1 && audioAt < binAt);
+});
+
+test('openAttachment dispatches audio by mime, name fallback, and served Content-Type', () => {
+  assert.match(src, /isAudioMime\(mime\) \|\| \(!mime && AUDIO_EXT\.test\(name\)\)\) return showAudio\(\)/);
+  assert.match(src, /isAudioMime\(ct\)\) return showAudio\(\)/);
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -1018,6 +1018,9 @@ a.a-uri { color: var(--accent); }
 /* image attachment preview (shares the av-overlay) */
 #av-img-wrap, #av-video-wrap { flex: 1; min-height: 60px; overflow: auto; display: flex; align-items: center; justify-content: center; padding: 12px; }
 #av-img, #av-video { max-width: 100%; max-height: 76vh; object-fit: contain; border-radius: 6px; }
+/* audio is a wide short control, not a contained box — span the modal width */
+#av-audio-wrap { flex: none; display: flex; align-items: center; padding: 24px 16px; }
+#av-audio { width: 100%; min-width: 0; }
 /* rendered html artifact (shares the av-overlay) — fills the body; white backdrop
    so a self-contained page renders on its own canvas, not the board's dark bg */
 #av-frame { flex: 1; min-height: 60px; width: 100%; border: 0; background: #fff; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -285,6 +285,7 @@
     <pre id="av-body"></pre>
     <div id="av-img-wrap" hidden><img id="av-img" alt=""></div>
     <div id="av-video-wrap" hidden><video id="av-video" controls playsinline preload="metadata"></video></div>
+    <div id="av-audio-wrap" hidden><audio id="av-audio" controls preload="metadata"></audio></div>
     <iframe id="av-frame" sandbox="allow-scripts" hidden></iframe>
   </div>
 </div>

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -190,6 +190,8 @@ const avImgWrap = document.getElementById('av-img-wrap');
 const avImg = document.getElementById('av-img');
 const avVideoWrap = document.getElementById('av-video-wrap');
 const avVideo = document.getElementById('av-video');
+const avAudioWrap = document.getElementById('av-audio-wrap');
+const avAudio = document.getElementById('av-audio');
 const avFrame = document.getElementById('av-frame');
 const avExpand = document.getElementById('av-expand');
 const avDownload = document.getElementById('av-download');
@@ -207,6 +209,10 @@ function avReset(name, uri) {
   avVideo.pause();
   avVideo.removeAttribute('src');
   avVideo.load(); // actually drop the previous stream (removeAttribute alone doesn't)
+  avAudioWrap.hidden = true;
+  avAudio.pause();
+  avAudio.removeAttribute('src');
+  avAudio.load(); // actually drop the previous stream (removeAttribute alone doesn't)
   avFrame.hidden = true;
   avFrame.removeAttribute('src'); // drop the previous page so it can't linger
   avBody.hidden = false;
@@ -229,7 +235,8 @@ function avReset(name, uri) {
 let avMd = null, avShowSrc = false;
 // The full text source currently in the viewer (markdown or plain) — what the
 // head ⧉ copies, regardless of the rendered ⇄ source toggle. Text-only: image /
-// video / iframe / download states never set it, so the button stays hidden there.
+// video / audio / iframe / download states never set it, so the button stays
+// hidden there.
 let avText = null;
 function avCopyable(text) { avText = text; avCopyBtn.hidden = false; }
 avCopyBtn.onclick = () => copyText(avText == null ? '' : avText).then((ok) => {
@@ -288,6 +295,12 @@ async function openArtifact(uri) {
     avBody.hidden = true; avVideoWrap.hidden = false; avVideo.src = rawUrl;
     return;
   }
+  if (AUDIO_EXT.test(name)) {
+    // Inline player fed by the same raw serve the ⬇ button uses. No autoplay.
+    avDownload.href = rawUrl; avDownload.setAttribute('download', name); avDownload.hidden = false;
+    avBody.hidden = true; avAudioWrap.hidden = false; avAudio.src = rawUrl;
+    return;
+  }
   if (HTML_EXT.test(name)) {
     // A rendered .html/.htm page (teach-me, report): show it live in a sandboxed
     // iframe (allow-scripts, no same-origin) fed by the raw serve, which sends a
@@ -322,9 +335,11 @@ const TEXTY_MIME = /^(text\/|application\/(json|xml|javascript|x-sh|x-yaml|yaml|
 const IMG_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|avif)$/i;
 const VIDEO_EXT = /\.(mp4|mov|webm|m4v)$/i;
 const isVideoMime = (m) => /^video\//.test(String(m || ''));
+const AUDIO_EXT = /\.(mp3|wav|m4a|aac|ogg|oga|opus|flac)$/i;
+const isAudioMime = (m) => /^audio\//.test(String(m || ''));
 const TEXT_EXT = /\.(md|markdown|txt|log|json|ya?ml|csv|js|ts|py|sh|css|html?)$/i;
 // Known binaries — never worth a text preview; offer a download straight away.
-const BIN_EXT = /\.(pdf|zip|gz|tgz|tar|xlsx?|docx?|pptx?|bin|exe|dmg|iso|mp3|wav|ogg|flac|woff2?|ttf|otf|parquet|pkl|npz|so|dll|wasm|class|jar)$/i;
+const BIN_EXT = /\.(pdf|zip|gz|tgz|tar|xlsx?|docx?|pptx?|bin|exe|dmg|iso|woff2?|ttf|otf|parquet|pkl|npz|so|dll|wasm|class|jar)$/i;
 export async function openAttachment(att) {
   const url = '/api/attachments/' + encodeURIComponent(att.id);
   const name = att.name || '';
@@ -334,6 +349,7 @@ export async function openAttachment(att) {
   avDownload.hidden = false;
   const showImage = () => { avBody.hidden = true; avImgWrap.hidden = false; avImg.src = url; avImg.alt = name; };
   const showVideo = () => { avBody.hidden = true; avVideoWrap.hidden = false; avVideo.src = url; };
+  const showAudio = () => { avBody.hidden = true; avAudioWrap.hidden = false; avAudio.src = url; };
   const showText = (text) => {
     if (isMdArtifact(att, name)) showMarkdown(text);
     else { avBody.className = ''; avBody.textContent = text; avCopyable(text); }
@@ -344,6 +360,7 @@ export async function openAttachment(att) {
   // Content-Type before falling back to a download.
   if (isImageMime(mime) || (!mime && IMG_EXT.test(name))) return showImage();
   if (isVideoMime(mime) || (!mime && VIDEO_EXT.test(name))) return showVideo();
+  if (isAudioMime(mime) || (!mime && AUDIO_EXT.test(name))) return showAudio();
   if (TEXTY_MIME.test(mime) || (!mime && TEXT_EXT.test(name))) {
     avBody.textContent = 'loading…';
     try {
@@ -363,6 +380,7 @@ export async function openAttachment(att) {
     const ct = (r.headers.get('content-type') || '').split(';')[0];
     if (isImageMime(ct)) return showImage();
     if (isVideoMime(ct)) return showVideo();
+    if (isAudioMime(ct)) return showAudio();
     if (TEXTY_MIME.test(ct)) return showText(await r.text());
     avBody.textContent = 'No inline preview for this file type. Use ⬇ to download.';
   } catch (e) { avBody.textContent = '⚠ no preview — ' + e.message + ' (use ⬇ to download)'; }
@@ -372,7 +390,7 @@ export async function openAttachment(att) {
 // state.js onRender: a setter avoids a circular import back into main.js.
 let onCloseFn = () => {};
 export function onArtifactClose(fn) { onCloseFn = fn; }
-export function closeArtifact() { avOverlay.hidden = true; avVideo.pause(); onCloseFn(); }
+export function closeArtifact() { avOverlay.hidden = true; avVideo.pause(); avAudio.pause(); onCloseFn(); }
 export function artifactOpen() { return !avOverlay.hidden; }
 document.getElementById('av-close').onclick = closeArtifact;
 // Maximize / restore the viewer (pure CSS class toggle — see #av-modal.expanded).


### PR DESCRIPTION
Audio twin of the video support (#58). An `.mp3`/`.wav`/`.m4a`/`.ogg`/`.opus`/`.flac`/`.aac` artifact or attachment now plays in the artifact viewer with a plain `<audio controls preload="metadata">` player instead of falling into the known-binary download branch.

- `ARTIFACT_MIME` learns the audio extensions; bytes go through the existing Range-honoring serve, so seeking works (same path that makes iOS Safari play video).
- Viewer wiring mirrors video exactly: `AUDIO_EXT`/`isAudioMime`, reset (pause + drop src + `load()`), close-pause, `openArtifact` branch, `openAttachment` dispatch including the served Content-Type tail. Audio extensions leave `BIN_EXT`.
- Own CSS rule: the player spans the modal width instead of borrowing the image/video `object-fit: contain` box.

Tests: mp3 raw-serve twin of the mp4 test (Content-Type + 206 Range), plus a source-level dispatch test pinning that audio names pick the audio branch and stay out of `BIN_EXT`. Full suite 362 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)