### PR TITLE
Stream the board's voice

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -133,8 +133,22 @@ const ARTIFACT_MIME = {
 
 const DEFAULT_PORT = 4780;
 // External TTS proxy timeouts — a hanging engine must never hang the board.
+// Speech has two deadlines, both on SILENCE rather than on the whole request:
+//  - the first byte, which an engine that does not stream only sends once the
+//    WHOLE message is synthesized (voxcpm2 measured 31 s for the 1200 characters
+//    the UI sends), so this one is budgeted per character with a floor and a cap;
+//  - every byte after it, which on a streaming engine arrives continuously — a
+//    flat cut there would truncate every long message mid-sentence.
 const TTS_VOICES_MS = 3000;
-const TTS_SPEECH_MS = 20000;
+const TTS_SPEECH_MS = parseInt(process.env.BC_TTS_SPEECH_MS, 10) > 0
+  ? parseInt(process.env.BC_TTS_SPEECH_MS, 10) : 20000;      // floor, and the gap between chunks
+const TTS_SPEECH_MS_PER_CHAR = 60;
+const TTS_SPEECH_MS_MAX = parseInt(process.env.BC_TTS_SPEECH_MAX_MS, 10) > 0
+  ? parseInt(process.env.BC_TTS_SPEECH_MAX_MS, 10) : 180000;
+function firstByteMs(input) {
+  const n = typeof input === 'string' ? input.length : 0;
+  return Math.min(TTS_SPEECH_MS_MAX, Math.max(TTS_SPEECH_MS, n * TTS_SPEECH_MS_PER_CHAR));
+}
 
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
@@ -2188,23 +2202,38 @@ const server = http.createServer(async (req, res) => {
       if (!payload.voice && t.voice) payload.voice = t.voice;
       if (!payload.voice && !payload.lang && t.lang) payload.lang = t.lang;
       if (!payload.params && Object.keys(t.params).length) payload.params = t.params;
+      const ac = new AbortController();
+      let timer = null;
+      let over = false;
+      const armFor = (ms) => { clearTimeout(timer); timer = setTimeout(() => ac.abort(), ms); };
+      armFor(firstByteMs(payload.input));       // nothing at all yet: the engine may be synthesizing
+      // The listener hung up (stop button, or a newer message superseding this
+      // one): stop the engine too. Synthesis nobody is waiting for is a GPU busy
+      // for half a minute, and voxcpm2 dies outright when an abandoned message
+      // overlaps the next one — which is exactly what cancel-then-speak does.
+      res.on('close', () => { if (!over) ac.abort(); });
       let r;
       try {
         r = await fetch(t.url + '/v1/audio/speech', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           body: JSON.stringify(payload),
-          signal: AbortSignal.timeout(TTS_SPEECH_MS),
+          signal: ac.signal,
         });
       } catch (e) {
+        clearTimeout(timer);
         return sendJson(res, 502, { error: String((e && e.message) || e) });
       }
       const head = { 'Content-Type': r.headers.get('content-type') || 'application/octet-stream', 'Cache-Control': 'no-store' };
       const rate = r.headers.get('x-sample-rate');
       if (rate) head['x-sample-rate'] = rate;
       res.writeHead(r.status, head);
-      if (!r.body) return res.end();
-      try { for await (const chunk of r.body) res.write(chunk); } catch (e) {}
+      if (!r.body) { over = true; clearTimeout(timer); return res.end(); }
+      // Audio is flowing: from here the deadline is the gap between chunks, so a
+      // stream may run as long as synthesis does and still be cut off if it dies.
+      try { for await (const chunk of r.body) { armFor(TTS_SPEECH_MS); res.write(chunk); } } catch (e) {}
+      over = true;
+      clearTimeout(timer);
       return res.end();
     }
     if (route === 'GET /api/status') {

--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -1,0 +1,128 @@
+'use strict';
+// ui/js/tts/remote.js — the streaming speaker. Two rules carry the feature:
+// sound starts on the first chunk rather than at the end of synthesis, and a
+// 400 from an engine that cannot stream is an ANSWER — the same engine is asked
+// again without streaming, never dropped straight to the browser voice.
+// Browser code (ES module), loaded via dynamic import; nothing here touches DOM.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let remoteSpeaker;
+test.before(async () => {
+  ({ remoteSpeaker } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'tts', 'remote.js')).href));
+});
+
+// A recording AudioContext: every scheduled buffer, with the time it starts.
+function fakeAudioContext() {
+  const scheduled = [];
+  let closed = false;
+  class Ctx {
+    constructor(opts) { this.sampleRate = opts && opts.sampleRate; this.state = 'running'; this.destination = {}; }
+    get currentTime() { return 0; }
+    resume() { return Promise.resolve(); }
+    close() { closed = true; return Promise.resolve(); }
+    createBuffer(ch, len, rate) {
+      const data = new Float32Array(len);
+      return { length: len, duration: len / rate, getChannelData: () => data };
+    }
+    createBufferSource() {
+      let ended = false, cb = null;
+      return {
+        connect() {},
+        start(at) { scheduled.push({ at, buffer: this.buffer }); setTimeout(() => { ended = true; if (cb) cb(); }, 1); },
+        set onended(f) { cb = f; if (ended) f(); },
+        get onended() { return cb; },
+      };
+    }
+  }
+  global.window = { AudioContext: Ctx };
+  return { scheduled, closed: () => closed };
+}
+
+// PCM body: signed 16-bit LE, handed over in `chunks` pieces (a chunk may end
+// mid-sample, which is exactly what the engine does).
+function pcmResponse(samples, chunkBytes, rate) {
+  const buf = Buffer.alloc(samples.length * 2);
+  samples.forEach((v, i) => buf.writeInt16LE(v, i * 2));
+  const stream = new ReadableStream({
+    start(c) {
+      for (let i = 0; i < buf.length; i += chunkBytes) c.enqueue(new Uint8Array(buf.subarray(i, i + chunkBytes)));
+      c.close();
+    },
+  });
+  return new Response(stream, { status: 200, headers: { 'x-sample-rate': String(rate) } });
+}
+
+// Records every /api/tts/speech body; `answer` decides what each one gets.
+function fakeFetch(answer) {
+  const posts = [];
+  global.fetch = (url, opts) => {
+    const body = JSON.parse(opts.body);
+    posts.push(body);
+    return Promise.resolve(answer(body, posts.length));
+  };
+  return posts;
+}
+
+test('a streaming engine: chunks play back to back, and speak() resolves at the end', async () => {
+  const audio = fakeAudioContext();
+  const posts = fakeFetch(() => pcmResponse([0, 16384, -16384, 32767, -32768, 0, 100, -100], 5, 24000));
+  await remoteSpeaker({}).speak('olá, capitão', {});
+  assert.deepEqual(posts, [{ input: 'olá, capitão', stream: true }], 'one request, streaming');
+  const total = audio.scheduled.reduce((n, s) => n + s.buffer.length, 0);
+  assert.equal(total, 8, 'every sample played, including the one split across a chunk boundary');
+  // Back to back: each buffer starts exactly where the previous one ended.
+  let at = audio.scheduled[0].at;
+  for (const s of audio.scheduled) {
+    assert.ok(Math.abs(s.at - at) < 1e-9, 'gap or overlap at a chunk seam');
+    at += s.buffer.length / 24000;
+  }
+  assert.ok(audio.closed(), 'the context is closed when the message is done');
+});
+
+test('an engine that cannot stream: the SAME engine is asked again, non-streaming', async () => {
+  fakeAudioContext();
+  let playedUrl = null;
+  global.URL = { createObjectURL: () => 'blob:x', revokeObjectURL: () => {} };
+  global.Audio = function (url) {
+    playedUrl = url;
+    setTimeout(() => this.onended && this.onended(), 1);
+    return this;
+  };
+  global.Audio.prototype.play = function () { return Promise.resolve(); };
+  const posts = fakeFetch((body) => (body.stream
+    ? new Response(JSON.stringify({ detail: 'this engine cannot stream' }), { status: 400 })
+    : new Response(Buffer.from('RIFFfake'), { status: 200, headers: { 'content-type': 'audio/wav' } })));
+  await remoteSpeaker({}).speak('olá', { voice: 'ana' });
+  assert.deepEqual(posts, [
+    { input: 'olá', voice: 'ana', stream: true },   // asked to stream
+    { input: 'olá', stream: true },                 // maybe it was the voice — same engine, default voice
+    { input: 'olá', voice: 'ana' },                 // no: it does not stream. Still this engine.
+  ], 'a non-streaming engine must not fall through to the browser voice');
+  assert.equal(playedUrl, 'blob:x', 'and it actually spoke');
+});
+
+test('a stream that dies mid-message rejects, so the fallback speaks the rest', async () => {
+  fakeAudioContext();
+  fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); c.error(new Error('engine crashed')); },
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  await assert.rejects(() => remoteSpeaker({}).speak('olá', {}), 'silence is not an outcome');
+});
+
+test('cancel() mid-stream settles speak() instead of hanging on a dead context', async () => {
+  fakeAudioContext();
+  let stall;
+  fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); stall = c; },   // never closes on its own
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  const s = remoteSpeaker({});
+  const done = s.speak('olá', {});
+  await new Promise((r) => setTimeout(r, 10));
+  s.cancel();
+  await done;                                       // cancelled is finished, not failed
+  assert.ok(stall, 'the body was still open when cancel() cut it');
+});

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -147,3 +147,99 @@ test('an explicit voice wins and suppresses the default lang (they must agree)',
     assert.ok(!('lang' in seen), 'no lang alongside an explicit voice');
   } finally { await s.stop(); engine.close(); }
 });
