### PR TITLE
Show every voice the engine has, not just the workspace language

### DIFF
--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -126,3 +126,22 @@ test('cancel() mid-stream settles speak() instead of hanging on a dead context',
   await done;                                       // cancelled is finished, not failed
   assert.ok(stall, 'the body was still open when cancel() cut it');
 });
+
+// The catalogue is not filtered by the workspace language: voxcpm2 clones from
+// any reference clip, so an `en` voice speaking Portuguese is a choice with an
+// accent, not an error. Hiding two thirds of the catalogue was the bug.
+test('voices(): the whole catalogue comes back, whatever the workspace language', async () => {
+  global.fetch = () => Promise.resolve(new Response(JSON.stringify({ voices: [
+    { id: 'a', name: 'Ana', langs: ['pt'] },
+    { id: 'b', name: 'Bell', langs: ['en'] },
+    { id: 'c', name: 'Chen', langs: ['zh'] },
+    { id: 'd', name: 'Dee' },
+  ] }), { status: 200 }));
+  const list = await remoteSpeaker({ lang: 'pt' }).voices();
+  assert.deepEqual(list, [
+    { id: 'a', name: 'Ana', lang: 'pt' },
+    { id: 'b', name: 'Bell', lang: 'en' },
+    { id: 'c', name: 'Chen', lang: 'zh' },
+    { id: 'd', name: 'Dee', lang: 'pt' },     // no langs at all: labelled with the default
+  ]);
+});

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -110,11 +110,15 @@ export function remoteSpeaker(cfg) {
     id: 'remote',
     key: 'bc-tts-voice',                        // deliberately NOT the browser key: a
                                                 // browser voice name is never an engine id
+    // The whole catalogue, in the engine's own order. It used to be filtered to
+    // the workspace language, which hid 145 of 221 voices for one assumption that
+    // is not true of a cloning engine: a reference clip tagged `en` speaks
+    // Portuguese fine, it just brings an accent. Picking a voice is the captain's
+    // ear, not ours — the language is on the label so he can see what he is picking.
     voices() {
       return fetch('/api/tts/voices')
         .then((r) => r.json())
         .then((j) => ((j && j.voices) || [])
-          .filter((v) => !lang || !Array.isArray(v.langs) || v.langs.includes(lang))
           .map((v) => ({ id: v.id, name: v.name, lang: (v.langs || []).join(',') || lang })))
         .catch(() => []);
     },


### PR DESCRIPTION
The picker showed **76** of voxcpm2's **221** voices. `remoteSpeaker.voices()` filtered the
catalogue to `config.tts.lang`, and that filter assumes a voice belongs to a language — not
true of a cloning engine. An `en` reference clip reads Portuguese with an accent, not with an
error, and which accent is worth it is the captain's ear, not the code's.

The filter is gone. Nothing else had to change: `ui/js/voice.js` already ranks pt-BR first,
then pt, then en, then the rest, and prints the language on every label.

Verified in Chrome against the live engine: 221 voices reach the picker — en 114, pt 76,
zh 8, hi 6, es 5, it 4, fr 3, de 2, nl 2, ar 1.
