### PR TITLE
Optimistic pending bubble: a sent message is never nowhere

### DIFF
--- a/test/pending.test.js
+++ b/test/pending.test.js
@@ -1,0 +1,83 @@
+'use strict';
+// ui/js/pending.js — the optimistic-send list behind the chat's pending
+// bubble. The contract: a sent message lives here from POST 200 until its
+// server echo lands in the thread; pendingFor() reconciles on every render so
+// there is never a paint with both the pending bubble and the real one. The
+// module is DOM-free, so it imports straight into Node (copytext.test.js
+// pattern); chat.js's wiring is pinned at the source level (av-dispatch
+// pattern) since chat.js binds DOM at import time.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const mod = import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'pending.js')).href);
+
+test('send → pending exists; echo lands in the doc → exactly the real message remains', async () => {
+  const { addPending, pendingFor } = await mod;
+  const target = 'lieutenant:ada';
+  addPending(target, 'hello there', []);
+  // the beat between the 200 and the echo: the pending entry is the message
+  let thread = [];
+  assert.strictEqual(pendingFor(target, thread).length, 1);
+  assert.strictEqual(pendingFor(target, thread)[0].text, 'hello there');
+  // the broadcast replaces the doc, now carrying the echo → pending reconciles
+  // away in the same render; the merged feed holds exactly one bubble (the
+  // real one: 1 thread message + 0 pending)
+  thread = [{ author: 'user', text: 'hello there', ts: '2026-07-25T12:00:00Z' }];
+  assert.strictEqual(pendingFor(target, thread).length, 0);
+  // and it stays gone on subsequent renders
+  assert.strictEqual(pendingFor(target, thread).length, 0);
+});
+
+test('reconciliation matches the echo, not other traffic', async () => {
+  const { addPending, pendingFor } = await mod;
+  const target = 'lieutenant:tan';
+  addPending(target, 'ping', []);
+  // a lieutenant message with the same text is NOT the echo; neither is a
+  // different captain message
+  const thread = [
+    { author: 'Ada', text: 'ping', ts: 't1' },
+    { author: 'user', text: 'other', ts: 't2' },
+  ];
+  assert.strictEqual(pendingFor(target, thread).length, 1);
+  thread.push({ author: 'user', text: 'ping', ts: 't3' });
+  assert.strictEqual(pendingFor(target, thread).length, 0);
+});
+
+test('attachments-only send reconciles by attachment ids', async () => {
+  const { addPending, pendingFor } = await mod;
+  const target = 'card:shippy';
+  addPending(target, '', [{ id: 'att-1', name: 'shot.png' }, { id: 'att-2', name: 'log.txt' }]);
+  // a USER message carrying only one of the ids is not it
+  let thread = [{ author: 'user', text: '', attachments: [{ id: 'att-1' }], ts: 't1' }];
+  assert.strictEqual(pendingFor(target, thread).length, 1);
+  thread = [{ author: 'user', text: '', attachments: [{ id: 'att-1' }, { id: 'att-2' }], ts: 't2' }];
+  assert.strictEqual(pendingFor(target, thread).length, 0);
+});
+
+test('pending is keyed by target — no leaking across threads; send order kept', async () => {
+  const { addPending, pendingFor } = await mod;
+  addPending('lieutenant:a', 'first', []);
+  addPending('card:x', 'elsewhere', []);
+  addPending('lieutenant:a', 'second', []);
+  const a = pendingFor('lieutenant:a', []);
+  assert.deepStrictEqual(a.map((p) => p.text), ['first', 'second']);
+  assert.ok(a[0].seq < a[1].seq);
+  assert.deepStrictEqual(pendingFor('card:x', []).map((p) => p.text), ['elsewhere']);
+  assert.strictEqual(pendingFor('lieutenant:other', []).length, 0);
+});
+
+test('chat.js shares the echo predicate and paints the bubble on send', () => {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'ui', 'js', 'chat.js'), 'utf8');
+  // watchEcho's seen() and the pending list reconcile by the SAME predicate
+  assert.match(src, /const seen = \(\) => threadMsgs\(target\)\.some\(\(m\) => isEchoOf\(m, \{ text \}\)\)/);
+  // the pending entry is added only after the POST resolves (a thrown POST
+  // keeps the failure path: red error, text preserved, no bubble)...
+  const postAt = src.indexOf('await api.feedback(target, text, metas)');
+  const addAt = src.indexOf('addPending(target, text, metas)');
+  assert.ok(postAt > -1 && addAt > postAt);
+  // ...and a render() paints it in the same beat the composer clears
+  assert.ok(/addPending\(target, text, metas\);[\s\S]{0,400}render\(\);/.test(src));
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -127,6 +127,8 @@ body.resizing { user-select: none; cursor: col-resize; }
 @keyframes msg-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
 .msg.agent { align-self: flex-start; background: var(--panel); border: 1px solid var(--line); border-bottom-left-radius: 4px; }
 .msg.user { align-self: flex-end; background: var(--user-bubble); border: 1px solid var(--user-line); border-bottom-right-radius: 4px; }