+
+// ---------- the two speech deadlines ----------
+// Both are deadlines on SILENCE, not on the whole request. They are set low here
+// (BC_TTS_SPEECH_MS) so the tests take seconds instead of the real half-minute.
+
+// A non-streaming engine sends nothing until the entire message is synthesized,
+// and synthesis scales with the text: voxcpm2 measured ~31 s for the 1200
+// characters the UI sends. A flat first-byte deadline cut every long message off
+// mid-synthesis and dropped the board to the browser voice.
+test('the first-byte deadline scales with the text: long input survives, short input does not', async () => {
+  const port = await freePort();
+  // Answers after 1.6 s — longer than the 1 s floor, shorter than 40 chars' budget.
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => setTimeout(() => {
+      res.writeHead(200, { 'Content-Type': 'audio/wav' });
+      res.end(Buffer.from('RIFFfake'));
+    }, 1600));
+  });
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }),
+    env: { BC_TTS_SPEECH_MS: '1000' },          // floor 1 s, + 60 ms per character
+  });
+  try {
+    const long = await s.api('POST', '/api/tts/speech', { input: 'x'.repeat(40) });  // 2.4 s budget
+    assert.equal(long.status, 200, 'a long message must outlive its own synthesis');
+    const short = await s.api('POST', '/api/tts/speech', { input: 'oi' });           // 1 s budget
+    assert.equal(short.status, 502, 'two characters taking 1.6 s is a sick engine');
+  } finally { await s.stop(); engine.close(); }
+});
+
+// A streaming engine emits for as long as it synthesizes — 34 s of chunks for
+// those same 1200 characters. The deadline there is the gap between chunks.
+test('a stream may run past the deadline while chunks keep arriving, and is cut when they stop', async () => {
+  const port = await freePort();
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      const n = JSON.parse(body).input === 'stall' ? 1 : 8;   // 8 chunks, 400 ms apart = 3.2 s
+      res.writeHead(200, { 'Content-Type': 'audio/pcm', 'x-sample-rate': '24000' });
+      let i = 0;
+      const t = setInterval(() => {
+        res.write(Buffer.alloc(100, 7));
+        if (++i >= n) { clearInterval(t); if (n > 1) res.end(); }   // 'stall': never ends
+      }, 400);
+    });
+  });
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }),
+    env: { BC_TTS_SPEECH_MS: '1000' },          // 1 s of silence is the limit, per chunk
+  });
+  try {
+    const ok = await s.api('POST', '/api/tts/speech', { input: 'oi', stream: true });
+    assert.equal(ok.body.length, 800, '3.2 s of chunks under a 1 s per-chunk deadline: all of it');
+    const cut = await s.api('POST', '/api/tts/speech', { input: 'stall', stream: true });
+    assert.equal(cut.body.length, 100, 'a stream that goes silent is still cut off');
+  } finally { await s.stop(); engine.close(); }
+});
+
+// Cancel has to reach the GPU. A listener who hits stop (or a newer message that
+// supersedes this one) leaves the engine synthesizing for another half-minute
+// otherwise — and voxcpm2 dies outright when that abandoned message overlaps the
+// next request, which is exactly the shape of cancel-then-speak.
+test('the listener hangs up: the engine request is aborted, not left running', async () => {
+  const port = await freePort();
+  let closed = null;
+  const engine = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      res.writeHead(200, { 'Content-Type': 'audio/pcm', 'x-sample-rate': '24000' });
+      let sent = 0;
+      const t = setInterval(() => { res.write(Buffer.alloc(100, 7)); sent++; }, 100);
+      res.on('close', () => { clearInterval(t); if (closed === null) closed = sent; });
+    });
+  });
+  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
+  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }) });
+  try {
+    const ac = new AbortController();
+    const req = fetch(s.base + '/api/tts/speech', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ input: 'olá', stream: true }), signal: ac.signal,
+    }).then((r) => r.arrayBuffer());
+    await new Promise((r) => setTimeout(r, 500));
+    ac.abort();                                 // the browser stops listening
+    await req.catch(() => {});
+    await new Promise((r) => setTimeout(r, 500));
+    assert.ok(closed !== null, 'the engine kept synthesizing for nobody');
+    assert.ok(closed < 12, 'it was cut where the listener left, not at the end (' + closed + ' chunks)');
+  } finally { await s.stop(); engine.close(); }
+});

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -1,26 +1,111 @@
 // Speaker over an external TTS engine, reached through the server's proxy
 // (/api/tts/voices, /api/tts/speech — the engines send no CORS headers).
 //
