### PR TITLE
Only stream: cut the non-streaming playback path

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -133,22 +133,13 @@ const ARTIFACT_MIME = {
 
 const DEFAULT_PORT = 4780;
 // External TTS proxy timeouts — a hanging engine must never hang the board.
-// Speech has two deadlines, both on SILENCE rather than on the whole request:
-//  - the first byte, which an engine that does not stream only sends once the
-//    WHOLE message is synthesized (voxcpm2 measured 31 s for the 1200 characters
-//    the UI sends), so this one is budgeted per character with a floor and a cap;
-//  - every byte after it, which on a streaming engine arrives continuously — a
-//    flat cut there would truncate every long message mid-sentence.
+// The speech deadline is on SILENCE, never on the whole request: audio streams in
+// for as long as synthesis runs (~34 s for the 1200 characters the UI sends), so a
+// cap on the total would truncate every long message. This is the gap allowed
+// before the first chunk and between any two after it.
 const TTS_VOICES_MS = 3000;
 const TTS_SPEECH_MS = parseInt(process.env.BC_TTS_SPEECH_MS, 10) > 0
-  ? parseInt(process.env.BC_TTS_SPEECH_MS, 10) : 20000;      // floor, and the gap between chunks
-const TTS_SPEECH_MS_PER_CHAR = 60;
-const TTS_SPEECH_MS_MAX = parseInt(process.env.BC_TTS_SPEECH_MAX_MS, 10) > 0
-  ? parseInt(process.env.BC_TTS_SPEECH_MAX_MS, 10) : 180000;
-function firstByteMs(input) {
-  const n = typeof input === 'string' ? input.length : 0;
-  return Math.min(TTS_SPEECH_MS_MAX, Math.max(TTS_SPEECH_MS, n * TTS_SPEECH_MS_PER_CHAR));
-}
+  ? parseInt(process.env.BC_TTS_SPEECH_MS, 10) : 20000;
 
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
@@ -2205,8 +2196,8 @@ const server = http.createServer(async (req, res) => {
       const ac = new AbortController();
       let timer = null;
       let over = false;
-      const armFor = (ms) => { clearTimeout(timer); timer = setTimeout(() => ac.abort(), ms); };
-      armFor(firstByteMs(payload.input));       // nothing at all yet: the engine may be synthesizing
+      const arm = () => { clearTimeout(timer); timer = setTimeout(() => ac.abort(), TTS_SPEECH_MS); };
+      arm();
       // The listener hung up (stop button, or a newer message superseding this
       // one): stop the engine too. Synthesis nobody is waiting for is a GPU busy
       // for half a minute, and voxcpm2 dies outright when an abandoned message
@@ -2229,9 +2220,9 @@ const server = http.createServer(async (req, res) => {
       if (rate) head['x-sample-rate'] = rate;
       res.writeHead(r.status, head);
       if (!r.body) { over = true; clearTimeout(timer); return res.end(); }
-      // Audio is flowing: from here the deadline is the gap between chunks, so a
-      // stream may run as long as synthesis does and still be cut off if it dies.
-      try { for await (const chunk of r.body) { armFor(TTS_SPEECH_MS); res.write(chunk); } } catch (e) {}
+      // Every chunk resets the clock, so a stream may run as long as synthesis
+      // does and is still cut off when it goes quiet.
+      try { for await (const chunk of r.body) { arm(); res.write(chunk); } } catch (e) {}
       over = true;
       clearTimeout(timer);
       return res.end();

--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -1,8 +1,7 @@
 'use strict';
-// ui/js/tts/remote.js — the streaming speaker. Two rules carry the feature:
-// sound starts on the first chunk rather than at the end of synthesis, and a
-// 400 from an engine that cannot stream is an ANSWER — the same engine is asked
-// again without streaming, never dropped straight to the browser voice.
+// ui/js/tts/remote.js — the streaming speaker, and the only playback path there
+// is: sound starts on the first chunk rather than at the end of synthesis.
+// Anything that is not a stream rejects, and withFallback takes it from there.
 // Browser code (ES module), loaded via dynamic import; nothing here touches DOM.
 const test = require('node:test');
 const assert = require('node:assert');
@@ -83,26 +82,31 @@ test('a streaming engine: chunks play back to back, and speak() resolves at the 
   assert.ok(audio.closed(), 'the context is closed when the message is done');
 });
 
-test('an engine that cannot stream: the SAME engine is asked again, non-streaming', async () => {
-  fakeAudioContext();
-  let playedUrl = null;
-  global.URL = { createObjectURL: () => 'blob:x', revokeObjectURL: () => {} };
-  global.Audio = function (url) {
-    playedUrl = url;
-    setTimeout(() => this.onended && this.onended(), 1);
-    return this;
-  };
-  global.Audio.prototype.play = function () { return Promise.resolve(); };
-  const posts = fakeFetch((body) => (body.stream
-    ? new Response(JSON.stringify({ detail: 'this engine cannot stream' }), { status: 400 })
-    : new Response(Buffer.from('RIFFfake'), { status: 200, headers: { 'content-type': 'audio/wav' } })));
+test('a voice the engine cannot use: retried once on its own default, same engine', async () => {
+  const audio = fakeAudioContext();
+  const posts = fakeFetch((body) => (body.voice
+    ? new Response(JSON.stringify({ detail: 'unknown voice' }), { status: 400 })
+    : pcmResponse([0, 100, -100, 0], 8, 24000)));
   await remoteSpeaker({}).speak('olá', { voice: 'ana' });
   assert.deepEqual(posts, [
-    { input: 'olá', voice: 'ana', stream: true },   // asked to stream
-    { input: 'olá', stream: true },                 // maybe it was the voice — same engine, default voice
-    { input: 'olá', voice: 'ana' },                 // no: it does not stream. Still this engine.
-  ], 'a non-streaming engine must not fall through to the browser voice');
-  assert.equal(playedUrl, 'blob:x', 'and it actually spoke');
+    { input: 'olá', stream: true, voice: 'ana' },
+    { input: 'olá', stream: true },               // the catalogue is shared: try its default
+  ]);
+  assert.ok(audio.scheduled.length, 'and it spoke');
+});
+
+// An engine that cannot stream is deliberately NOT handled: it rejects, and
+// withFallback hands the message to the browser voice.
+test('an engine that cannot stream rejects instead of growing a second playback path', async () => {
+  fakeAudioContext();
+  fakeFetch(() => new Response(JSON.stringify({ detail: 'this engine cannot stream' }), { status: 400 }));
+  await assert.rejects(() => remoteSpeaker({}).speak('olá', {}));
+});
+
+test('a 200 without x-sample-rate is not audio we can play: reject, do not guess', async () => {
+  fakeAudioContext();
+  fakeFetch(() => new Response(Buffer.from('RIFFfake'), { status: 200, headers: { 'content-type': 'audio/wav' } }));
+  await assert.rejects(() => remoteSpeaker({}).speak('olá', {}), /did not stream/);
 });
 
 test('a stream that dies mid-message rejects, so the fallback speaks the rest', async () => {

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -148,40 +148,12 @@ test('an explicit voice wins and suppresses the default lang (they must agree)',
   } finally { await s.stop(); engine.close(); }
 });
 
-// ---------- the two speech deadlines ----------
-// Both are deadlines on SILENCE, not on the whole request. They are set low here
+// ---------- the speech deadline ----------
+// It is a deadline on SILENCE, not on the whole request, and it is set low here
 // (BC_TTS_SPEECH_MS) so the tests take seconds instead of the real half-minute.
-
-// A non-streaming engine sends nothing until the entire message is synthesized,
-// and synthesis scales with the text: voxcpm2 measured ~31 s for the 1200
-// characters the UI sends. A flat first-byte deadline cut every long message off
-// mid-synthesis and dropped the board to the browser voice.
-test('the first-byte deadline scales with the text: long input survives, short input does not', async () => {
-  const port = await freePort();
-  // Answers after 1.6 s — longer than the 1 s floor, shorter than 40 chars' budget.
-  const engine = http.createServer((req, res) => {
-    let body = '';
-    req.on('data', (c) => (body += c));
-    req.on('end', () => setTimeout(() => {
-      res.writeHead(200, { 'Content-Type': 'audio/wav' });
-      res.end(Buffer.from('RIFFfake'));
-    }, 1600));
-  });
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({
-    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }),
-    env: { BC_TTS_SPEECH_MS: '1000' },          // floor 1 s, + 60 ms per character
-  });
-  try {
-    const long = await s.api('POST', '/api/tts/speech', { input: 'x'.repeat(40) });  // 2.4 s budget
-    assert.equal(long.status, 200, 'a long message must outlive its own synthesis');
-    const short = await s.api('POST', '/api/tts/speech', { input: 'oi' });           // 1 s budget
-    assert.equal(short.status, 502, 'two characters taking 1.6 s is a sick engine');
-  } finally { await s.stop(); engine.close(); }
-});
-
-// A streaming engine emits for as long as it synthesizes — 34 s of chunks for
-// those same 1200 characters. The deadline there is the gap between chunks.
+//
+// A streaming engine emits for as long as it synthesizes — 34 s of chunks for the
+// 1200 characters the UI sends. Only a gap between chunks is a broken engine.
 test('a stream may run past the deadline while chunks keep arriving, and is cut when they stop', async () => {
   const port = await freePort();
   const engine = http.createServer((req, res) => {

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -1,36 +1,36 @@
 // Speaker over an external TTS engine, reached through the server's proxy
 // (/api/tts/voices, /api/tts/speech — the engines send no CORS headers).
 //
-// Speech is asked for STREAMING: the body is then raw signed 16-bit little-endian
-// mono PCM (no header, no framing) at the rate in `x-sample-rate`, and it plays as
-// it arrives instead of after the whole synthesis. An engine that cannot stream
-// says so with a 400 — that is an answer, so we ask the same engine again without
-// streaming before giving up on it.
+// Speech is always STREAMING: the body is raw signed 16-bit little-endian mono
+// PCM (no header, no framing) at the rate in `x-sample-rate`, and it plays as it
+// arrives instead of after the whole synthesis.
 //
-// Every failure rejects: network, non-200, empty body, a blocked or failed
-// play(). Nothing here knows what happens next — that is withFallback's job.
+// An engine that cannot stream is not handled here. It answers 400, speak()
+// rejects, and the browser voice takes the message — a worse voice, never
+// silence. Carrying a second playback path for an engine the board does not talk
+// to costs more than that trade.
+//
+// Every failure rejects: network, non-200, no stream, empty body, blocked audio.
+// Nothing here knows what happens next — that is withFallback's job.
 
 const LEAD = 0.05;                              // schedule this far ahead of "now"
 
 export function remoteSpeaker(cfg) {
   const lang = (cfg && cfg.lang) || '';
-  let audio = null;                             // <audio>, the non-streaming path
-  let ctx = null;                               // AudioContext, the streaming path
+  let ctx = null;                               // the AudioContext playing right now
   let reader = null;                            // the body being read right now
   let endStream = null;                         // resolves the stream awaiting its last buffer
   let gen = 0;                                  // bumped by cancel(); stale work stops quietly
 
   function stop() {
-    if (audio) { const a = audio; audio = null; try { a.pause(); a.src = ''; } catch (e) {} }
     if (reader) { const rd = reader; reader = null; try { rd.cancel(); } catch (e) {} }
     if (ctx) { const c = ctx; ctx = null; try { c.close(); } catch (e) {} }
     const done = endStream; endStream = null;
     if (done) done();                           // a cancelled message is finished, not failed
   }
-  function post(input, voice, stream) {
-    const body = { input };
+  function post(input, voice) {
+    const body = { input, stream: true };
     if (voice) body.voice = voice;
-    if (stream) body.stream = true;
     return fetch('/api/tts/speech', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
@@ -86,26 +86,6 @@ export function remoteSpeaker(cfg) {
     }
   }
 
-  async function playBlob(res, my) {
-    const blob = await res.blob();
-    if (!blob.size) throw new Error('tts empty audio');
-    if (my !== gen) return;                     // superseded while synthesizing
-    const url = URL.createObjectURL(blob);
-    const a = new Audio(url);
-    audio = a;
-    try {
-      await a.play();
-      await new Promise((resolve, reject) => {
-        a.onended = resolve;
-        a.onpause = resolve;                    // cancel(): finished, not failed
-        a.onerror = () => reject(new Error('tts playback failed'));
-      });
-    } finally {
-      URL.revokeObjectURL(url);
-      if (audio === a) audio = null;
-    }
-  }
-
   return {
     id: 'remote',
     key: 'bc-tts-voice',                        // deliberately NOT the browser key: a
@@ -122,18 +102,14 @@ export function remoteSpeaker(cfg) {
       const my = ++gen;
       stop();                                   // a new message supersedes the old one, sound and all
       const voice = (opts && opts.voice) || '';
-      // A 400 is the engine answering, not failing, and there are two answers worth
-      // retrying: a voice it lists but cannot use (the catalogue is shared across
-      // engines), and "I do not stream". Streaming first, this engine to the end.
-      let r;
-      for (const stream of [true, false]) {
-        r = await post(text, voice, stream);
-        if (r.status === 400 && voice) r = await post(text, '', stream);
-        if (r.status !== 400) break;
-      }
+      // A voice the engine lists but cannot use is a 400 (the catalogue is shared
+      // across engines): retry once on the engine's own default before giving up.
+      let r = await post(text, voice);
+      if (r.status === 400 && voice) r = await post(text, '');
       if (!r.ok) throw new Error('tts http ' + r.status);
       const rate = Number(r.headers.get('x-sample-rate'));
-      return rate ? playStream(r, rate, my) : playBlob(r, my);
+      if (!rate) throw new Error('tts did not stream');
+      return playStream(r, rate, my);
     },
     cancel() { gen++; stop(); },
   };


### PR DESCRIPTION
The board talks to voxcpm2, which streams. The second playback path was there for an
engine it does not use, and it was not free: a blob player, a 400-ladder that asked every
engine twice, and a per-character first-byte budget in the proxy that only made sense for
a response that arrives all at once.

**Out**: `playBlob`, the `<audio>` element, the `for (const stream of [true, false])`
ladder, and `firstByteMs`. `speak()` asks for `stream: true`, plays PCM, rejects on
anything else. The proxy keeps one deadline — silence, before the first chunk or between
any two — and still aborts upstream when the listener hangs up.

**Kept**: the voice retry. A voice the engine lists but cannot use is a 400 for a
different reason, and the catalogue is genuinely shared across engines.

An engine that cannot stream now rejects, and `withFallback` hands the message to the
browser voice: worse voice, never silence.

## Measured after the cut — Chrome, voxcpm2, 1188 characters

first audible sample **78 ms** · 469 buffers · 74.6 s of audio · **0** discontinuous seams

`node --test test/*.test.js harness/test/*.test.js` — 390 pass. −117 lines, +60.
