### PR TITLE
Speak through an external TTS service

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Per-workspace config lives in `.bridge-commander/config.json`:
 | `host` | `127.0.0.1` | bind address — see network exposure below |
 | `harness` | `claude` | default agent harness (`claude` \| `codex`) |
 | `voices` | — | UI text-to-speech voice filter |
+| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the browser's own voice; any engine failure falls back to it |
 
 Env knobs (set on the server process):
 

--- a/server/server.js
+++ b/server/server.js
@@ -4,7 +4,7 @@
 // One workspace = one board. All state lives in <workspace>/.bridge-commander/:
 //   board.json     the board (canonical state of the world)
 //   archive.jsonl  append-only frozen card snapshots (reason: merged|killed)
-//   config.json    { port, host?, voices? } — port default 4780, written on first boot
+//   config.json    { port, host?, voices?, tts? } — port default 4780, written on first boot
 //   queue/<lieutenant>.jsonl  durable per-lieutenant delivery queue (global seq)
 //   queue/<lieutenant>.ack    committed ack cursor (at-least-once; only ack removes)
 //   server.pid     single server instance per workspace
@@ -132,6 +132,9 @@ const ARTIFACT_MIME = {
 };
 
 const DEFAULT_PORT = 4780;
+// External TTS proxy timeouts — a hanging engine must never hang the board.
+const TTS_VOICES_MS = 3000;
+const TTS_SPEECH_MS = 20000;
 
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
@@ -143,11 +146,33 @@ function readConfig() {
 }
 function userConfig() {
   const c = readConfig();
+  const out = { voices: null };
   if (Array.isArray(c.voices)) {
     const voices = c.voices.filter((v) => typeof v === 'string' && v.trim()).map((v) => v.trim());
-    if (voices.length) return { voices };
+    if (voices.length) out.voices = voices;
   }
-  return { voices: null };
+  // The engine URL is server-side only — the browser talks to /api/tts/* and
+  // never needs to reach the engine itself. No tts config => no tts key => the
+  // UI is byte-for-byte what it was before this feature existed.
+  const t = ttsConfig();
+  if (t) out.tts = { enabled: true, lang: t.lang, voice: t.voice };
+  return out;
+}
+// External TTS engine (voxbench API), optional: config.json
+//   "tts": { "url": "http://127.0.0.1:8883", "voice": null, "lang": "pt", "params": {} }
+// Anything malformed (or a missing url) reads as "not configured".
+function ttsConfig() {
+  const t = readConfig().tts;
+  if (!t || typeof t !== 'object' || Array.isArray(t)) return null;
+  const url = typeof t.url === 'string' ? t.url.trim().replace(/\/+$/, '') : '';
+  if (!/^https?:\/\/\S+$/.test(url)) return null;
+  const str = (v) => (typeof v === 'string' && v.trim() ? v.trim() : null);
+  return {
+    url,
+    lang: str(t.lang),
+    voice: str(t.voice),
+    params: t.params && typeof t.params === 'object' && !Array.isArray(t.params) ? t.params : {},
+  };
 }
 // Port: --port flag > config.json "port" > 4780. The resolved port is written
 // back into config.json when absent, so the CLI and UI can always find it.