+// Speech is asked for STREAMING: the body is then raw signed 16-bit little-endian
+// mono PCM (no header, no framing) at the rate in `x-sample-rate`, and it plays as
+// it arrives instead of after the whole synthesis. An engine that cannot stream
+// says so with a 400 — that is an answer, so we ask the same engine again without
+// streaming before giving up on it.
+//
 // Every failure rejects: network, non-200, empty body, a blocked or failed
 // play(). Nothing here knows what happens next — that is withFallback's job.
 
+const LEAD = 0.05;                              // schedule this far ahead of "now"
+
 export function remoteSpeaker(cfg) {
   const lang = (cfg && cfg.lang) || '';
-  let audio = null;
+  let audio = null;                             // <audio>, the non-streaming path
+  let ctx = null;                               // AudioContext, the streaming path
+  let reader = null;                            // the body being read right now
+  let endStream = null;                         // resolves the stream awaiting its last buffer
   let gen = 0;                                  // bumped by cancel(); stale work stops quietly
 
   function stop() {
-    if (!audio) return;
-    const a = audio; audio = null;
-    try { a.pause(); a.src = ''; } catch (e) {}
+    if (audio) { const a = audio; audio = null; try { a.pause(); a.src = ''; } catch (e) {} }
+    if (reader) { const rd = reader; reader = null; try { rd.cancel(); } catch (e) {} }
+    if (ctx) { const c = ctx; ctx = null; try { c.close(); } catch (e) {} }
+    const done = endStream; endStream = null;
+    if (done) done();                           // a cancelled message is finished, not failed
   }
-  function post(input, voice) {
+  function post(input, voice, stream) {
+    const body = { input };
+    if (voice) body.voice = voice;
+    if (stream) body.stream = true;
     return fetch('/api/tts/speech', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(voice ? { input, voice } : { input }),
+      body: JSON.stringify(body),
     });
   }
+
+  // Play raw PCM as it arrives, buffer scheduled back to back so the seams are
+  // silent. Resolves when the last one has finished, rejects if the stream dies.
+  async function playStream(res, rate, my) {
+    const c = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: rate });
+    ctx = c;
+    // Audio the page has not been allowed to make yet: resume() then waits for a
+    // gesture that may never come, so it is raced rather than awaited — a context
+    // that is not running is a failure, and failure is what withFallback reads.
+    if (c.state !== 'running') {
+      await Promise.race([c.resume().catch(() => {}), new Promise((r) => setTimeout(r, 250))]);
+      if (c.state !== 'running') throw new Error('tts audio blocked');
+    }
+    const rd = res.body.getReader();
+    reader = rd;
+    try {
+      let at = 0;                               // when the next buffer starts, on c's clock
+      let odd = null;                           // a chunk can end mid-sample: carry the byte over
+      let last = null;
+      for (;;) {
+        const { value, done } = await rd.read();
+        if (done || my !== gen) break;
+        let bytes = value;
+        if (odd) { const j = new Uint8Array(odd.length + bytes.length); j.set(odd); j.set(bytes, odd.length); bytes = j; }
+        odd = bytes.length % 2 ? bytes.slice(-1) : null;
+        bytes = odd ? bytes.slice(0, -1) : bytes.slice();  // copy: Int16Array needs its own aligned buffer
+        if (!bytes.length) continue;
+        const pcm = new Int16Array(bytes.buffer);
+        const buf = c.createBuffer(1, pcm.length, rate);
+        const ch = buf.getChannelData(0);
+        for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
+        const src = c.createBufferSource();
+        src.buffer = buf;
+        src.connect(c.destination);
+        at = Math.max(at, c.currentTime + LEAD); // never schedule in the past (a slow engine underruns)
+        src.start(at);
+        at += buf.duration;
+        last = src;
+      }
+      if (my !== gen) return;                   // cancelled: stop() already tore the context down
+      if (!last) throw new Error('tts empty audio');
+      await new Promise((resolve) => { endStream = resolve; last.onended = resolve; });
+    } finally {
+      endStream = null;
+      if (reader === rd) reader = null;
+      if (ctx === c) { ctx = null; try { c.close(); } catch (e) {} }
+    }
+  }
+
+  async function playBlob(res, my) {
+    const blob = await res.blob();
+    if (!blob.size) throw new Error('tts empty audio');
+    if (my !== gen) return;                     // superseded while synthesizing
+    const url = URL.createObjectURL(blob);
+    const a = new Audio(url);
+    audio = a;
+    try {
+      await a.play();
+      await new Promise((resolve, reject) => {
+        a.onended = resolve;
+        a.onpause = resolve;                    // cancel(): finished, not failed
+        a.onerror = () => reject(new Error('tts playback failed'));
+      });
+    } finally {
+      URL.revokeObjectURL(url);
+      if (audio === a) audio = null;
+    }
+  }
+
   return {
     id: 'remote',
     key: 'bc-tts-voice',                        // deliberately NOT the browser key: a
@@ -35,30 +120,20 @@ export function remoteSpeaker(cfg) {
     },
     async speak(text, opts) {
       const my = ++gen;
+      stop();                                   // a new message supersedes the old one, sound and all
       const voice = (opts && opts.voice) || '';
-      let r = await post(text, voice);
-      // A voice the engine lists but cannot actually use is a 400 (the catalogue
-      // is shared across engines). Retry once on the engine's own default rather
-      // than dropping all the way back to the browser voice.
-      if (r.status === 400 && voice) r = await post(text, '');
-      if (!r.ok) throw new Error('tts http ' + r.status);
-      const blob = await r.blob();
-      if (!blob.size) throw new Error('tts empty audio');
-      if (my !== gen) return;                   // superseded while synthesizing
-      const url = URL.createObjectURL(blob);
-      const a = new Audio(url);
-      audio = a;
-      try {
-        await a.play();
-        await new Promise((resolve, reject) => {
-          a.onended = resolve;
-          a.onpause = resolve;                  // cancel(): finished, not failed
-          a.onerror = () => reject(new Error('tts playback failed'));
-        });
-      } finally {
-        URL.revokeObjectURL(url);
-        if (audio === a) audio = null;
+      // A 400 is the engine answering, not failing, and there are two answers worth
+      // retrying: a voice it lists but cannot use (the catalogue is shared across
+      // engines), and "I do not stream". Streaming first, this engine to the end.
+      let r;
+      for (const stream of [true, false]) {
+        r = await post(text, voice, stream);
+        if (r.status === 400 && voice) r = await post(text, '', stream);
+        if (r.status !== 400) break;
       }
+      if (!r.ok) throw new Error('tts http ' + r.status);
+      const rate = Number(r.headers.get('x-sample-rate'));
+      return rate ? playStream(r, rate, my) : playBlob(r, my);
     },
     cancel() { gen++; stop(); },
   };


### PR DESCRIPTION
The board waited out the whole synthesis before making a sound: ~31 s of silence
for a real chat message (voxcpm2, 1200 characters). It now plays the audio as it
arrives.

`remoteSpeaker.speak()` asks for `stream: true`, reads the body as it comes —
raw signed 16-bit LE mono PCM, rate from `x-sample-rate` — converts each chunk to
Float32 and schedules the buffers back to back on an `AudioContext`.

## Measured in Chrome, voxcpm2, 1200 characters

| | before | after |
|---|---|---|
| click to first audible sample | ~31 s | **92 ms** (median of 5: 125, 94, 91, 92, 91) |
| seams over a full message | — | 636 buffers, 101 s of audio, **0** discontinuous |
| `speak()` resolves | after synthesis | when the audio ends (101.2 s = 100 ms + 101.12 s) |
| stop mid-message | — | context closed and clock frozen in the same tick, with 8.7 s still queued |
| fish-s2-pro (cannot stream) | speaks | still speaks, via 400 → non-streaming retry |

## Three things that had to survive

- **An engine that does not stream.** Its 400 is an answer, not a failure: the
  same engine is asked again without streaming, and only then does the browser
  voice get a turn. Dropping to the browser because an engine is not a streamer
  would be the regression.
- **`cancel()` stops the sound now.** It cancels the reader and closes the
  context mid-stream rather than finishing the current buffer.
- **`speak()` settles exactly once** — resolving when the audio ends, rejecting
  when the stream dies halfway so `withFallback` speaks the rest. A blocked
  `AudioContext` is a rejection too: `resume()` on one waits for a gesture that
  may never come, so it is raced, not awaited.

## Two things found while measuring

**The proxy's flat 20 s cut** truncated a healthy stream — synthesis runs ~34 s
for those 1200 characters. It is now two deadlines, both on silence rather than
on the whole request: the first byte scales with the text (a non-streaming engine
sends nothing until synthesis ends), every byte after it gets the flat gap. This
is what #65 was opened for, folded in here.

**Cancel now reaches the GPU.** A listener who hung up left the engine
synthesizing for another half-minute, and voxcpm2's CUDA context dies when that
abandoned message overlaps the next request — the exact shape of the stop button
and of a superseding message. Five cancel-then-speak cycles killed the engine
before this; they run clean now.

`node --test test/*.test.js harness/test/*.test.js` — 389 pass. New: the
streaming speaker (seams, the non-streaming retry, a dying stream, cancel), both
deadlines, and the hang-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)