+/* optimistic send awaiting its server echo: same bubble, visibly provisional */
+.msg.pending { opacity: .55; }
 .msg .ts { display: block; color: var(--faint); font-size: 11px; margin-top: 4px; font-family: var(--mono); }
 .msg .pre { white-space: pre-wrap; overflow-wrap: anywhere; }
 /* the card chip on a unified-stream bubble: which card thread this message

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -9,6 +9,7 @@ import { md, mdEnhance, copyText } from './md.js';
 import { speakMessage, trackMessages } from './voice.js';
 import { openAttachment } from './detail.js';
 import { avatarHtml } from './avatars.js';
+import { isEchoOf, addPending, pendingFor } from './pending.js';
 
 const feedEl = document.getElementById('chat-feed');
 const titleEl = document.getElementById('chat-title');
@@ -184,8 +185,10 @@ function msgHtml(m, promote, avatarIdx) {
   // so even a worker's stamped-as-owner say gets its face)
   const hasAvatar = !mine && avatarIdx != null;
   const face = hasAvatar ? avatarHtml(avatarIdx, 'msg-face') : '';
-  return '<div class="msg ' + (mine ? 'user' : 'agent') + (hasAvatar ? ' has-avatar' : '') + '">' + face + chipHtml(m) + body + atts +
-    '<span class="ts">' + who + hhmm(m.ts) + '</span>' + copyBtn + speakBtn + '</div>';
+  // an optimistic (pending) send renders as a normal captain bubble, dimmed,
+  // with a clock on the timestamp — provisional, but never error-looking
+  return '<div class="msg ' + (mine ? 'user' : 'agent') + (m._pending ? ' pending' : '') + (hasAvatar ? ' has-avatar' : '') + '">' + face + chipHtml(m) + body + atts +
+    '<span class="ts">' + (m._pending ? '🕓 ' : '') + who + hhmm(m.ts) + '</span>' + copyBtn + speakBtn + '</div>';
 }
 // empty-conversation placeholder: the lieutenant's face (or its colored dot,
 // same fallback rule as everywhere else) above the "no messages yet" text
@@ -367,8 +370,16 @@ export function renderChat() {
     const speakable = m.author !== USER && !(m.cmd && typeof m.cmd === 'object');
     blocks.push({ html: h + msgHtml(m, isCard, avatarIdx), msg: speakable ? m : null });
   };
+  // optimistic sends: reconciled against the server thread on every render
+  // (the entry drops in the same paint that first shows its echo — never both),
+  // rendered after everything the server sent, in send order. The unified
+  // stream also merges the owned card threads' pendings, chip-labeled, so a
+  // just-sent thread message doesn't vanish when the captain taps back.
+  const pendMsg = (p, extra) => Object.assign(
+    { author: USER, text: p.text, attachments: p.atts, ts: p.ts, _pending: true }, extra);
   if (isCard) {
     for (const m of c.thread || []) push(m);
+    for (const p of pendingFor(target, c.thread || [])) push(pendMsg(p));
   } else {
     // only the newest COLLAPSE_KEEP messages render by default; older history
     // sits behind the expander (anchored cutoff — see collapsedHidden above)
@@ -377,6 +388,15 @@ export function renderChat() {
     const hidden = mainExpanded ? 0 : Math.min(collapsedHidden, msgs.length);
     if (hidden) blocks.push({ html: '<button class="feed-expand" type="button">show earlier messages (' + hidden + ')</button>' });
     for (const m of msgs.slice(hidden)) push(m);
+    const pend = pendingFor(target, (lt && lt.chat) || []).map((p) => [p, null]);
+    if (lt) for (const cc of cards()) {
+      if (cc.owner !== lt.id) continue;
+      for (const p of pendingFor('card:' + cc.id, cc.thread || [])) {
+        pend.push([p, { _card: cc.id, _cardTitle: cc.title || cc.id, _cardEmoji: cardEmoji(cc) }]);
+      }
+    }
+    pend.sort((a, b) => a[0].seq - b[0].seq);
+    for (const [p, extra] of pend) push(pendMsg(p, extra));
   }
   // owed tails: the filtered view shows its own target's; the unified stream
   // also surfaces every owed CARD thread of this lieutenant (chip-labeled), so
@@ -540,9 +560,10 @@ async function promoteAttachment(att, btn) {
 }
 
 // ---------- composer ----------
-// The input clears ONLY once the message is confirmed delivered AND visible in
-// the chat timeline; until then the text is the captain's only copy. On failure
-// it stays in the composer with an error indication — never silently eaten.
+// The message is never nowhere: the text stays in the input until the POST
+// 200 (delivery), at which point it moves to the thread as a pending bubble
+// until the server echo replaces it. On failure it stays in the composer with
+// an error indication — never silently eaten.
 const sendBtn = document.querySelector('#chat-form button[type=submit]');
 const sendErrEl = document.getElementById('chat-send-err');
 const fileInput = document.getElementById('chat-file');
@@ -681,7 +702,7 @@ function threadMsgs(target) {
 let echoWatch = 0;
 async function watchEcho(target, text) {
   const token = ++echoWatch;
-  const seen = () => threadMsgs(target).some((m) => m.author === USER && m.text === text);
+  const seen = () => threadMsgs(target).some((m) => isEchoOf(m, { text })); // same predicate the pending bubble reconciles by
   for (let i = 0; i < 120; i++) { // 250ms steps: refetch at 3s, hint at 10s, give up at 30s
     if (token !== echoWatch) return;
     if (seen()) { clearSyncHint(); return; }
@@ -737,13 +758,16 @@ async function send() {
     // (the server re-resolves them authoritatively by id).
     const metas = await Promise.all(atts.map((p) => api.uploadAttachment(p.file)));
     await api.feedback(target, text, metas);
-    // The 200 IS delivery (write-ahead queue) — clear the composer now. The
-    // soft watchdog only flags a stalled echo; attachments-only has no text
-    // to match, so the 200 alone confirms it.
+    // The 200 IS delivery (write-ahead queue) — clear the composer now, and in
+    // the SAME paint put the message in the thread as a pending bubble, so
+    // there is never a frame where it exists nowhere. The soft watchdog only
+    // flags a stalled echo.
+    addPending(target, text, metas);
     inputEl.value = '';
     closeSlash();
     pendingAtts = [];
     renderPendingAtts();
+    render();
     if (text) watchEcho(target, text);
   } catch (e) {
     setSendError(e.message); // a real POST failure: red + input preserved

--- a/ui/js/pending.js
+++ b/ui/js/pending.js
@@ -1,0 +1,41 @@
+// Optimistic sends: a client-only pending list, keyed by target. The server's
+// doc is authoritative and replaced wholesale on every SSE broadcast, so a
+// just-sent message must live BESIDE it until its echo lands — otherwise the
+// composer clears (the 200 is delivery) and the message exists nowhere on
+// screen. renderChat() merges these after the server messages; pendingFor()
+// reconciles on every render, dropping an entry the moment its echo is in the
+// thread, so there is never a frame with both bubbles.
+import { USER } from './state.js';
+
+const pending = new Map(); // target -> [{ text, atts, ts, seq }] in send order
+let seq = 0;
+
+// The one echo predicate, shared with chat.js's watchEcho: a thread message m
+// is the server echo of pending entry p. Text matches by exact text;
+// attachments-only matches by the uploaded attachment ids (the server
+// re-resolves metas by id, so the echo carries the same ids).
+export function isEchoOf(m, p) {
+  if (m.author !== USER) return false;
+  if (p.text) return m.text === p.text;
+  const ids = new Set((m.attachments || []).map((a) => a.id));
+  return p.atts.length > 0 && p.atts.every((a) => ids.has(a.id));
+}
+
+export function addPending(target, text, atts) {
+  const p = { text: text || '', atts: atts || [], ts: new Date().toISOString(), seq: ++seq };
+  const list = pending.get(target);
+  if (list) list.push(p); else pending.set(target, [p]);
+  return p;
+}
+
+// Reconcile against the target's server messages and return what's still
+// pending. Cheap: a no-op map lookup for targets with nothing in flight.
+export function pendingFor(target, msgs) {
+  const list = pending.get(target);
+  if (!list || !list.length) return [];
+  const kept = list.filter((p) => !msgs.some((m) => isEchoOf(m, p)));
+  if (kept.length !== list.length) {
+    if (kept.length) pending.set(target, kept); else pending.delete(target);
+  }
+  return kept;
+}


### PR DESCRIPTION
Fixes the regression the captain reported twice: since #57 the composer clears on the POST 200, but nothing appeared in the thread until the SSE echo — on a slow link the message existed nowhere for seconds. #57's reasoning (the 200 IS delivery) is preserved; the message now enters the thread immediately as a pending bubble.

## How

- `ui/js/pending.js` (new, DOM-free): a client-only pending list keyed by target, kept beside `S.doc` (which every broadcast replaces wholesale). `pendingFor()` reconciles at render time — an entry drops in the same paint that first shows its echo, so there is never a frame with both bubbles, and never a frame with neither.
- `isEchoOf()` is the one shared predicate: `watchEcho`'s `seen()` and the bubble reconciliation both use it (`author === USER && text` match; attachments-only matches by the uploaded attachment ids, which the server echoes back verbatim since it re-resolves metas by id).
- Rendering reuses the existing user bubble via `msgHtml` with a `_pending` flag: `opacity .55` + 🕓 on the timestamp. The unified stream also merges owned card threads' pendings, chip-labeled, so a thread send doesn't vanish when you tap back.
- Failure path unchanged: the entry is only added after the POST resolves, so a thrown POST keeps red error + text preserved + no bubble. `watchEcho`/the 10s syncing hint untouched.

Known degradation (same semantics as the existing watchdog, which shares the predicate): re-sending text identical to an already-echoed message reconciles the bubble early — behavior falls back to pre-PR (nothing visible until the echo), never a duplicate.

## Verified

- `node --test test/*.test.js harness/test/*.test.js`: 367 pass (362 + 5 new in `test/pending.test.js` — send → pending exists → doc arrives with the echo → exactly one bubble remains, the real one; plus attachments-only, target isolation, and source-level pins on chat.js wiring, av-dispatch style).
- In a browser against `dev/ui-server.js` served from this branch (the live 4780 board serves main's UI from the source repo, so the branch UI can't be driven there without restarting the captain's live server). Devtools throttle delays the POST and the SSE echo equally, so instead the echo was delayed server-side by 3s to simulate a slow link. Sampled DOM at submit / 0.5s / 1.5s / 4.5s: text stays in the input until the 200, then input clears and the pending bubble appears in the same paint, survives repaints, and the echo replaces it with exactly one bubble — no frame where the message was neither in the input nor the history.
- Attachment-only and text+attachment sends: pending bubble with the file chip, reconciled by attachment ids.
- Target switching both ways within the echo gap: bubble absent in the other thread, still there on return; card-thread pendings show chip-labeled in the unified stream.
- Server killed mid-session: red "not delivered", text preserved in the composer, zero pending bubbles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)