@@ -2134,6 +2159,54 @@ const server = http.createServer(async (req, res) => {
     // ----- reads -----
     if (route === 'GET /api/board') return sendJson(res, 200, publicBoard(url.searchParams.get('user') || 'user'));
     if (route === 'GET /api/config') return sendJson(res, 200, userConfig());
+    // ----- external TTS proxy (the engines send no CORS headers) -----
+    // Both routes are short-timeout and never let a sick engine wedge the board:
+    // voices degrades to an empty list with a reason, speech answers an error the
+    // UI turns into a fallback to the browser's own voice.
+    if (route === 'GET /api/tts/voices') {
+      const t = ttsConfig();
+      if (!t) return sendJson(res, 200, { voices: [], error: 'tts not configured' });
+      try {
+        const r = await fetch(t.url + '/v1/voices', { signal: AbortSignal.timeout(TTS_VOICES_MS) });
+        if (!r.ok) return sendJson(res, 200, { voices: [], error: 'engine http ' + r.status });
+        const j = await r.json();
+        return sendJson(res, 200, { voices: Array.isArray(j && j.voices) ? j.voices : [] });
+      } catch (e) {
+        return sendJson(res, 200, { voices: [], error: String((e && e.message) || e) });
+      }
+    }
+    if (route === 'POST /api/tts/speech') {
+      const t = ttsConfig();
+      if (!t) return sendJson(res, 503, { error: 'tts not configured' });
+      let body;
+      try { body = JSON.parse((await readBody(req)) || '{}'); } catch (e) { return sendJson(res, 400, { error: 'bad json' }); }
+      if (!body || typeof body !== 'object' || Array.isArray(body)) return sendJson(res, 400, { error: 'bad body' });
+      // Body through, with the workspace defaults filled in where the caller said
+      // nothing. voice implies lang for the engine, so only send lang when there
+      // is no voice — sending both is a 400 when they disagree.
+      const payload = Object.assign({}, body);
+      if (!payload.voice && t.voice) payload.voice = t.voice;
+      if (!payload.voice && !payload.lang && t.lang) payload.lang = t.lang;
+      if (!payload.params && Object.keys(t.params).length) payload.params = t.params;
+      let r;
+      try {
+        r = await fetch(t.url + '/v1/audio/speech', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload),
+          signal: AbortSignal.timeout(TTS_SPEECH_MS),
+        });
+      } catch (e) {
+        return sendJson(res, 502, { error: String((e && e.message) || e) });
+      }
+      const head = { 'Content-Type': r.headers.get('content-type') || 'application/octet-stream', 'Cache-Control': 'no-store' };
+      const rate = r.headers.get('x-sample-rate');
+      if (rate) head['x-sample-rate'] = rate;
+      res.writeHead(r.status, head);
+      if (!r.body) return res.end();
+      try { for await (const chunk of r.body) res.write(chunk); } catch (e) {}
+      return res.end();
+    }
     if (route === 'GET /api/status') {
       let pending = 0;
       for (const lt of queueIds()) pending += pendingItems(lt).length;

--- a/test/tts-speaker.test.js
+++ b/test/tts-speaker.test.js
@@ -1,0 +1,83 @@
+'use strict';
+// ui/js/tts/index.js — the speaker seam. The rule that matters: a speaker that
+// fails is not silence, it is the next speaker down. withFallback is the ONE
+// place that knows it, so it is the one place that gets tested for it.
+// Browser code (ES module), loaded via dynamic import; nothing here touches DOM.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let withFallback, speakerFor;
+test.before(async () => {
+  ({ withFallback, speakerFor } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'tts', 'index.js')).href));
+});
+
+// A recording speaker: `fail` makes speak() reject the way a dead engine does.
+function fake(id, fail) {
+  const calls = { speak: [], cancel: 0, voices: 0 };
+  return {
+    calls,
+    id,
+    key: 'key-' + id,
+    voices() { calls.voices++; return Promise.resolve([{ id: id + '-v', name: id, lang: 'pt' }]); },
+    speak(text, opts) {
+      calls.speak.push({ text, opts });
+      return fail ? Promise.reject(new Error(id + ' is down')) : Promise.resolve();
+    },
+    cancel() { calls.cancel++; },
+  };
+}
+
+test('primary speaks: the secondary is never asked', async () => {
+  const a = fake('remote'), b = fake('browser');
+  await withFallback(a, b).speak('olá', { voice: 'x' });
+  assert.deepEqual(a.calls.speak, [{ text: 'olá', opts: { voice: 'x' } }]);
+  assert.equal(b.calls.speak.length, 0);
+});
+
+test('primary rejects: the SAME text is spoken through the secondary', async () => {
+  const a = fake('remote', true), b = fake('browser');
+  await withFallback(a, b).speak('olá, capitão', { voice: 'pt_BR-faber-medium' });
+  assert.equal(a.calls.speak.length, 1);
+  assert.equal(b.calls.speak.length, 1, 'a dead primary must not mean silence');
+  assert.equal(b.calls.speak[0].text, 'olá, capitão');
+});
+
+test('the fallback carries no voice: the picked id belongs to the primary', async () => {
+  const a = fake('remote', true), b = fake('browser');
+  await withFallback(a, b).speak('olá', { voice: 'pt_BR-faber-medium' });
+  assert.deepEqual(b.calls.speak[0].opts, {}, 'never hand one speaker the other one\'s voice id');
+});
+
+test('both speakers reject: speak() rejects rather than hanging a caller', async () => {
+  const a = fake('remote', true), b = fake('browser', true);
+  await assert.rejects(() => withFallback(a, b).speak('olá', {}));
+});
+
+test('the picker follows the primary; cancel reaches both', async () => {
+  const a = fake('remote'), b = fake('browser');
+  const s = withFallback(a, b);
+  assert.equal(s.id, 'remote');
+  assert.equal(s.key, 'key-remote', 'per-speaker storage key: a browser voice name is never an engine id');
+  assert.deepEqual(await s.voices(), [{ id: 'remote-v', name: 'remote', lang: 'pt' }]);
+  assert.equal(b.calls.voices, 0, 'the catalogue is the primary\'s alone');
+  s.cancel();
+  assert.equal(a.calls.cancel, 1);
+  assert.equal(b.calls.cancel, 1);
+});
+
+test('speakerFor: no tts config is the browser speaker, plain', () => {
+  for (const cfg of [null, {}, { voices: ['Luciana'] }, { tts: { enabled: false } }]) {
+    const s = speakerFor(cfg);
+    assert.equal(s.id, 'browser', 'cfg=' + JSON.stringify(cfg));
+    assert.equal(s.key, 'bc-voice');
+  }
+});
+
+test('speakerFor: a configured engine is the remote speaker, with the browser under it', () => {
+  const s = speakerFor({ tts: { enabled: true, lang: 'pt', voice: null } });
+  assert.equal(s.id, 'remote');
+  assert.equal(s.key, 'bc-tts-voice');
+});

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -1,0 +1,149 @@
+'use strict';
+// External TTS: config parsing (/api/config) and the proxy's failure paths.
+// The contract that matters here is "absent tts = today's behaviour" and "a sick
+// engine degrades, never 500s and never hangs" — the UI's fallback to the
+// browser voice is built on both.
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const http = require('node:http');
+const { startServer, freePort } = require('./helper');
+
+// Seed <dir>/.bridge-commander/config.json before the server boots.
+function seedConfig(cfg) {
+  return (dir) => {
+    const sd = path.join(dir, '.bridge-commander');
+    fs.mkdirSync(sd, { recursive: true });
+    fs.writeFileSync(path.join(sd, 'config.json'), JSON.stringify(cfg));
+  };
+}
+
+test('no tts in config: /api/config is unchanged', async () => {
+  const s = await startServer({ seed: seedConfig({ voices: ['Luciana'] }) });
+  try {
+    const r = await s.api('GET', '/api/config');
+    assert.equal(r.status, 200);
+    assert.deepEqual(r.body, { voices: ['Luciana'] });
+    assert.ok(!('tts' in r.body));
+  } finally { await s.stop(); }
+});
+
+test('tts in config: enabled, lang and voice are exposed, the url is not', async () => {
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:9/', lang: 'pt', voice: null, params: {} } }),
+  });
+  try {
+    const r = await s.api('GET', '/api/config');
+    assert.deepEqual(r.body.tts, { enabled: true, lang: 'pt', voice: null });
+    assert.ok(!('url' in r.body.tts), 'the engine url must not reach the browser');
+  } finally { await s.stop(); }
+});
+
+test('malformed tts config reads as not configured', async () => {
+  for (const tts of [{ lang: 'pt' }, { url: '' }, 'nope', []]) {
+    const s = await startServer({ seed: seedConfig({ tts }) });
+    try {
+      const r = await s.api('GET', '/api/config');
+      assert.ok(!('tts' in r.body), 'tts=' + JSON.stringify(tts) + ' should be off');
+    } finally { await s.stop(); }
+  }
+});
+
+test('engine unreachable: voices degrade to an empty list, speech answers an error', async () => {
+  const dead = await freePort(); // nothing is listening there
+  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + dead, lang: 'pt' } }) });
+  try {
+    const v = await s.api('GET', '/api/tts/voices');
+    assert.equal(v.status, 200, 'never a 500 — the UI has to be able to fall back');
+    assert.deepEqual(v.body.voices, []);
+    assert.ok(v.body.error, 'the reason comes back with the empty list');
+
+    const sp = await s.api('POST', '/api/tts/speech', { input: 'olá' });
+    assert.equal(sp.status, 502);
+    assert.ok(sp.body.error);
+  } finally { await s.stop(); }
+});
+
+test('tts not configured: the proxy says so instead of pretending', async () => {
+  const s = await startServer();
+  try {
+    const v = await s.api('GET', '/api/tts/voices');
+    assert.equal(v.status, 200);
+    assert.deepEqual(v.body, { voices: [], error: 'tts not configured' });
+    const sp = await s.api('POST', '/api/tts/speech', { input: 'olá' });
+    assert.equal(sp.status, 503);
+  } finally { await s.stop(); }
+});
+
+test('engine 400: the status and body reach the browser verbatim', async () => {
+  const engine = http.createServer((req, res) => {
+    res.writeHead(400, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ detail: 'input must not be empty' }));
+  });
+  const port = await freePort();
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port } }) });
+  try {
+    const sp = await s.api('POST', '/api/tts/speech', { input: ' ' });
+    assert.equal(sp.status, 400);
+    assert.match(sp.body.detail, /empty/);
+  } finally { await s.stop(); engine.close(); }
+});
+
+test('engine 200: audio bytes and x-sample-rate stream through, defaults filled in', async () => {
+  let seen = null;
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      seen = JSON.parse(body);
+      res.writeHead(200, { 'Content-Type': 'audio/wav', 'x-sample-rate': '22050' });
+      res.end(Buffer.from('RIFFfake'));
+    });
+  });
+  const port = await freePort();
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt', params: { speed: 1.2 } } }),
+  });
+  try {
+    const res = await fetch(s.base + '/api/tts/speech', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ input: 'olá, capitão', stream: false }),
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get('content-type'), 'audio/wav');
+    assert.equal(res.headers.get('x-sample-rate'), '22050');
+    assert.equal(Buffer.from(await res.arrayBuffer()).toString(), 'RIFFfake');
+    assert.equal(seen.input, 'olá, capitão');
+    assert.equal(seen.lang, 'pt', 'the workspace default fills in');
+    assert.deepEqual(seen.params, { speed: 1.2 });
+    assert.equal(seen.stream, false, 'stream passes through untouched');
+  } finally { await s.stop(); engine.close(); }
+});
+
+test('an explicit voice wins and suppresses the default lang (they must agree)', async () => {
+  let seen = null;
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      seen = JSON.parse(body);
+      res.writeHead(200, { 'Content-Type': 'audio/wav' });
+      res.end(Buffer.from('x'));
+    });
+  });
+  const port = await freePort();
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt', voice: 'cfg-voice' } }),
+  });
+  try {
+    await s.api('POST', '/api/tts/speech', { input: 'olá', voice: 'pt_BR-faber-medium' });
+    assert.equal(seen.voice, 'pt_BR-faber-medium');
+    assert.ok(!('lang' in seen), 'no lang alongside an explicit voice');
+  } finally { await s.stop(); engine.close(); }
+});

