### PR TITLE
Speak the whole message, not its first 1200 characters

### DIFF
--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -92,12 +92,17 @@ function stripForSpeech(text) {
 let session = 0;
 let speaking = false;
 
+// The message is spoken whole. It used to be cut at 1200 characters, from when a
+// long message meant half a minute of silence before any sound — the cap bought
+// a shorter wait by throwing the rest of the answer away. Streaming removed the
+// wait, so the cap only truncated: a 2664-character reply stopped mid-sentence,
+// at 45% of itself. Stopping early is the bubble's job, not a slice().
 function speakPlain(plain) {
   const my = ++session;
   speaker.cancel();
   speaking = true;
   speakingBubble.show();
-  speaker.speak(plain.slice(0, 1200), { voice: pickedVoice() })
+  speaker.speak(plain, { voice: pickedVoice() })
     .catch(() => {})
     .then(() => { if (my !== session) return; speaking = false; speakingBubble.hide(); });
 }


### PR DESCRIPTION
The board still stopped speaking halfway through a long message. It was not the proxy and
not the engine: `ui/js/voice.js` cut every message at 1200 characters before handing it to
the speaker.

```js
speaker.speak(plain.slice(0, 1200), { voice: pickedVoice() })
```

That cap is from when a long message meant ~31 s of silence before any sound — it bought a
shorter wait by throwing the rest of the answer away. Streaming removed the wait, so all the
cap does now is truncate. A 2664-character reply stopped at 45% of itself, mid-sentence,
which is exactly what "it speaks half of it" looks like.

Measured through the live board with that same 2664-character text: **164.8 s of audio, HTTP
200, first byte at 0.32 s, nothing cut** — the whole message was always available; the UI was
throwing it away.

Stopping early is the floating bubble's job, not a `slice()`.

Verified in Chrome after the change: the card Speak button now sends all 2727 characters to
`/api/tts/speech` (it sent 1200 before).
