### PR TITLE
Give the TTS proxy a timeout that outlives a real message

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -133,8 +133,19 @@ const ARTIFACT_MIME = {
 
 const DEFAULT_PORT = 4780;
 // External TTS proxy timeouts — a hanging engine must never hang the board.
+// Speech scales with the text: an engine synthesizing a real chat message runs
+// for tens of seconds (voxcpm2 measured 31 s for 1200 characters, and 1200 is
+// what we send), so a flat 20 s cut every long message off mid-synthesis and
+// dropped it to the browser voice. Budget per character with a floor, and cap
+// it — a minute of silence is a broken engine either way.
 const TTS_VOICES_MS = 3000;
-const TTS_SPEECH_MS = 20000;
+const TTS_SPEECH_MS_MIN = 20000;
+const TTS_SPEECH_MS_PER_CHAR = 60;
+const TTS_SPEECH_MS_MAX = 180000;
+function speechTimeoutMs(input) {
+  const n = typeof input === 'string' ? input.length : 0;
+  return Math.min(TTS_SPEECH_MS_MAX, Math.max(TTS_SPEECH_MS_MIN, n * TTS_SPEECH_MS_PER_CHAR));
+}
 
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
@@ -2194,7 +2205,7 @@ const server = http.createServer(async (req, res) => {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(TTS_SPEECH_MS),
+          signal: AbortSignal.timeout(speechTimeoutMs(payload.input)),
         });
       } catch (e) {
         return sendJson(res, 502, { error: String((e && e.message) || e) });

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -147,3 +147,28 @@ test('an explicit voice wins and suppresses the default lang (they must agree)',
     assert.ok(!('lang' in seen), 'no lang alongside an explicit voice');
   } finally { await s.stop(); engine.close(); }
 });
+
+// The timeout has to outlive a real message. voxcpm2 measured 31 s for the 1200
+// characters the UI sends; the flat 20 s that used to be here cut every long
+// message off mid-synthesis and silently dropped it to the browser voice.
+test('the speech timeout scales with the text, so a long message is not cut off', async () => {
+  const port = await freePort();
+  let seen = null;
+  // An engine that answers only AFTER 20 s — the old flat cap — and reports the
+  // wait it survived. If the proxy still cut at 20 s, this request never lands.
+  const engine = http.createServer((req, res) => {
+    const t0 = Date.now();
+    setTimeout(() => {
+      seen = Date.now() - t0;
+      res.writeHead(200, { 'Content-Type': 'audio/wav' });
+      res.end(Buffer.from('RIFFfake'));
+    }, 22000);
+  });
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port } }) });
+  try {
+    const r = await s.api('POST', '/api/tts/speech', { input: 'x'.repeat(1200) });
+    assert.equal(r.status, 200, 'a 1200-character message must survive a 22 s synthesis');
+    assert.ok(seen >= 22000, 'the engine really did take longer than the old flat cap');
+  } finally { await s.stop(); engine.close(); }
+});


### PR DESCRIPTION
The chat's speak button looked broken while the settings voice-test worked. Both take the same path; the only difference is length.

The proxy capped synthesis at a flat **20 s**. voxcpm2 takes **31 s** for the 1200 characters the UI sends (measured, twice: 31.4 s and 31.2 s). So every long message was aborted mid-synthesis, answered 502, and fell back to the browser voice without saying why. A short greeting fit under the cap; a real message never did.

Now the budget scales with the text — 60 ms per character, floor 20 s, ceiling 3 minutes.

Test drives it against an engine that answers only after 22 s: under the old cap that request never lands.

`node --test test/tts.test.js` → 9/9.