--- a/ui/js/tts/browser.js
+++ b/ui/js/tts/browser.js
@@ -1,0 +1,118 @@
+// Speaker over the browser's own window.speechSynthesis.
+//
+// Reliability hazards this guards against:
+//  - overlapping utterances wedging the queue (rapid messages) -> cancel-and-
+//    speak-latest: a new message supersedes the old so the newest is always heard;
+//  - Chrome/Safari idle auto-pause and the ~15s mid-utterance cutoff -> a keepalive
+//    that resume()s while speaking, plus splitting long text into sentence chunks;
+//  - a stuck/failed utterance killing all later speech -> onerror resets the engine
+//    and retries the chunk once, then moves on instead of dying silently.
+
+// split into sentence-sized chunks so no single utterance is long enough to hit
+// the engine's mid-utterance cutoff; hard-wrap anything still oversized.
+function chunkText(s) {
+  const parts = s.match(/[^.!?\n]+[.!?]*|\n+/g) || [s];
+  const out = [];
+  let buf = '';
+  for (let p of parts) {
+    p = p.replace(/\s+/g, ' ').trim();
+    if (!p) continue;
+    if (buf && (buf + ' ' + p).length > 180) { out.push(buf); buf = ''; }
+    buf = buf ? buf + ' ' + p : p;
+    while (buf.length > 200) { out.push(buf.slice(0, 200)); buf = buf.slice(200).trim(); }
+  }
+  if (buf) out.push(buf);
+  return out.length ? out : [s];
+}
+
+export function browserSpeaker() {
+  let queue = [];        // remaining chunks of the CURRENT message
+  let gen = 0;           // bumped per message; stale utterance callbacks are ignored
+  let retried = false;
+  let keepalive = null;
+  let settle = null;     // resolve of the in-flight speak()
+
+  function stopKeepalive() { if (keepalive) { clearInterval(keepalive); keepalive = null; } }
+  function startKeepalive() {
+    stopKeepalive();
+    keepalive = setInterval(() => {
+      if (!window.speechSynthesis) return stopKeepalive();
+      if (speechSynthesis.speaking || speechSynthesis.pending) speechSynthesis.resume();
+      else stopKeepalive();
+    }, 7000);
+  }
+  function finish(my) {
+    if (my !== gen) return;
+    stopKeepalive();
+    const done = settle; settle = null;
+    if (done) done();
+  }
+  function playNext(my) {
+    if (my !== gen) return;                    // a newer message superseded this one
+    if (!queue.length) return finish(my);      // message done
+    const u = new SpeechSynthesisUtterance(queue[0]);
+    const v = voiceObj(current.voice) || defaultVoice();
+    if (v) { u.voice = v; u.lang = v.lang; }   // else: default voice (voices may still be loading)
+    u.onend = () => { if (my !== gen) return; queue.shift(); retried = false; playNext(my); };
+    u.onerror = () => {
+      if (my !== gen) return;                  // 'canceled'/'interrupted' from a newer speak(): ignore
+      if (!retried) {                          // recover once: reset the engine, retry this chunk
+        retried = true;
+        try { speechSynthesis.cancel(); } catch (e) {}
+        setTimeout(() => playNext(my), 150);
+      } else { retried = false; queue.shift(); playNext(my); } // give up on this chunk, continue
+    };
+    try { speechSynthesis.resume(); speechSynthesis.speak(u); }
+    catch (e) { queue.shift(); playNext(my); }
+  }
+  // A browser voice's identity is its name|lang pair — the same token the picker
+  // stores, so nothing downstream has to know it is not an opaque engine id.
+  function list() { return window.speechSynthesis ? speechSynthesis.getVoices() : []; }
+  function idOf(v) { return v.name + '|' + v.lang; }
+  function voiceObj(id) { return id ? list().find((v) => idOf(v) === id) || null : null; }
+  function defaultVoice() {
+    const all = list();
+    return all.find((v) => /pt[-_]BR/i.test(v.lang)) || all.find((v) => /^pt/i.test(v.lang)) || null;
+  }
+  let current = {};
+
+  return {
+    id: 'browser',
+    key: 'bc-voice',                           // where the picker persists its choice
+    // Voices arrive asynchronously in every browser; poll briefly rather than
+    // answering with the empty list the first call would otherwise see.
+    voices() {
+      return new Promise((resolve) => {
+        let tries = 0;
+        const take = () => list().map((v) => ({ id: idOf(v), name: v.name, lang: v.lang }));
+        if (take().length) return resolve(take());
+        const t = setInterval(() => {
+          if (take().length || ++tries > 10) { clearInterval(t); resolve(take()); }
+        }, 300);
+      });
+    },
+    speak(text, opts) {
+      return new Promise((resolve, reject) => {
+        if (!window.speechSynthesis) return reject(new Error('no speechSynthesis'));
+        const my = ++gen;
+        current = opts || {};
+        queue = chunkText(text);
+        retried = false;
+        settle = resolve;
+        startKeepalive();
+        // Only do the cancel-then-wait dance when something is actually in
+        // flight: speaking straight away keeps a click-gesture unlock intact.
+        if (speechSynthesis.speaking || speechSynthesis.pending) {
+          try { speechSynthesis.cancel(); } catch (e) {}
+          setTimeout(() => playNext(my), 60);  // let cancel() settle before speak() (Chrome quirk)
+        } else playNext(my);
+      });
+    },
+    cancel() {
+      gen++; queue = []; stopKeepalive();
+      try { if (window.speechSynthesis) speechSynthesis.cancel(); } catch (e) {}
+      const done = settle; settle = null;
+      if (done) done();                        // a cancelled message is finished, not failed
+    },
+  };
+}

