### PR TITLE
Board speaks straight to the engine: delete the TTS proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Per-workspace config lives in `.bridge-commander/config.json`:
 | `host` | `127.0.0.1` | bind address — see network exposure below |
 | `harness` | `claude` | default agent harness (`claude` \| `codex`) |
 | `voices` | — | UI text-to-speech voice filter |
-| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the browser's own voice; any engine failure falls back to it |
+| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the browser's own voice; any engine failure falls back to it. The **browser** calls the engine, so the url must be reachable from wherever the board is open and the engine must allow that origin (CORS) |
 
 Env knobs (set on the server process):
 

--- a/server/server.js
+++ b/server/server.js
@@ -137,10 +137,6 @@ const DEFAULT_PORT = 4780;
 // for as long as synthesis runs (~34 s for the 1200 characters the UI sends), so a
 // cap on the total would truncate every long message. This is the gap allowed
 // before the first chunk and between any two after it.
-const TTS_VOICES_MS = 3000;
-const TTS_SPEECH_MS = parseInt(process.env.BC_TTS_SPEECH_MS, 10) > 0
-  ? parseInt(process.env.BC_TTS_SPEECH_MS, 10) : 20000;
-
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
   try {
@@ -156,11 +152,11 @@ function userConfig() {
     const voices = c.voices.filter((v) => typeof v === 'string' && v.trim()).map((v) => v.trim());
     if (voices.length) out.voices = voices;
   }
-  // The engine URL is server-side only — the browser talks to /api/tts/* and
-  // never needs to reach the engine itself. No tts config => no tts key => the
-  // UI is byte-for-byte what it was before this feature existed.
+  // The browser IS the engine's client — url and defaults go to it whole. No tts
+  // config => no tts key => the UI is byte-for-byte what it was before this
+  // feature existed.
   const t = ttsConfig();
-  if (t) out.tts = { enabled: true, lang: t.lang, voice: t.voice };
+  if (t) out.tts = Object.assign({ enabled: true }, t);
   return out;
 }
 // External TTS engine (voxbench API), optional: config.json