--- a/ui/js/tts/index.js
+++ b/ui/js/tts/index.js
@@ -1,0 +1,36 @@
+// The speaker seam. One interface, two implementations, one composition:
+//
+//   { id, key, voices(), speak(text, {voice}), cancel() }
+//
+// voices() answers [{id, name, lang}] whatever is behind it — a browser voice's
+// name|lang pair and an engine voice's opaque id both come out as an `id`, so
+// nothing downstream knows the difference. speak() rejects on failure.
+//
+// This module is the ONLY place that knows a remote failure means "use the
+// browser": speakerFor() composes it once, and voice.js holds a single speaker
+// it never questions.
+import { browserSpeaker } from './browser.js';
+import { remoteSpeaker } from './remote.js';
+
+// speak() tries `primary` and, if it rejects, speaks the same text through
+// `secondary` — so the board never loses its voice when an engine is down.
+// The secondary is spoken with NO voice option: the picked id belongs to the
+// primary and would be meaningless (or wrong) to the other side.
+export function withFallback(primary, secondary) {
+  return {
+    id: primary.id,
+    key: primary.key,
+    voices: () => primary.voices(),
+    speak: (text, opts) => primary.speak(text, opts).catch(() => secondary.speak(text, {})),
+    cancel: () => { primary.cancel(); secondary.cancel(); },
+  };
+}
+
+// Build the speaker for a workspace config (/api/config). No external engine
+// configured => the browser speaker alone, exactly as it always was.
+export function speakerFor(cfg) {
+  const tts = cfg && cfg.tts;
+  const browser = browserSpeaker();
+  if (!tts || !tts.enabled) return browser;
+  return withFallback(remoteSpeaker(tts), browser);
+}

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -1,0 +1,65 @@
+// Speaker over an external TTS engine, reached through the server's proxy
+// (/api/tts/voices, /api/tts/speech — the engines send no CORS headers).
+//
+// Every failure rejects: network, non-200, empty body, a blocked or failed
+// play(). Nothing here knows what happens next — that is withFallback's job.
+
+export function remoteSpeaker(cfg) {
+  const lang = (cfg && cfg.lang) || '';
+  let audio = null;
+  let gen = 0;                                  // bumped by cancel(); stale work stops quietly
+
+  function stop() {
+    if (!audio) return;
+    const a = audio; audio = null;
+    try { a.pause(); a.src = ''; } catch (e) {}
+  }
+  function post(input, voice) {
+    return fetch('/api/tts/speech', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(voice ? { input, voice } : { input }),
+    });
+  }
+  return {
+    id: 'remote',
+    key: 'bc-tts-voice',                        // deliberately NOT the browser key: a
+                                                // browser voice name is never an engine id
+    voices() {
+      return fetch('/api/tts/voices')
+        .then((r) => r.json())
+        .then((j) => ((j && j.voices) || [])
+          .filter((v) => !lang || !Array.isArray(v.langs) || v.langs.includes(lang))
+          .map((v) => ({ id: v.id, name: v.name, lang: (v.langs || []).join(',') || lang })))
+        .catch(() => []);
+    },
+    async speak(text, opts) {
+      const my = ++gen;
+      const voice = (opts && opts.voice) || '';
+      let r = await post(text, voice);
+      // A voice the engine lists but cannot actually use is a 400 (the catalogue
+      // is shared across engines). Retry once on the engine's own default rather
+      // than dropping all the way back to the browser voice.
+      if (r.status === 400 && voice) r = await post(text, '');
+      if (!r.ok) throw new Error('tts http ' + r.status);
+      const blob = await r.blob();
+      if (!blob.size) throw new Error('tts empty audio');
+      if (my !== gen) return;                   // superseded while synthesizing
+      const url = URL.createObjectURL(blob);
+      const a = new Audio(url);
+      audio = a;
+      try {
+        await a.play();
+        await new Promise((resolve, reject) => {
+          a.onended = resolve;
+          a.onpause = resolve;                  // cancel(): finished, not failed
+          a.onerror = () => reject(new Error('tts playback failed'));
+        });
+      } finally {
+        URL.revokeObjectURL(url);
+        if (audio === a) audio = null;
+      }
+    },
+    cancel() { gen++; stop(); },
+  };
+}

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -1,67 +1,39 @@
-// TTS: speak new agent messages when enabled; toggle persists in localStorage
+// TTS: speak new agent messages when enabled; toggle persists in localStorage.
+// WHICH speaker does the talking — the browser's speechSynthesis or an external
+// engine, with the browser as the fallback under it — is decided once in
+// ./tts/index.js. Everything below holds a single `speaker` and never asks.
 import { api } from './api.js';
+import { speakerFor } from './tts/index.js';
 
-const VOICE_KEY = 'bc-voice';
-const TTS_VOICE_KEY = 'bc-tts-voice'; // engine voice *id* — deliberately NOT VOICE_KEY,
-                                      // so a stale browser voice name is never sent as one
 const VOICE_ON_KEY = 'bc-voice-on';
 const voiceSelect = document.getElementById('voice-select');
 const voiceBtn = document.getElementById('voice-btn');
 
 let voiceOn = false;
-let voices = [];
-let voiceFilter = null; // lowercase substrings from /api/config, or null
-
-// ---------- external TTS engine (optional) ----------
-// When the workspace configures one, the picker lists the engine's voices and
-// messages are synthesized through /api/tts/*. Any failure at all — engine down,
-// 400, timeout, empty body — falls back to speechSynthesis; the board never
-// loses its voice because a container is down.
-let ttsCfg = null;     // {enabled, lang, voice} from /api/config, or null
-let ttsVoices = [];    // the engine catalogue, empty until (and unless) it answers
-let audio = null;      // the <audio> currently playing engine speech
-
-function ttsOn() { return !!(ttsCfg && ttsCfg.enabled); }
-function ttsPicker() { return ttsOn() && ttsVoices.length > 0; }
+let speaker = speakerFor(null);   // browser-only until /api/config answers
+let voiceList = [];               // [{id, name, lang}] from speaker.voices()
+let voiceFilter = null;           // lowercase substrings from /api/config, or null
 
 api.config().then((cfg) => {
   if (cfg && Array.isArray(cfg.voices) && cfg.voices.length) {
     voiceFilter = cfg.voices.map((s) => String(s).toLowerCase());
   }
-  if (cfg && cfg.tts && cfg.tts.enabled) { ttsCfg = cfg.tts; loadTtsVoices(); }
-  if (voices.length) populatePicker();
-}).catch(() => {});
+  speaker = speakerFor(cfg);
+  loadVoices();
+}).catch(() => loadVoices());
 
-function loadTtsVoices() {
-  fetch('/api/tts/voices').then((r) => r.json()).then((j) => {
-    const list = (j && j.voices) || [];
-    if (!list.length) return;              // engine down at load: keep the browser picker
-    ttsVoices = list;
-    populateTtsPicker();
-  }).catch(() => {});
+function loadVoices() {
+  speaker.voices().then((list) => { voiceList = list; populatePicker(); }).catch(() => {});
 }
-function populateTtsPicker() {
-  const lang = ttsCfg && ttsCfg.lang;
-  const speaks = (v) => !lang || !Array.isArray(v.langs) || v.langs.includes(lang);
-  const list = ttsVoices.filter(speaks).length ? ttsVoices.filter(speaks) : ttsVoices;
-  voiceSelect.textContent = '';
-  const def = document.createElement('option');
-  def.value = '';
-  def.textContent = 'default voice';
-  voiceSelect.appendChild(def);
-  for (const v of list) {
-    const o = document.createElement('option');
-    o.value = v.id;
-    o.textContent = v.name + (Array.isArray(v.langs) && v.langs.length ? ' (' + v.langs.join(',') + ')' : '');
-    voiceSelect.appendChild(o);
-  }
-  let saved = null;
-  try { saved = localStorage.getItem(TTS_VOICE_KEY); } catch (e) {}
-  if (saved && list.some((v) => v.id === saved)) voiceSelect.value = saved;
-}
-
-function savedVoice() {
-  try { return JSON.parse(localStorage.getItem(VOICE_KEY)); } catch (e) { return null; }
+// The picker's saved choice is keyed per speaker (speaker.key), so a browser
+// voice name can never come back as an engine voice id. The legacy {name,lang}
+// shape is still read, so an existing selection survives the upgrade.
+function savedVoiceId() {
+  let raw = null;
+  try { raw = localStorage.getItem(speaker.key); } catch (e) {}
+  if (!raw) return '';
+  if (raw[0] !== '{') return raw;
+  try { const o = JSON.parse(raw); return o.name + '|' + o.lang; } catch (e) { return ''; }
 }
 function voiceRank(v) {
   if (/^pt[-_]BR/i.test(v.lang)) return 0;
@@ -70,16 +42,12 @@ function voiceRank(v) {
   return 3;
 }
 function populatePicker() {
-  if (ttsPicker()) return;                 // engine voices own the picker
-  let sorted = voices.slice().sort((a, b) =>
+  let sorted = voiceList.slice().sort((a, b) =>
     voiceRank(a) - voiceRank(b) || a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name));
+  const saved = savedVoiceId();
   if (voiceFilter) {
     const matches = (v) => voiceFilter.some((f) => v.name.toLowerCase().includes(f));
-    if (sorted.some(matches)) {
-      const saved = savedVoice();
-      const isSaved = (v) => saved && v.name === saved.name && v.lang === saved.lang;
-      sorted = sorted.filter((v) => matches(v) || isSaved(v));
-    }
+    if (sorted.some(matches)) sorted = sorted.filter((v) => matches(v) || v.id === saved);
   }
   voiceSelect.textContent = '';
   const def = document.createElement('option');
@@ -88,56 +56,21 @@ function populatePicker() {
   voiceSelect.appendChild(def);
   for (const v of sorted) {
     const o = document.createElement('option');
-    o.value = v.name + '|' + v.lang;
-    o.textContent = v.name + ' (' + v.lang + ')';
+    o.value = v.id;
+    o.textContent = v.name + (v.lang ? ' (' + v.lang + ')' : '');
     voiceSelect.appendChild(o);
   }
-  const saved = savedVoice();
-  if (saved && sorted.some((v) => v.name === saved.name && v.lang === saved.lang)) {
-    voiceSelect.value = saved.name + '|' + saved.lang;
-  }
-}
-function loadVoices() {
-  voices = window.speechSynthesis ? speechSynthesis.getVoices() : [];
-  if (voices.length) populatePicker();
-}
-if (window.speechSynthesis) {
-  loadVoices();
-  speechSynthesis.onvoiceschanged = loadVoices;
-  let tries = 0;
-  const retry = setInterval(() => {
-    if (voices.length || ++tries > 10) clearInterval(retry); else loadVoices();
-  }, 300);
-}
-function selectedVoice() {
-  const val = voiceSelect.value;
-  if (!val) return null;
-  const i = val.lastIndexOf('|');
-  const name = val.slice(0, i), lang = val.slice(i + 1);
-  return voices.find((v) => v.name === name && v.lang === lang) || null;
+  if (saved && sorted.some((v) => v.id === saved)) voiceSelect.value = saved;
 }
 voiceSelect.onchange = () => {
-  if (ttsPicker()) {
-    const id = voiceSelect.value;
-    try { if (id) localStorage.setItem(TTS_VOICE_KEY, id); else localStorage.removeItem(TTS_VOICE_KEY); } catch (e) {}
-    return;
-  }
-  const v = selectedVoice();
-  if (v) localStorage.setItem(VOICE_KEY, JSON.stringify({ name: v.name, lang: v.lang }));
-  else localStorage.removeItem(VOICE_KEY);
+  const id = voiceSelect.value;
+  try { if (id) localStorage.setItem(speaker.key, id); else localStorage.removeItem(speaker.key); } catch (e) {}
 };
-function pickVoice() {
-  // Only ever return a voice that is actually in the loaded list, so a stale or
-  // not-yet-loaded selection falls back to the engine default instead of failing.
-  const sel = selectedVoice();
-  if (sel && voices.includes(sel)) return sel;
-  return voices.find((v) => /pt[-_]BR/i.test(v.lang)) || voices.find((v) => /^pt/i.test(v.lang)) || null;
-}
-function utter(text) {
-  const u = new SpeechSynthesisUtterance(text);
-  const v = pickVoice();
-  if (v) { u.voice = v; u.lang = v.lang; } // else: default voice (voices may still be loading)
-  return u;
+// Only ever hand over a voice that is actually in the loaded list, so a stale or
+// not-yet-loaded selection falls back to the speaker's default instead of failing.
+function pickedVoice() {
+  const id = voiceSelect.value;
+  return id && voiceList.some((v) => v.id === id) ? id : '';
 }
 function stripEmoji(s) { // spoken text only
   return s
@@ -147,95 +80,47 @@ function stripEmoji(s) { // spoken text only
     .replace(/[←-⇿⌀-⏿■-◿☀-➿⬀-⯿]/g, ' ')
     .replace(/\s{2,}/g, ' ').trim();
 }
-// ---------- robust speech controller ----------
-// Reliability hazards this guards against:
-//  - overlapping utterances wedging the queue (rapid messages) -> cancel-and-
-//    speak-latest: a new message supersedes the old so the newest is always heard;
-//  - Chrome/Safari idle auto-pause and the ~15s mid-utterance cutoff -> a keepalive
-//    that resume()s while speaking, plus splitting long text into sentence chunks;
-//  - a stuck/failed utterance killing all later speech -> onerror resets the engine
-//    and retries the chunk once, then moves on instead of dying silently.
-let speakQueue = [];   // remaining chunks of the CURRENT message
-let speakGen = 0;      // bumped per message; stale utterance callbacks are ignored
-let retriedChunk = false;
-let keepalive = null;
+function stripForSpeech(text) {
+  return stripEmoji(text.replace(/```[\s\S]*?```/g, ' code ').replace(/[`*#\[\]()]/g, ' ').replace(/https?:\S+/g, ' link '));
+}
 
-function stopKeepalive() { if (keepalive) { clearInterval(keepalive); keepalive = null; } }
-function startKeepalive() {
-  stopKeepalive();
-  keepalive = setInterval(() => {
-    if (!window.speechSynthesis) return stopKeepalive();
-    if (speechSynthesis.speaking || speechSynthesis.pending) speechSynthesis.resume();
-    else stopKeepalive();
-  }, 7000);
-}
-// split into sentence-sized chunks so no single utterance is long enough to hit
-// the engine's mid-utterance cutoff; hard-wrap anything still oversized.
-function chunkText(s) {
-  const parts = s.match(/[^.!?\n]+[.!?]*|\n+/g) || [s];
-  const out = [];
-  let buf = '';
-  for (let p of parts) {
-    p = p.replace(/\s+/g, ' ').trim();
-    if (!p) continue;
-    if (buf && (buf + ' ' + p).length > 180) { out.push(buf); buf = ''; }
-    buf = buf ? buf + ' ' + p : p;
-    while (buf.length > 200) { out.push(buf.slice(0, 200)); buf = buf.slice(200).trim(); }
-  }
-  if (buf) out.push(buf);
-  return out.length ? out : [s];
-}
-function playNext(gen) {
-  if (gen !== speakGen) return;             // a newer message superseded this one
-  if (!speakQueue.length) { stopKeepalive(); speakingBubble.hide(); return; } // message done
-  const u = utter(speakQueue[0]);
-  u.onend = () => { if (gen !== speakGen) return; speakQueue.shift(); retriedChunk = false; playNext(gen); };
-  u.onerror = () => {
-    if (gen !== speakGen) return;           // 'canceled'/'interrupted' from a newer speak(): ignore
-    if (!retriedChunk) {                     // recover once: reset the engine, retry this chunk
-      retriedChunk = true;
-      try { speechSynthesis.cancel(); } catch (e) {}
-      setTimeout(() => playNext(gen), 150);
-    } else { retriedChunk = false; speakQueue.shift(); playNext(gen); } // give up on this chunk, continue
-  };
-  try { speechSynthesis.resume(); speechSynthesis.speak(u); }
-  catch (e) { speakQueue.shift(); playNext(gen); }
+// ---------- speech sessions ----------
+// One session at a time: a new message supersedes the old, so the newest is
+// always what you hear. speak() settles when the message is done (spoken,
+// cancelled, or — after every fallback under it failed — given up on), which is
+// also what drives the floating indicator.
+let session = 0;
+let speaking = false;
+
+function speakPlain(plain) {
+  const my = ++session;
+  speaker.cancel();
+  speaking = true;
+  speakingBubble.show();
+  speaker.speak(plain.slice(0, 1200), { voice: pickedVoice() })
+    .catch(() => {})
+    .then(() => { if (my !== session) return; speaking = false; speakingBubble.hide(); });
 }
 export function speak(text) {
-  if (!voiceOn || !(window.speechSynthesis || ttsOn())) return;
+  if (!voiceOn) return;
   const plain = stripForSpeech(text);
   if (!plain) return;
   manualSpeakingKey = null;                  // an auto-speak supersedes any manual toggle state
   speakPlain(plain);
 }
 export function stopSpeaking() {
-  speakGen++; speakQueue = []; stopKeepalive(); stopAudio();
-  try { if (window.speechSynthesis) speechSynthesis.cancel(); } catch (e) {}
+  session++;
+  speaking = false;
+  speaker.cancel();
   speakingBubble.hide();
-}
-function stopAudio() {
-  if (!audio) return;
-  const a = audio; audio = null;
-  try { a.pause(); a.src = ''; } catch (e) {}
-}
-// True while ANY speech path is producing sound — the engine's <audio> or the
-// browser's own synthesizer.
-function isSpeaking() {
-  if (audio && !audio.paused && !audio.ended) return true;
-  return !!(window.speechSynthesis && (speechSynthesis.speaking || speechSynthesis.pending));
 }
 
 // ---------- floating "speaking" indicator ----------
-// A small fixed bubble shown ONLY while TTS is actually producing speech. It is
-// driven by the engine state (speechSynthesis.speaking/pending) rather than a
-// single utterance, so it correctly spans the whole message across its queued
-// sentence chunks and hides on natural end, error, or cancel. show() is called
-// when a speak session begins (speakPlain); the poll is the robust hide — it only
-// hides once it has actually observed speech (so the cancel()->speak() startup gap
-// never hides it early), and a grace window covers a message that never starts.
+// A small fixed bubble shown ONLY while a speech session is live: up when one
+// starts, down when the speaker settles it (natural end, error, or cancel).
 // Clicking the bubble cancels all speech immediately.
 const speakingBubble = (() => {
-  let el = null, poll = null, sawSpeech = false, misses = 0, giveUp = 0;
+  let el = null;
   function ensureEl() {
     if (el) return el;
     el = document.createElement('button');
@@ -249,85 +134,20 @@ const speakingBubble = (() => {
     document.body.appendChild(el);
     return el;
   }
-  function stopPoll() { if (poll) { clearInterval(poll); poll = null; } }
-  function hide() { stopPoll(); sawSpeech = false; misses = 0; if (el) el.hidden = true; }
-  function show() {
-    if (!window.speechSynthesis && !ttsOn()) return;
-    ensureEl().hidden = false;
-    sawSpeech = false; misses = 0; giveUp = Date.now() + 3500;
-    if (poll) return; // already watching this speak session
-    poll = setInterval(() => {
-      if (isSpeaking()) { sawSpeech = true; misses = 0; return; }
-      if (sawSpeech) { if (++misses >= 2) hide(); }   // spoke, now idle for two ticks -> done
-      else if (Date.now() > giveUp) hide();           // never started within the grace window
-    }, 250);
-  }
-  return { show, hide };
+  return {
+    show() { ensureEl().hidden = false; },
+    hide() { if (el) el.hidden = true; },
+  };
 })();
-function stripForSpeech(text) {
-  return stripEmoji(text.replace(/```[\s\S]*?```/g, ' code ').replace(/[`*#\[\]()]/g, ' ').replace(/https?:\S+/g, ' link '));
-}
-// speak the queued chunks of `plain` as the newest message (shared by speak() and manual)
-function speakPlain(plain) {
-  const gen = ++speakGen;                    // newest message wins
-  stopAudio();
-  if (ttsOn()) { speakingBubble.show(); ttsSpeak(plain, gen); return; }
-  browserSpeak(plain, gen);
-}
-function browserSpeak(plain, gen) {
-  speakQueue = chunkText(plain.slice(0, 1200));
-  retriedChunk = false;
-  try { speechSynthesis.cancel(); } catch (e) {} // clear anything in flight / a wedged queue
-  startKeepalive();
-  speakingBubble.show();                      // floating indicator up for this speak session
-  setTimeout(() => playNext(gen), 60);       // let cancel() settle before speak() (Chrome quirk)
-}
-// Synthesize through the configured engine and play the returned audio. EVERY
-// failure — network, non-200, empty body, a blocked/failed play() — falls back
-// to the browser voice for the same message. Silence is not an outcome.
-async function ttsSpeak(plain, gen) {
-  const input = plain.slice(0, 1200);
-  try {
-    const voice = ttsPicker() ? voiceSelect.value : '';
-    const post = (v) => fetch('/api/tts/speech', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(v ? { input, voice: v } : { input }),
-    });
-    let r = await post(voice);
-    // A voice the engine lists but cannot actually use is a 400 (a catalogue is
-    // shared across engines). Retry once on the engine's own default rather than
-    // dropping all the way back to the browser voice.
-    if (r.status === 400 && voice) r = await post('');
-    if (!r.ok) throw new Error('http ' + r.status);
-    const blob = await r.blob();
-    if (!blob.size) throw new Error('empty audio');
-    if (gen !== speakGen) return;            // superseded while synthesizing
-    const url = URL.createObjectURL(blob);
-    const a = new Audio(url);
-    audio = a;
-    const done = () => { URL.revokeObjectURL(url); if (audio === a) audio = null; };
-    a.onended = done;
-    a.onerror = done;
-    await a.play();
-    speakingBubble.show();                   // re-arm the indicator's grace window
-  } catch (e) {
-    if (gen !== speakGen) return;            // superseded: the newer message owns the voice
-    stopAudio();
-    if (window.speechSynthesis) browserSpeak(plain, gen);
-    else speakingBubble.hide();
-  }
-}
+
 // Manual, on-demand speak for a single message. Independent of the auto-speak
 // toggle: this call happens inside a real user gesture (the speak-button click),
-// so the speak() it fires is itself the gesture that unlocks speechSynthesis — no
-// separate primer needed. Returns true if it spoke, false if there was nothing to
-// say / no engine. Clicking again while this message is speaking stops it (cheap
-// toggle).
+// so the speak() it fires is itself the gesture that unlocks audio — no separate
+// primer needed. Returns true if it spoke, false if there was nothing to say.
+// Clicking again while this message is speaking stops it (cheap toggle).
 let manualSpeakingKey = null;
 export function speakMessage(text, key) {
-  if (!window.speechSynthesis && !ttsOn()) return false;
-  if (key != null && manualSpeakingKey === key && isSpeaking()) {
+  if (key != null && manualSpeakingKey === key && speaking) {
     manualSpeakingKey = null; stopSpeaking(); return false; // toggle off
   }
   const plain = stripForSpeech(text);
@@ -345,27 +165,13 @@ function setVoiceOn(on) {
   try { if (on) localStorage.setItem(VOICE_ON_KEY, '1'); else localStorage.removeItem(VOICE_ON_KEY); } catch (e) {}
 }
 // No gesture-primer: nothing is ever spoken except real content and the
-// deliberate voice-test greeting. speechSynthesis is gesture-gated, but every
-// speak path already rides a genuine user gesture — a card's Speak button click
-// (speakMessage) and the voice-test button both call speak() inside the click, and
-// that real in-gesture utterance is itself the unlock. The voice-test button
-// speaks an audible greeting through this same routine.
-function realUnlock(text) {
-  if (!window.speechSynthesis) return;
-  try {
-    speechSynthesis.cancel();
-    speechSynthesis.resume();
-    speechSynthesis.speak(utter(text));
-  } catch (e) {}
-}
-
+// deliberate voice-test greeting. Audio is gesture-gated, but every speak path
+// already rides a genuine user gesture — a card's Speak button click
+// (speakMessage) and the voice-test button both speak inside the click, and that
+// real in-gesture utterance is itself the unlock.
 voiceBtn.onclick = () => setVoiceOn(!voiceOn);
 try { if (localStorage.getItem(VOICE_ON_KEY) === '1') setVoiceOn(true); } catch (e) {} // restore toggle
-document.getElementById('voice-test').onclick = () => {
-  // Both paths ride this real click, which is the gesture that unlocks audio.
-  if (ttsOn()) speakPlain('Hello, this is my voice.');
-  else realUnlock('Hello, this is my voice.');
-};
+document.getElementById('voice-test').onclick = () => speakPlain('Hello, this is my voice.');
 
 // ---------- speak only NEW lieutenant messages ----------
 let firstLoad = true;

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -2,6 +2,8 @@
 import { api } from './api.js';
 
 const VOICE_KEY = 'bc-voice';
+const TTS_VOICE_KEY = 'bc-tts-voice'; // engine voice *id* — deliberately NOT VOICE_KEY,
+                                      // so a stale browser voice name is never sent as one
 const VOICE_ON_KEY = 'bc-voice-on';
 const voiceSelect = document.getElementById('voice-select');
 const voiceBtn = document.getElementById('voice-btn');
@@ -10,12 +12,53 @@ let voiceOn = false;
 let voices = [];
 let voiceFilter = null; // lowercase substrings from /api/config, or null
 
+// ---------- external TTS engine (optional) ----------
+// When the workspace configures one, the picker lists the engine's voices and
+// messages are synthesized through /api/tts/*. Any failure at all — engine down,
+// 400, timeout, empty body — falls back to speechSynthesis; the board never
+// loses its voice because a container is down.
+let ttsCfg = null;     // {enabled, lang, voice} from /api/config, or null
+let ttsVoices = [];    // the engine catalogue, empty until (and unless) it answers
+let audio = null;      // the <audio> currently playing engine speech
+
+function ttsOn() { return !!(ttsCfg && ttsCfg.enabled); }
+function ttsPicker() { return ttsOn() && ttsVoices.length > 0; }
+
 api.config().then((cfg) => {
   if (cfg && Array.isArray(cfg.voices) && cfg.voices.length) {
     voiceFilter = cfg.voices.map((s) => String(s).toLowerCase());
   }
+  if (cfg && cfg.tts && cfg.tts.enabled) { ttsCfg = cfg.tts; loadTtsVoices(); }
   if (voices.length) populatePicker();
 }).catch(() => {});
+
+function loadTtsVoices() {
+  fetch('/api/tts/voices').then((r) => r.json()).then((j) => {
+    const list = (j && j.voices) || [];
+    if (!list.length) return;              // engine down at load: keep the browser picker
+    ttsVoices = list;
+    populateTtsPicker();
+  }).catch(() => {});
+}
+function populateTtsPicker() {
+  const lang = ttsCfg && ttsCfg.lang;
+  const speaks = (v) => !lang || !Array.isArray(v.langs) || v.langs.includes(lang);
+  const list = ttsVoices.filter(speaks).length ? ttsVoices.filter(speaks) : ttsVoices;
+  voiceSelect.textContent = '';
+  const def = document.createElement('option');
+  def.value = '';
+  def.textContent = 'default voice';
+  voiceSelect.appendChild(def);
+  for (const v of list) {
+    const o = document.createElement('option');
+    o.value = v.id;
+    o.textContent = v.name + (Array.isArray(v.langs) && v.langs.length ? ' (' + v.langs.join(',') + ')' : '');
+    voiceSelect.appendChild(o);
+  }
+  let saved = null;
+  try { saved = localStorage.getItem(TTS_VOICE_KEY); } catch (e) {}
+  if (saved && list.some((v) => v.id === saved)) voiceSelect.value = saved;
+}
 
 function savedVoice() {
   try { return JSON.parse(localStorage.getItem(VOICE_KEY)); } catch (e) { return null; }
@@ -27,6 +70,7 @@ function voiceRank(v) {
   return 3;
 }
 function populatePicker() {
+  if (ttsPicker()) return;                 // engine voices own the picker
   let sorted = voices.slice().sort((a, b) =>
     voiceRank(a) - voiceRank(b) || a.lang.localeCompare(b.lang) || a.name.localeCompare(b.name));
   if (voiceFilter) {
@@ -73,6 +117,11 @@ function selectedVoice() {
   return voices.find((v) => v.name === name && v.lang === lang) || null;
 }
 voiceSelect.onchange = () => {
+  if (ttsPicker()) {
+    const id = voiceSelect.value;
+    try { if (id) localStorage.setItem(TTS_VOICE_KEY, id); else localStorage.removeItem(TTS_VOICE_KEY); } catch (e) {}
+    return;
+  }
   const v = selectedVoice();
   if (v) localStorage.setItem(VOICE_KEY, JSON.stringify({ name: v.name, lang: v.lang }));
   else localStorage.removeItem(VOICE_KEY);
@@ -153,16 +202,27 @@ function playNext(gen) {
   catch (e) { speakQueue.shift(); playNext(gen); }
 }
 export function speak(text) {
-  if (!voiceOn || !window.speechSynthesis) return;
+  if (!voiceOn || !(window.speechSynthesis || ttsOn())) return;
   const plain = stripForSpeech(text);
   if (!plain) return;
   manualSpeakingKey = null;                  // an auto-speak supersedes any manual toggle state
   speakPlain(plain);
 }
 export function stopSpeaking() {
-  speakGen++; speakQueue = []; stopKeepalive();
+  speakGen++; speakQueue = []; stopKeepalive(); stopAudio();
   try { if (window.speechSynthesis) speechSynthesis.cancel(); } catch (e) {}
   speakingBubble.hide();
+}
+function stopAudio() {
+  if (!audio) return;
+  const a = audio; audio = null;
+  try { a.pause(); a.src = ''; } catch (e) {}
+}
+// True while ANY speech path is producing sound — the engine's <audio> or the
+// browser's own synthesizer.
+function isSpeaking() {
+  if (audio && !audio.paused && !audio.ended) return true;
+  return !!(window.speechSynthesis && (speechSynthesis.speaking || speechSynthesis.pending));
 }
 
 // ---------- floating "speaking" indicator ----------
@@ -192,13 +252,12 @@ const speakingBubble = (() => {
   function stopPoll() { if (poll) { clearInterval(poll); poll = null; } }
   function hide() { stopPoll(); sawSpeech = false; misses = 0; if (el) el.hidden = true; }
   function show() {
-    if (!window.speechSynthesis) return;
+    if (!window.speechSynthesis && !ttsOn()) return;
     ensureEl().hidden = false;
     sawSpeech = false; misses = 0; giveUp = Date.now() + 3500;
     if (poll) return; // already watching this speak session
     poll = setInterval(() => {
-      const active = !!(window.speechSynthesis && (speechSynthesis.speaking || speechSynthesis.pending));
-      if (active) { sawSpeech = true; misses = 0; return; }
+      if (isSpeaking()) { sawSpeech = true; misses = 0; return; }
       if (sawSpeech) { if (++misses >= 2) hide(); }   // spoke, now idle for two ticks -> done
       else if (Date.now() > giveUp) hide();           // never started within the grace window
     }, 250);
@@ -211,12 +270,53 @@ function stripForSpeech(text) {
 // speak the queued chunks of `plain` as the newest message (shared by speak() and manual)
 function speakPlain(plain) {
   const gen = ++speakGen;                    // newest message wins
+  stopAudio();
+  if (ttsOn()) { speakingBubble.show(); ttsSpeak(plain, gen); return; }
+  browserSpeak(plain, gen);
+}
+function browserSpeak(plain, gen) {
   speakQueue = chunkText(plain.slice(0, 1200));
   retriedChunk = false;
   try { speechSynthesis.cancel(); } catch (e) {} // clear anything in flight / a wedged queue
   startKeepalive();
   speakingBubble.show();                      // floating indicator up for this speak session
   setTimeout(() => playNext(gen), 60);       // let cancel() settle before speak() (Chrome quirk)
+}
+// Synthesize through the configured engine and play the returned audio. EVERY
+// failure — network, non-200, empty body, a blocked/failed play() — falls back
+// to the browser voice for the same message. Silence is not an outcome.
+async function ttsSpeak(plain, gen) {
+  const input = plain.slice(0, 1200);
+  try {
+    const voice = ttsPicker() ? voiceSelect.value : '';
+    const post = (v) => fetch('/api/tts/speech', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(v ? { input, voice: v } : { input }),
+    });
+    let r = await post(voice);
+    // A voice the engine lists but cannot actually use is a 400 (a catalogue is
+    // shared across engines). Retry once on the engine's own default rather than
+    // dropping all the way back to the browser voice.
+    if (r.status === 400 && voice) r = await post('');
+    if (!r.ok) throw new Error('http ' + r.status);
+    const blob = await r.blob();
+    if (!blob.size) throw new Error('empty audio');
+    if (gen !== speakGen) return;            // superseded while synthesizing
+    const url = URL.createObjectURL(blob);
+    const a = new Audio(url);
+    audio = a;
+    const done = () => { URL.revokeObjectURL(url); if (audio === a) audio = null; };
+    a.onended = done;
+    a.onerror = done;
+    await a.play();
+    speakingBubble.show();                   // re-arm the indicator's grace window
+  } catch (e) {
+    if (gen !== speakGen) return;            // superseded: the newer message owns the voice
+    stopAudio();
+    if (window.speechSynthesis) browserSpeak(plain, gen);
+    else speakingBubble.hide();
+  }
 }
 // Manual, on-demand speak for a single message. Independent of the auto-speak
 // toggle: this call happens inside a real user gesture (the speak-button click),
@@ -226,8 +326,8 @@ function speakPlain(plain) {
 // toggle).
 let manualSpeakingKey = null;
 export function speakMessage(text, key) {
-  if (!window.speechSynthesis) return false;
-  if (key != null && manualSpeakingKey === key && (speechSynthesis.speaking || speechSynthesis.pending)) {
+  if (!window.speechSynthesis && !ttsOn()) return false;
+  if (key != null && manualSpeakingKey === key && isSpeaking()) {
     manualSpeakingKey = null; stopSpeaking(); return false; // toggle off
   }
   const plain = stripForSpeech(text);
@@ -261,7 +361,11 @@ function realUnlock(text) {
 
 voiceBtn.onclick = () => setVoiceOn(!voiceOn);
 try { if (localStorage.getItem(VOICE_ON_KEY) === '1') setVoiceOn(true); } catch (e) {} // restore toggle
-document.getElementById('voice-test').onclick = () => realUnlock('Hello, this is my voice.');
+document.getElementById('voice-test').onclick = () => {
+  // Both paths ride this real click, which is the gesture that unlocks audio.
+  if (ttsOn()) speakPlain('Hello, this is my voice.');
+  else realUnlock('Hello, this is my voice.');
+};
 
 // ---------- speak only NEW lieutenant messages ----------
 let firstLoad = true;


### PR DESCRIPTION
The board can now speak through an external TTS engine (voxbench API) instead of
`speechSynthesis`, and falls back to the browser the moment that engine misbehaves.

## Config

```json
"tts": { "url": "http://127.0.0.1:8883", "voice": null, "lang": "pt", "params": {} }
```

No `tts` block = nothing changes. `/api/config` still answers `{"voices": ...}` with no
`tts` key, no `/api/tts/*` request is ever made, and the picker and the speech are what
they were on master.

## Server

The engines send no CORS headers, so the browser cannot reach them. Two proxied routes,
both short-timeout — a TTS service that hangs must not hang the board:

- `GET /api/tts/voices` → the engine's `/v1/voices`. Engine down or slow: `{"voices": [],
  "error": "<why>"}`, never a 500.
- `POST /api/tts/speech` → the engine's `/v1/audio/speech`, body through with the
  workspace defaults filled in, response streamed back with `content-type` and
  `x-sample-rate`. `stream` passes through untouched, so streamed playback stays a
  UI-only change later.

The engine URL never leaves the server; `/api/config` only exposes `{enabled, lang, voice}`.

## UI — the speaker seam

`voice.js` holds one `speaker` and has no branch on which backend is live:

```
ui/js/tts/browser.js   speechSynthesis           { id, key, voices(), speak(), cancel() }
ui/js/tts/remote.js    /api/tts/voices + speech  same shape
ui/js/tts/index.js     speakerFor(cfg) = withFallback(remote, browser)
```

A browser voice's `name|lang` and an engine voice's opaque id both come out of `voices()`
as `{id, name, lang}`, so nothing downstream knows the difference. The fallback is not an
`if` either: `withFallback` is the one place that knows a dead primary means "use the
browser", and it speaks the secondary with **no** voice option — one side's id can never
reach the other. Each speaker declares its own picker storage key (`bc-voice` /
`bc-tts-voice`) for the same reason.

Falling out of it: the "speaking…" bubble is driven by `speak()`'s promise instead of
polling `speechSynthesis`.

Out of scope, deliberately: streamed playback, and when the board decides to speak
(`notifypolicy.js` untouched).

## Verified against piper (CPU, :8888)

**1. Picker filled from the engine, a real message spoken through it.** 78 pt voices +
default; the pick persists under `bc-tts-voice` and is restored on reload:

```
{"options":79, "first":[" :: default voice","xtts-v2-aaron-dreschner-pt :: Aaron Dreschner (pt)", ...],
 "saved":"pt_BR-faber-medium", "selected":"pt_BR-faber-medium"}
```

A lieutenant message posted to the live board, with `play()` instrumented:

```
POST /api/tts/speech {"input":"Capitão, o cartão está pronto para revisão.","voice":"pt_BR-faber-medium"} → 200 audio/wav
["ENGINE audio.play()", "ended t=2.32"]
```

**2. `engines/tts down piper` mid-session → the next message is still spoken, by the browser.**
Same page, no reload:

```
["BROWSER speechSynthesis.speak(\"O motor caiu, mas a ponte cont\")", ...]   # no ENGINE play(), no silence
GET  /api/tts/voices → 200 {"voices":[],"error":"fetch failed"}
POST /api/tts/speech → 502 {"error":"fetch failed"}
```

(The doubled `speak` is the pre-existing retry-once-per-chunk recovery — this headless
Chrome has no voices installed, so every utterance errors.)

**3. No `tts` in config** — same build, second workspace:

```
GET /api/config → {"voices":null}          # no tts key
fetches made by the page: /api/config, /api/board   # no /api/tts/* at all
["BROWSER speechSynthesis.speak", ...]     # browser voice
localStorage: ["bc-voice-on"]              # no bc-tts-voice
```

## Tests

`test/tts.test.js` — config parsing (absent / present / malformed, url never exposed) and
the proxy: engine unreachable, not configured, engine 400 verbatim, audio bytes +
`x-sample-rate` through, defaults filled in.
`test/tts-speaker.test.js` — `withFallback`: the primary rejecting speaks the same text
through the secondary, with no voice option; both rejecting rejects; the catalogue and
storage key follow the primary.

314/314 green.