@@ -2164,69 +2160,6 @@ const server = http.createServer(async (req, res) => {
     // ----- reads -----
     if (route === 'GET /api/board') return sendJson(res, 200, publicBoard(url.searchParams.get('user') || 'user'));
     if (route === 'GET /api/config') return sendJson(res, 200, userConfig());
-    // ----- external TTS proxy (the engines send no CORS headers) -----
-    // Both routes are short-timeout and never let a sick engine wedge the board:
-    // voices degrades to an empty list with a reason, speech answers an error the
-    // UI turns into a fallback to the browser's own voice.
-    if (route === 'GET /api/tts/voices') {
-      const t = ttsConfig();
-      if (!t) return sendJson(res, 200, { voices: [], error: 'tts not configured' });
-      try {
-        const r = await fetch(t.url + '/v1/voices', { signal: AbortSignal.timeout(TTS_VOICES_MS) });
-        if (!r.ok) return sendJson(res, 200, { voices: [], error: 'engine http ' + r.status });
-        const j = await r.json();
-        return sendJson(res, 200, { voices: Array.isArray(j && j.voices) ? j.voices : [] });
-      } catch (e) {
-        return sendJson(res, 200, { voices: [], error: String((e && e.message) || e) });
-      }
-    }
-    if (route === 'POST /api/tts/speech') {
-      const t = ttsConfig();
-      if (!t) return sendJson(res, 503, { error: 'tts not configured' });
-      let body;
-      try { body = JSON.parse((await readBody(req)) || '{}'); } catch (e) { return sendJson(res, 400, { error: 'bad json' }); }
-      if (!body || typeof body !== 'object' || Array.isArray(body)) return sendJson(res, 400, { error: 'bad body' });
-      // Body through, with the workspace defaults filled in where the caller said
-      // nothing. voice implies lang for the engine, so only send lang when there
-      // is no voice — sending both is a 400 when they disagree.
-      const payload = Object.assign({}, body);
-      if (!payload.voice && t.voice) payload.voice = t.voice;
-      if (!payload.voice && !payload.lang && t.lang) payload.lang = t.lang;
-      if (!payload.params && Object.keys(t.params).length) payload.params = t.params;
-      const ac = new AbortController();
-      let timer = null;
-      let over = false;
-      const arm = () => { clearTimeout(timer); timer = setTimeout(() => ac.abort(), TTS_SPEECH_MS); };
-      arm();
-      // The listener hung up (stop button, or a newer message superseding this
-      // one): stop the engine too. Synthesis nobody is waiting for is a GPU busy
-      // for half a minute, and voxcpm2 dies outright when an abandoned message
-      // overlaps the next one — which is exactly what cancel-then-speak does.
-      res.on('close', () => { if (!over) ac.abort(); });
-      let r;
-      try {
-        r = await fetch(t.url + '/v1/audio/speech', {
-          method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(payload),
-          signal: ac.signal,
-        });
-      } catch (e) {
-        clearTimeout(timer);
-        return sendJson(res, 502, { error: String((e && e.message) || e) });
-      }
-      const head = { 'Content-Type': r.headers.get('content-type') || 'application/octet-stream', 'Cache-Control': 'no-store' };
-      const rate = r.headers.get('x-sample-rate');
-      if (rate) head['x-sample-rate'] = rate;
-      res.writeHead(r.status, head);
-      if (!r.body) { over = true; clearTimeout(timer); return res.end(); }
-      // Every chunk resets the clock, so a stream may run as long as synthesis
-      // does and is still cut off when it goes quiet.
-      try { for await (const chunk of r.body) { arm(); res.write(chunk); } } catch (e) {}
-      over = true;
-      clearTimeout(timer);
-      return res.end();
-    }
     if (route === 'GET /api/status') {
       let pending = 0;
       for (const lt of queueIds()) pending += pendingItems(lt).length;

--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -55,22 +55,31 @@ function pcmResponse(samples, chunkBytes, rate) {
   return new Response(stream, { status: 200, headers: { 'x-sample-rate': String(rate) } });
 }
 
-// Records every /api/tts/speech body; `answer` decides what each one gets.
+// Records every speech request (url, body, signal); `answer` decides what each
+// one gets. The requests go to the ENGINE now — nothing here is a board route.
 function fakeFetch(answer) {
   const posts = [];
   global.fetch = (url, opts) => {
     const body = JSON.parse(opts.body);
-    posts.push(body);
-    return Promise.resolve(answer(body, posts.length));
+    posts.push(Object.assign({ url, signal: opts.signal }, body));
+    // A real fetch rejects when its signal fires, however far along it is.
+    return Promise.race([
+      answer(body, posts.length),
+      new Promise((_, rej) => opts.signal.addEventListener('abort',
+        () => rej(new DOMException('aborted', 'AbortError')))),
+    ]);
   };
   return posts;
 }
+// The body alone, for the request-shape assertions.
+const bodies = (posts) => posts.map(({ url, signal, ...b }) => b);
 
 test('a streaming engine: chunks play back to back, and speak() resolves at the end', async () => {
   const audio = fakeAudioContext();
   const posts = fakeFetch(() => pcmResponse([0, 16384, -16384, 32767, -32768, 0, 100, -100], 5, 24000));
-  await remoteSpeaker({}).speak('olá, capitão', {});
-  assert.deepEqual(posts, [{ input: 'olá, capitão', stream: true }], 'one request, streaming');
+  await remoteSpeaker({ url: 'http://127.0.0.1:8883' }).speak('olá, capitão', {});
+  assert.deepEqual(bodies(posts), [{ input: 'olá, capitão', stream: true }], 'one request, streaming');
+  assert.equal(posts[0].url, 'http://127.0.0.1:8883/v1/audio/speech', 'straight to the engine');
   const total = audio.scheduled.reduce((n, s) => n + s.buffer.length, 0);
   assert.equal(total, 8, 'every sample played, including the one split across a chunk boundary');
   // Back to back: each buffer starts exactly where the previous one ended.
@@ -87,12 +96,32 @@ test('a voice the engine cannot use: retried once on its own default, same engin
   const posts = fakeFetch((body) => (body.voice
     ? new Response(JSON.stringify({ detail: 'unknown voice' }), { status: 400 })
     : pcmResponse([0, 100, -100, 0], 8, 24000)));
-  await remoteSpeaker({}).speak('olá', { voice: 'ana' });
-  assert.deepEqual(posts, [
+  await remoteSpeaker({ lang: 'pt' }).speak('olá', { voice: 'ana' });
+  assert.deepEqual(bodies(posts), [
     { input: 'olá', stream: true, voice: 'ana' },
-    { input: 'olá', stream: true },               // the catalogue is shared: try its default
+    { input: 'olá', stream: true, lang: 'pt' },   // the catalogue is shared: try the language
   ]);
   assert.ok(audio.scheduled.length, 'and it spoke');
+});
+
+// What the proxy used to fill in on the way past. voice implies lang for the
+// engine, so they are never sent together.
+test('the workspace defaults are filled in here now', async () => {
+  fakeAudioContext();
+  const cfg = { url: 'http://e', lang: 'pt', voice: 'cfg-voice', params: { speed: 1.2 } };
+  let posts = fakeFetch(() => pcmResponse([0, 100], 4, 24000));
+  await remoteSpeaker(cfg).speak('olá', {});
+  assert.deepEqual(bodies(posts), [{ input: 'olá', stream: true, voice: 'cfg-voice', params: { speed: 1.2 } }]);
+
+  posts = fakeFetch(() => pcmResponse([0, 100], 4, 24000));
+  await remoteSpeaker(cfg).speak('olá', { voice: 'picked' });
+  assert.deepEqual(bodies(posts), [{ input: 'olá', stream: true, voice: 'picked', params: { speed: 1.2 } }],
+    'a picked voice wins over the workspace default');
+
+  posts = fakeFetch(() => pcmResponse([0, 100], 4, 24000));
+  await remoteSpeaker({ url: 'http://e', lang: 'pt' }).speak('olá', {});
+  assert.deepEqual(bodies(posts), [{ input: 'olá', stream: true, lang: 'pt' }],
+    'no voice anywhere: the language goes instead, never both');
 });
 
 // An engine that cannot stream is deliberately NOT handled: it rejects, and
@@ -117,31 +146,68 @@ test('a stream that dies mid-message rejects, so the fallback speaks the rest', 
   await assert.rejects(() => remoteSpeaker({}).speak('olá', {}), 'silence is not an outcome');
 });
 
-test('cancel() mid-stream settles speak() instead of hanging on a dead context', async () => {
+// The proxy used to abort the engine when the listener hung up. With the proxy
+// gone the browser's own AbortController is the only thing that can: an
+// abandoned synthesis keeps the GPU busy for another half-minute, and voxcpm2
+// dies for good when that overlaps the next request.
+test('cancel() mid-stream aborts the ENGINE request, and settles speak()', async () => {
   fakeAudioContext();
   let stall;
-  fakeFetch(() => new Response(new ReadableStream({
+  const posts = fakeFetch(() => new Response(new ReadableStream({
     start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); stall = c; },   // never closes on its own
   }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
-  const s = remoteSpeaker({});
+  const s = remoteSpeaker({ url: 'http://e' });
   const done = s.speak('olá', {});
   await new Promise((r) => setTimeout(r, 10));
+  assert.equal(posts[0].signal.aborted, false, 'still synthesizing');
   s.cancel();
   await done;                                       // cancelled is finished, not failed
   assert.ok(stall, 'the body was still open when cancel() cut it');
+  assert.ok(posts[0].signal.aborted, 'the abort has to reach the GPU, not just the speaker');
+});
+
+// Same reason, one beat earlier: cancelled before the first byte, while the
+// engine is still synthesizing and there is no body to read yet.
+test('cancel() before the first chunk aborts too, and does not wake the fallback', async () => {
+  fakeAudioContext();
+  const posts = fakeFetch(() => new Promise(() => {}));   // the engine never answers
+  const s = remoteSpeaker({ url: 'http://e' });
+  const done = s.speak('olá', {});
+  await new Promise((r) => setTimeout(r, 10));
+  s.cancel();
+  await done;                                       // must NOT reject: withFallback would speak it again
+  assert.ok(posts[0].signal.aborted);
+});
+
+// A superseding message is the same shape as the stop button, and the one that
+// kills voxcpm2 in practice: the old synthesis has to die before the new one runs.
+test('a new message aborts the one it supersedes', async () => {
+  fakeAudioContext();
+  const posts = fakeFetch((body) => (body.input === 'first'
+    ? new Promise(() => {})
+    : pcmResponse([0, 100], 4, 24000)));
+  const s = remoteSpeaker({ url: 'http://e' });
+  const first = s.speak('first', {});
+  await new Promise((r) => setTimeout(r, 10));
+  await s.speak('second', {});
+  await first;
+  assert.ok(posts[0].signal.aborted, 'the superseded request was cut at the engine');
+  assert.equal(posts[1].signal.aborted, false);
 });
 
 // The catalogue is not filtered by the workspace language: voxcpm2 clones from
 // any reference clip, so an `en` voice speaking Portuguese is a choice with an
 // accent, not an error. Hiding two thirds of the catalogue was the bug.
 test('voices(): the whole catalogue comes back, whatever the workspace language', async () => {
-  global.fetch = () => Promise.resolve(new Response(JSON.stringify({ voices: [
+  let asked = null;
+  global.fetch = (u) => (asked = u) && Promise.resolve(new Response(JSON.stringify({ voices: [
     { id: 'a', name: 'Ana', langs: ['pt'] },
     { id: 'b', name: 'Bell', langs: ['en'] },
     { id: 'c', name: 'Chen', langs: ['zh'] },
     { id: 'd', name: 'Dee' },
   ] }), { status: 200 }));
-  const list = await remoteSpeaker({ lang: 'pt' }).voices();
+  const list = await remoteSpeaker({ url: 'http://127.0.0.1:8883', lang: 'pt' }).voices();
+  assert.equal(asked, 'http://127.0.0.1:8883/v1/voices', 'the engine, not the board');
   assert.deepEqual(list, [
     { id: 'a', name: 'Ana', lang: 'pt' },
     { id: 'b', name: 'Bell', lang: 'en' },

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -1,15 +1,13 @@
 'use strict';
-// External TTS: config parsing (/api/config) and the proxy's failure paths.
-// The contract that matters here is "absent tts = today's behaviour" and "a sick
-// engine degrades, never 500s and never hangs" — the UI's fallback to the
-// browser voice is built on both.
+// External TTS: all the server does now is parse the tts block and hand it to the
+// browser through /api/config. The browser talks to the engine itself, so the
+// only contracts here are "absent tts = today's behaviour" and "a configured
+// engine reaches the client whole, url included".
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
-const http = require('node:http');
-const { startServer, freePort } = require('./helper');
+const { startServer } = require('./helper');
 
 // Seed <dir>/.bridge-commander/config.json before the server boots.
 function seedConfig(cfg) {
@@ -30,14 +28,21 @@ test('no tts in config: /api/config is unchanged', async () => {
   } finally { await s.stop(); }
 });
 
-test('tts in config: enabled, lang and voice are exposed, the url is not', async () => {
+// The url used to be withheld deliberately. That reverses: the browser is the
+// engine's client now, and a client without an address cannot call anyone.
+test('tts in config: the whole block reaches the browser, url and defaults included', async () => {
   const s = await startServer({
-    seed: seedConfig({ tts: { url: 'http://127.0.0.1:9/', lang: 'pt', voice: null, params: {} } }),
+    seed: seedConfig({ tts: { url: 'http://127.0.0.1:8883/', lang: 'pt', voice: null, params: { speed: 1.2 } } }),
   });
   try {
     const r = await s.api('GET', '/api/config');
-    assert.deepEqual(r.body.tts, { enabled: true, lang: 'pt', voice: null });
-    assert.ok(!('url' in r.body.tts), 'the engine url must not reach the browser');
+    assert.deepEqual(r.body.tts, {
+      enabled: true,
+      url: 'http://127.0.0.1:8883',              // trailing slash trimmed: the browser appends /v1/...
+      lang: 'pt',
+      voice: null,
+      params: { speed: 1.2 },
+    });
   } finally { await s.stop(); }
 });
 
@@ -51,167 +56,12 @@ test('malformed tts config reads as not configured', async () => {
   }
 });
 
-test('engine unreachable: voices degrade to an empty list, speech answers an error', async () => {
-  const dead = await freePort(); // nothing is listening there
-  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + dead, lang: 'pt' } }) });
+// The proxy is gone. Nothing should answer where it used to live — a route that
+// half-exists is worse than one that does not.
+test('the proxy routes are gone', async () => {
+  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:8883', lang: 'pt' } }) });
   try {
-    const v = await s.api('GET', '/api/tts/voices');
-    assert.equal(v.status, 200, 'never a 500 — the UI has to be able to fall back');
-    assert.deepEqual(v.body.voices, []);
-    assert.ok(v.body.error, 'the reason comes back with the empty list');
-
-    const sp = await s.api('POST', '/api/tts/speech', { input: 'olá' });
-    assert.equal(sp.status, 502);
-    assert.ok(sp.body.error);
+    assert.equal((await s.api('GET', '/api/tts/voices')).status, 404);
+    assert.equal((await s.api('POST', '/api/tts/speech', { input: 'olá' })).status, 404);
   } finally { await s.stop(); }
-});
-
-test('tts not configured: the proxy says so instead of pretending', async () => {
-  const s = await startServer();
-  try {
-    const v = await s.api('GET', '/api/tts/voices');
-    assert.equal(v.status, 200);
-    assert.deepEqual(v.body, { voices: [], error: 'tts not configured' });
-    const sp = await s.api('POST', '/api/tts/speech', { input: 'olá' });
-    assert.equal(sp.status, 503);
-  } finally { await s.stop(); }
-});
-
-test('engine 400: the status and body reach the browser verbatim', async () => {
-  const engine = http.createServer((req, res) => {
-    res.writeHead(400, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify({ detail: 'input must not be empty' }));
-  });
-  const port = await freePort();
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port } }) });
-  try {
-    const sp = await s.api('POST', '/api/tts/speech', { input: ' ' });
-    assert.equal(sp.status, 400);
-    assert.match(sp.body.detail, /empty/);
-  } finally { await s.stop(); engine.close(); }
-});
-
-test('engine 200: audio bytes and x-sample-rate stream through, defaults filled in', async () => {
-  let seen = null;
-  const engine = http.createServer((req, res) => {
-    let body = '';
-    req.on('data', (c) => (body += c));
-    req.on('end', () => {
-      seen = JSON.parse(body);
-      res.writeHead(200, { 'Content-Type': 'audio/wav', 'x-sample-rate': '22050' });
-      res.end(Buffer.from('RIFFfake'));
-    });
-  });
-  const port = await freePort();
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({
-    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt', params: { speed: 1.2 } } }),
-  });
-  try {
-    const res = await fetch(s.base + '/api/tts/speech', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ input: 'olá, capitão', stream: false }),
-    });
-    assert.equal(res.status, 200);
-    assert.equal(res.headers.get('content-type'), 'audio/wav');
-    assert.equal(res.headers.get('x-sample-rate'), '22050');
-    assert.equal(Buffer.from(await res.arrayBuffer()).toString(), 'RIFFfake');
-    assert.equal(seen.input, 'olá, capitão');
-    assert.equal(seen.lang, 'pt', 'the workspace default fills in');
-    assert.deepEqual(seen.params, { speed: 1.2 });
-    assert.equal(seen.stream, false, 'stream passes through untouched');
-  } finally { await s.stop(); engine.close(); }
-});
-
-test('an explicit voice wins and suppresses the default lang (they must agree)', async () => {
-  let seen = null;
-  const engine = http.createServer((req, res) => {
-    let body = '';
-    req.on('data', (c) => (body += c));
-    req.on('end', () => {
-      seen = JSON.parse(body);
-      res.writeHead(200, { 'Content-Type': 'audio/wav' });
-      res.end(Buffer.from('x'));
-    });
-  });
-  const port = await freePort();
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({
-    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt', voice: 'cfg-voice' } }),
-  });
-  try {
-    await s.api('POST', '/api/tts/speech', { input: 'olá', voice: 'pt_BR-faber-medium' });
-    assert.equal(seen.voice, 'pt_BR-faber-medium');
-    assert.ok(!('lang' in seen), 'no lang alongside an explicit voice');
-  } finally { await s.stop(); engine.close(); }
-});
-
-// ---------- the speech deadline ----------
-// It is a deadline on SILENCE, not on the whole request, and it is set low here
-// (BC_TTS_SPEECH_MS) so the tests take seconds instead of the real half-minute.
-//
-// A streaming engine emits for as long as it synthesizes — 34 s of chunks for the
-// 1200 characters the UI sends. Only a gap between chunks is a broken engine.
-test('a stream may run past the deadline while chunks keep arriving, and is cut when they stop', async () => {
-  const port = await freePort();
-  const engine = http.createServer((req, res) => {
-    let body = '';
-    req.on('data', (c) => (body += c));
-    req.on('end', () => {
-      const n = JSON.parse(body).input === 'stall' ? 1 : 8;   // 8 chunks, 400 ms apart = 3.2 s
-      res.writeHead(200, { 'Content-Type': 'audio/pcm', 'x-sample-rate': '24000' });
-      let i = 0;
-      const t = setInterval(() => {
-        res.write(Buffer.alloc(100, 7));
-        if (++i >= n) { clearInterval(t); if (n > 1) res.end(); }   // 'stall': never ends
-      }, 400);
-    });
-  });
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({
-    seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }),
-    env: { BC_TTS_SPEECH_MS: '1000' },          // 1 s of silence is the limit, per chunk
-  });
-  try {
-    const ok = await s.api('POST', '/api/tts/speech', { input: 'oi', stream: true });
-    assert.equal(ok.body.length, 800, '3.2 s of chunks under a 1 s per-chunk deadline: all of it');
-    const cut = await s.api('POST', '/api/tts/speech', { input: 'stall', stream: true });
-    assert.equal(cut.body.length, 100, 'a stream that goes silent is still cut off');
-  } finally { await s.stop(); engine.close(); }
-});
-
-// Cancel has to reach the GPU. A listener who hits stop (or a newer message that
-// supersedes this one) leaves the engine synthesizing for another half-minute
-// otherwise — and voxcpm2 dies outright when that abandoned message overlaps the
-// next request, which is exactly the shape of cancel-then-speak.
-test('the listener hangs up: the engine request is aborted, not left running', async () => {
-  const port = await freePort();
-  let closed = null;
-  const engine = http.createServer((req, res) => {
-    let body = '';
-    req.on('data', (c) => (body += c));
-    req.on('end', () => {
-      res.writeHead(200, { 'Content-Type': 'audio/pcm', 'x-sample-rate': '24000' });
-      let sent = 0;
-      const t = setInterval(() => { res.write(Buffer.alloc(100, 7)); sent++; }, 100);
-      res.on('close', () => { clearInterval(t); if (closed === null) closed = sent; });
-    });
-  });
-  await new Promise((r) => engine.listen(port, '127.0.0.1', r));
-  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:' + port, lang: 'pt' } }) });
-  try {
-    const ac = new AbortController();
-    const req = fetch(s.base + '/api/tts/speech', {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ input: 'olá', stream: true }), signal: ac.signal,
-    }).then((r) => r.arrayBuffer());
-    await new Promise((r) => setTimeout(r, 500));
-    ac.abort();                                 // the browser stops listening
-    await req.catch(() => {});
-    await new Promise((r) => setTimeout(r, 500));
-    assert.ok(closed !== null, 'the engine kept synthesizing for nobody');
-    assert.ok(closed < 12, 'it was cut where the listener left, not at the end (' + closed + ' chunks)');
-  } finally { await s.stop(); engine.close(); }
 });

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -1,5 +1,6 @@
-// Speaker over an external TTS engine, reached through the server's proxy
-// (/api/tts/voices, /api/tts/speech — the engines send no CORS headers).
+// Speaker over an external TTS engine, reached DIRECTLY: the engine answers CORS
+// now, so the browser is its client and the board is not in the path at all.
+// `cfg` is /api/config's tts block — {url, lang, voice, params}.
 //
 // Speech is always STREAMING: the body is raw signed 16-bit little-endian mono
 // PCM (no header, no framing) at the rate in `x-sample-rate`, and it plays as it
@@ -16,25 +17,39 @@
 const LEAD = 0.05;                              // schedule this far ahead of "now"
 
 export function remoteSpeaker(cfg) {
+  const url = (cfg && cfg.url) || '';
   const lang = (cfg && cfg.lang) || '';
+  const params = (cfg && cfg.params) || null;
   let ctx = null;                               // the AudioContext playing right now
   let reader = null;                            // the body being read right now
   let endStream = null;                         // resolves the stream awaiting its last buffer
   let gen = 0;                                  // bumped by cancel(); stale work stops quietly
+  let ac = null;                                // aborts the ENGINE, not just the playback
 
   function stop() {
+    // Abandoned synthesis keeps the GPU busy for another half-minute, and voxcpm2
+    // dies outright when it overlaps the next request — which is exactly the shape
+    // of the stop button and of a superseding message. The abort has to reach the
+    // engine, so it is the request that is cut, not only the reader.
+    if (ac) { const a = ac; ac = null; try { a.abort(); } catch (e) {} }
     if (reader) { const rd = reader; reader = null; try { rd.cancel(); } catch (e) {} }
     if (ctx) { const c = ctx; ctx = null; try { c.close(); } catch (e) {} }
     const done = endStream; endStream = null;
     if (done) done();                           // a cancelled message is finished, not failed
   }
+  // The workspace defaults fill in here now. voice implies lang for the engine, so
+  // only send lang when there is no voice — sending both is a 400 when they disagree.
   function post(input, voice) {
     const body = { input, stream: true };
     if (voice) body.voice = voice;
-    return fetch('/api/tts/speech', {
+    else if (lang) body.lang = lang;
+    if (params && Object.keys(params).length) body.params = params;
+    ac = new AbortController();
+    return fetch(url + '/v1/audio/speech', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
+      signal: ac.signal,
     });
   }
 
@@ -96,7 +111,7 @@ export function remoteSpeaker(cfg) {
     // Portuguese fine, it just brings an accent. Picking a voice is the captain's
     // ear, not ours — the language is on the label so he can see what he is picking.
     voices() {
-      return fetch('/api/tts/voices')
+      return fetch(url + '/v1/voices')
         .then((r) => r.json())
         .then((j) => ((j && j.voices) || [])
           .map((v) => ({ id: v.id, name: v.name, lang: (v.langs || []).join(',') || lang })))
@@ -105,15 +120,22 @@ export function remoteSpeaker(cfg) {
     async speak(text, opts) {
       const my = ++gen;
       stop();                                   // a new message supersedes the old one, sound and all
-      const voice = (opts && opts.voice) || '';
-      // A voice the engine lists but cannot use is a 400 (the catalogue is shared
-      // across engines): retry once on the engine's own default before giving up.
-      let r = await post(text, voice);
-      if (r.status === 400 && voice) r = await post(text, '');
-      if (!r.ok) throw new Error('tts http ' + r.status);
-      const rate = Number(r.headers.get('x-sample-rate'));
-      if (!rate) throw new Error('tts did not stream');
-      return playStream(r, rate, my);
+      const voice = (opts && opts.voice) || (cfg && cfg.voice) || '';
+      try {
+        // A voice the engine lists but cannot use is a 400 (the catalogue is shared
+        // across engines): retry once on the workspace language before giving up.
+        let r = await post(text, voice);
+        if (r.status === 400 && voice) r = await post(text, '');
+        if (!r.ok) throw new Error('tts http ' + r.status);
+        const rate = Number(r.headers.get('x-sample-rate'));
+        if (!rate) throw new Error('tts did not stream');
+        return await playStream(r, rate, my);
+      } catch (e) {
+        // Our own abort is not a failure — it must not reach withFallback, or the
+        // browser voice would speak the message the captain just stopped.
+        if (my !== gen) return;
+        throw e;
+      }
     },
     cancel() { gen++; stop(); },
   };


### PR DESCRIPTION
# Description

The board's `/api/tts/*` proxy only ever existed because the TTS engines sent no CORS headers; they do now (chatterbox_server #34), so it is one network hop and ~75 lines of timeout-and-abort plumbing between the captain and his voice for no reason — the browser talks to the engine directly, the way the bench page does. `/api/config` now hands over the `tts` block whole (the `url` it deliberately withheld before), `remote.js` fills in the workspace defaults the proxy used to fill in, and the browser's own `AbortController` takes over the job the proxy's abort was doing: cutting an abandoned synthesis at the engine, which is what keeps voxcpm2's CUDA context alive across cancel-then-speak.

Nothing assumes loopback — whatever `.bridge-commander/config.json` says is what the browser gets, so the tailnet address that lets the board work from the captain's phone keeps working.

## Type of change

- [x] Refactor (non-breaking; net −129 lines)

## How has this change been tested?

- Measured in a real browser (Chrome) against voxcpm2, not reasoned about:
  - 2310-character message: **58 ms** click → first audible sample (78–115 ms through the proxy).
  - Whole message plays: 844 buffers, 134.08 s of audio, and byte accounting on the same run shows **0 bytes lost** against the 12,871,680 the engine sent.
  - 5 cancel-then-speak cycles: every one settles as *cancelled*, never as a failure; `docker logs` shows each synthesis stopping at step ~48/598 where the listener left instead of running on, and the engine is `{"status":"ok"}` after with no restart.
  - Engine down: `speak()` rejects and the browser voice speaks the same text.
- `node --test test/*.test.js harness/test/*.test.js` — 388 pass.

## Any specific deployment considerations

- The engine must be reachable **from the browser** and must allow the board's origin. Loopback and `100.114.197.65:*` are both allowed today; a board opened on some other origin falls back to the browser voice rather than breaking.
