### PR TITLE
The board keeps speaking with the screen off

### DIFF
--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -14,15 +14,21 @@ test.before(async () => {
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'tts', 'remote.js')).href));
 });
 
-// A recording AudioContext: every scheduled buffer, with the time it starts.
-function fakeAudioContext() {
+// A recording AudioContext: every scheduled buffer, with the time it starts and
+// the node it was connected to. `withStream` is a browser that can route into a
+// media element; without it the context is an old one that cannot, which is the
+// fallback every other test in this file runs on.
+function fakeAudioContext(withStream) {
   const scheduled = [];
+  const nodes = {};
   let closed = false;
   class Ctx {
-    constructor(opts) { this.sampleRate = opts && opts.sampleRate; this.state = 'running'; this.destination = {}; }
+    constructor(opts) { this.sampleRate = opts && opts.sampleRate; this.state = 'running'; nodes.destination = this.destination = {}; }
     get currentTime() { return 0; }
     resume() { return Promise.resolve(); }
     close() { closed = true; return Promise.resolve(); }
+    createGain() { return (nodes.gain = { to: null, connect(n) { this.to = n; }, disconnect() { this.to = null; } }); }
+    createMediaStreamDestination() { return (nodes.msd = { stream: { id: 'live' } }); }
     createBuffer(ch, len, rate) {
       const data = new Float32Array(len);
       return { length: len, duration: len / rate, getChannelData: () => data };
@@ -30,15 +36,40 @@ function fakeAudioContext() {
     createBufferSource() {
       let ended = false, cb = null;
       return {
-        connect() {},
-        start(at) { scheduled.push({ at, buffer: this.buffer }); setTimeout(() => { ended = true; if (cb) cb(); }, 1); },
+        connect(n) { this.to = n; },
+        start(at) { scheduled.push({ at, buffer: this.buffer, to: this.to }); setTimeout(() => { ended = true; if (cb) cb(); }, 1); },
         set onended(f) { cb = f; if (ended) f(); },
         get onended() { return cb; },
       };
     }
   }
-  global.window = { AudioContext: Ctx };
-  return { scheduled, closed: () => closed };
+  if (!withStream) { delete Ctx.prototype.createGain; delete Ctx.prototype.createMediaStreamDestination; }
+  global.window = { AudioContext: Ctx, MediaMetadata: function (m) { Object.assign(this, m); } };
+  return { scheduled, nodes, closed: () => closed };
+}
+
+// The hidden <audio>. remote.js keeps ONE for the life of the page — iOS blesses
+// an element once and only inside a tap — so this is one element for the file.
+const sinkEl = {
+  plays: 0, paused: true, refuse: false, fed: [], _src: null,
+  get srcObject() { return this._src; },
+  set srcObject(v) { this._src = v; if (v) this.fed.push(v); },
+  play() { this.plays++; this.paused = false; return this.refuse ? Promise.reject(new Error('autoplay blocked')) : Promise.resolve(); },
+  pause() { this.paused = true; },
+};
+// A page with a DOM and a lock screen. Returns the mediaSession, recording every
+// title it was ever given — closeSink() clears it, so the last value is not it.
+function fakeDom() {
+  Object.assign(sinkEl, { plays: 0, paused: true, refuse: false, fed: [], _src: null });
+  global.document = { createElement: () => sinkEl, body: { appendChild() {} } };
+  const session = {
+    playbackState: 'none', handlers: {}, titles: [], _m: null,
+    get metadata() { return this._m; },
+    set metadata(m) { this._m = m; if (m) this.titles.push(m.title); },
+    setActionHandler(a, f) { this.handlers[a] = f; },
+  };
+  Object.defineProperty(global, 'navigator', { value: { mediaSession: session }, configurable: true });
+  return session;
 }
 
 // PCM body: signed 16-bit LE, handed over in `chunks` pieces (a chunk may end
@@ -193,6 +224,59 @@ test('a new message aborts the one it supersedes', async () => {
   await first;
   assert.ok(posts[0].signal.aborted, 'the superseded request was cut at the engine');
   assert.equal(posts[1].signal.aborted, false);
+});
+
+// ── the screen going off ──────────────────────────────────────────────────
+// Straight out of the AudioContext the sound dies the moment the phone locks:
+// the OS suspends the page and the context with it. Through a media element that
+// is playing it is real playback to the OS and keeps going.
+test('the sound leaves through a media element, and the lock screen says who is speaking', async () => {
+  const audio = fakeAudioContext(true);
+  const session = fakeDom();
+  fakeFetch(() => pcmResponse([0, 100, -100, 0, 50, -50], 4, 24000));
+  await remoteSpeaker({ url: 'http://e' }).speak('olá', { who: 'Ana' });
+  assert.ok(audio.scheduled.length, 'it spoke');
+  assert.deepEqual(sinkEl.fed, [audio.nodes.msd.stream], 'the element is fed the context’s own stream');
+  assert.ok(sinkEl.plays >= 1, 'and is actually playing — a paused element is not playback to the OS');
+  for (const s of audio.scheduled) assert.equal(s.to, audio.nodes.gain, 'no buffer goes straight to the speakers');
+  assert.equal(audio.nodes.gain.to, audio.nodes.msd, 'and the bus feeds the element');
+  assert.deepEqual(session.titles, ['Ana'], 'the lock screen names the lieutenant, not the message');
+  // Over means over: a dead player must not sit on the lock screen afterwards.
+  assert.equal(sinkEl.srcObject, null, 'the element was released');
+  assert.ok(sinkEl.paused);
+  assert.equal(session.playbackState, 'none');
+});
+
+// The lock-screen stop has to be the stop BUTTON — same path, same abort. One
+// that only mutes the page leaves the GPU synthesizing into the next message,
+// which is the overlap that kills voxcpm2's CUDA context.
+test('the lock screen stop aborts the ENGINE, not just this page’s speakers', async () => {
+  fakeAudioContext(true);
+  const session = fakeDom();
+  const posts = fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); },      // never closes on its own
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  const done = remoteSpeaker({ url: 'http://e' }).speak('olá', { who: 'Ana' });
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(posts[0].signal.aborted, false, 'still synthesizing');
+  session.handlers.stop();
+  await done;                                    // stopped is finished, not failed
+  assert.ok(posts[0].signal.aborted, 'the abort has to reach the GPU');
+  assert.ok(sinkEl.paused, 'and the lock screen player goes away with it');
+});
+
+// Everything is scheduled onto a bus rather than onto a node picked per chunk,
+// so a refusal moves what is ALREADY playing — not just what comes after it.
+test('an element that is not allowed to play falls back to the speakers, never to silence', async () => {
+  const audio = fakeAudioContext(true);
+  const session = fakeDom();
+  sinkEl.refuse = true;
+  fakeFetch(() => pcmResponse([0, 100, -100, 0, 50, -50], 4, 24000));
+  await remoteSpeaker({ url: 'http://e' }).speak('olá', { who: 'Ana' });
+  assert.ok(audio.scheduled.length, 'it still spoke');
+  assert.equal(audio.nodes.gain.to, audio.nodes.destination, 'the whole bus moved to the speakers');
+  for (const s of audio.scheduled) assert.equal(s.to, audio.nodes.gain, 'including buffers already scheduled');
+  assert.deepEqual(session.titles, [], 'nothing is playing on the lock screen, so nothing is announced');
 });
 
 // The catalogue is not filtered by the workspace language: voxcpm2 clones from

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -283,7 +283,7 @@ function wireSpeak(blocks, target) {
     const key = target + '|' + m.ts + '|' + m.author; // stable per message, for toggle-off
     btn.onclick = (e) => {
       e.stopPropagation();
-      const spoke = speakMessage(m.text, key);
+      const spoke = speakMessage(m.text, key, m.author);
       btn.classList.toggle('speaking', spoke);
     };
   });

--- a/ui/js/tts/index.js
+++ b/ui/js/tts/index.js
@@ -1,6 +1,10 @@
 // The speaker seam. One interface, two implementations, one composition:
 //
-//   { id, key, voices(), speak(text, {voice}), cancel() }
+//   { id, key, voices(), speak(text, {voice, who}), cancel() }
+//
+// `who` is the author of what is being spoken. The browser speaker ignores it;
+// the remote one shows it on the lock screen, because a phone with its screen
+// off is exactly where "who is talking" stops being obvious.
 //
 // voices() answers [{id, name, lang}] whatever is behind it — a browser voice's
 // name|lang pair and an engine voice's opaque id both come out as an `id`, so

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -4,7 +4,8 @@
 //
 // Speech is always STREAMING: the body is raw signed 16-bit little-endian mono
 // PCM (no header, no framing) at the rate in `x-sample-rate`, and it plays as it
-// arrives instead of after the whole synthesis.
+// arrives instead of after the whole synthesis. It leaves through a hidden
+// <audio> element so it survives the phone's screen going off — see sink() below.
 //
 // An engine that cannot stream is not handled here. It answers 400, speak()
 // rejects, and the browser voice takes the message — a worse voice, never
@@ -15,6 +16,37 @@
 // Nothing here knows what happens next — that is withFallback's job.
 
 const LEAD = 0.05;                              // schedule this far ahead of "now"
+
+// Sound leaves through a hidden <audio> element instead of straight out of the
+// AudioContext. The OS suspends a page — and its context with it — the moment
+// the screen goes off; a media element that is playing is real playback to the
+// OS and stays scheduled, which is why a plain audio file survives a lock and a
+// live stream does not. Same buffers, same seams, one extra hop.
+// Refused (autoplay blocked, or a browser without createMediaStreamDestination)
+// the buffers go to the speakers: today's behaviour, never silence.
+let el = null;              // ONE element for the page: iOS blesses it once, in a gesture
+let primed = false;
+function sink() {
+  if (el || typeof document === 'undefined') return el;
+  el = document.createElement('audio');
+  el.playsInline = true;
+  document.body.appendChild(el);
+  return el;
+}
+// iOS only allows play() inside the tap. speak() runs in the click that asked
+// for it, so the element is opened there — before the fetch, before any await.
+// Once is enough: the blessing sticks for the life of the element.
+function primeSink() {
+  const a = sink();
+  if (a && !primed) { primed = true; a.play().catch(() => {}); }
+}
+// Let the element go, so the lock screen stops showing a player for speech that
+// is over. Dropping srcObject is what ends it — pause alone leaves the sheet up.
+function closeSink() {
+  if (el) { el.pause(); el.srcObject = null; }
+  const s = typeof navigator !== 'undefined' && navigator.mediaSession;
+  if (s) { s.playbackState = 'none'; s.metadata = null; }
+}
 
 export function remoteSpeaker(cfg) {
   const url = (cfg && cfg.url) || '';
@@ -34,8 +66,21 @@ export function remoteSpeaker(cfg) {
     if (ac) { const a = ac; ac = null; try { a.abort(); } catch (e) {} }
     if (reader) { const rd = reader; reader = null; try { rd.cancel(); } catch (e) {} }
     if (ctx) { const c = ctx; ctx = null; try { c.close(); } catch (e) {} }
+    closeSink();
     const done = endStream; endStream = null;
     if (done) done();                           // a cancelled message is finished, not failed
+  }
+  function cancel() { gen++; stop(); }
+  // The lock screen: WHO is speaking, and a stop that IS the stop button — the
+  // same path, so the abort reaches the ENGINE. A stop that only mutes the page
+  // leaves the GPU synthesizing an abandoned message into the next one, which is
+  // the exact overlap that kills voxcpm2.
+  function announce(who) {
+    const s = typeof navigator !== 'undefined' && navigator.mediaSession;
+    if (!s) return;
+    if (window.MediaMetadata) s.metadata = new window.MediaMetadata({ title: who || 'Bridge Commander', artist: 'Bridge Commander' });
+    s.playbackState = 'playing';
+    for (const a of ['stop', 'pause']) { try { s.setActionHandler(a, cancel); } catch (e) {} }
   }
   // The workspace defaults fill in here now. voice implies lang for the engine, so
   // only send lang when there is no voice — sending both is a 400 when they disagree.
@@ -55,7 +100,7 @@ export function remoteSpeaker(cfg) {
 
   // Play raw PCM as it arrives, buffer scheduled back to back so the seams are
   // silent. Resolves when the last one has finished, rejects if the stream dies.
-  async function playStream(res, rate, my) {
+  async function playStream(res, rate, my, who) {
     const c = new (window.AudioContext || window.webkitAudioContext)({ sampleRate: rate });
     ctx = c;
     // Audio the page has not been allowed to make yet: resume() then waits for a
@@ -64,6 +109,19 @@ export function remoteSpeaker(cfg) {
     if (c.state !== 'running') {
       await Promise.race([c.resume().catch(() => {}), new Promise((r) => setTimeout(r, 250))]);
       if (c.state !== 'running') throw new Error('tts audio blocked');
+    }
+    // Everything is scheduled onto `bus`, not onto the destination, so a refused
+    // element reroutes what is ALREADY scheduled — no chunk is lost to the
+    // fallback. play() is not awaited: it must not stand between the first byte
+    // and the first sample.
+    let bus = c.destination;
+    const a = sink();
+    if (a && c.createMediaStreamDestination) {
+      const out = c.createMediaStreamDestination();
+      a.srcObject = out.stream;
+      bus = c.createGain();
+      bus.connect(out);
+      a.play().then(() => announce(who), () => { bus.disconnect(); bus.connect(c.destination); });
     }
     const rd = res.body.getReader();
     reader = rd;
@@ -85,7 +143,7 @@ export function remoteSpeaker(cfg) {
         for (let i = 0; i < pcm.length; i++) ch[i] = pcm[i] / 32768;
         const src = c.createBufferSource();
         src.buffer = buf;
-        src.connect(c.destination);
+        src.connect(bus);
         at = Math.max(at, c.currentTime + LEAD); // never schedule in the past (a slow engine underruns)
         src.start(at);
         at += buf.duration;
@@ -98,6 +156,9 @@ export function remoteSpeaker(cfg) {
       endStream = null;
       if (reader === rd) reader = null;
       if (ctx === c) { ctx = null; try { c.close(); } catch (e) {} }
+      // Spoken, or failed: let the element go. Superseded is NOT ours to close —
+      // stop() already did, and the message that replaced us owns it now.
+      if (my === gen) closeSink();
     }
   }
 
@@ -120,6 +181,7 @@ export function remoteSpeaker(cfg) {
     async speak(text, opts) {
       const my = ++gen;
       stop();                                   // a new message supersedes the old one, sound and all
+      primeSink();                              // still inside the click; the fetch below is the first await
       const voice = (opts && opts.voice) || (cfg && cfg.voice) || '';
       try {
         // A voice the engine lists but cannot use is a 400 (the catalogue is shared
@@ -129,7 +191,7 @@ export function remoteSpeaker(cfg) {
         if (!r.ok) throw new Error('tts http ' + r.status);
         const rate = Number(r.headers.get('x-sample-rate'));
         if (!rate) throw new Error('tts did not stream');
-        return await playStream(r, rate, my);
+        return await playStream(r, rate, my, opts && opts.who);
       } catch (e) {
         // Our own abort is not a failure — it must not reach withFallback, or the
         // browser voice would speak the message the captain just stopped.
@@ -137,6 +199,6 @@ export function remoteSpeaker(cfg) {
         throw e;
       }
     },
-    cancel() { gen++; stop(); },
+    cancel,
   };
 }

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -97,21 +97,24 @@ let speaking = false;
 // a shorter wait by throwing the rest of the answer away. Streaming removed the
 // wait, so the cap only truncated: a 2664-character reply stopped mid-sentence,
 // at 45% of itself. Stopping early is the bubble's job, not a slice().
-function speakPlain(plain) {
+function speakPlain(plain, who) {
   const my = ++session;
   speaker.cancel();
   speaking = true;
   speakingBubble.show();
-  speaker.speak(plain, { voice: pickedVoice() })
+  // `who` is the author, and it is not decoration: the remote speaker puts it on
+  // the phone's lock screen, which is where the captain sees WHO is talking to
+  // him while the screen is off. Nothing here knows that — it just carries it.
+  speaker.speak(plain, { voice: pickedVoice(), who })
     .catch(() => {})
     .then(() => { if (my !== session) return; speaking = false; speakingBubble.hide(); });
 }
-export function speak(text) {
+export function speak(text, who) {
   if (!voiceOn) return;
   const plain = stripForSpeech(text);
   if (!plain) return;
   manualSpeakingKey = null;                  // an auto-speak supersedes any manual toggle state
-  speakPlain(plain);
+  speakPlain(plain, who);
 }
 export function stopSpeaking() {
   session++;
@@ -151,14 +154,14 @@ const speakingBubble = (() => {
 // primer needed. Returns true if it spoke, false if there was nothing to say.
 // Clicking again while this message is speaking stops it (cheap toggle).
 let manualSpeakingKey = null;
-export function speakMessage(text, key) {
+export function speakMessage(text, key, who) {
   if (key != null && manualSpeakingKey === key && speaking) {
     manualSpeakingKey = null; stopSpeaking(); return false; // toggle off
   }
   const plain = stripForSpeech(text);
   if (!plain) return false;
   manualSpeakingKey = key != null ? key : null;
-  speakPlain(plain);
+  speakPlain(plain, who);
   return true;
 }
 function setVoiceOn(on) {
@@ -190,7 +193,7 @@ export function trackMessages(doc) {
     const k = scope + '|' + m.ts + '|' + m.author + '|' + m.text;
     if (!seenMsgs.has(k)) {
       seenMsgs.add(k);
-      if (!firstLoad && m.author !== 'user') speak(m.text);
+      if (!firstLoad && m.author !== 'user') speak(m.text, m.author);
     }
   }
   firstLoad = false;


### PR DESCRIPTION
# Description

The captain reads the board from his phone, and the moment the screen goes off the board goes quiet mid-sentence — the OS suspends the page and the AudioContext the streamed speech is scheduled into. Streamed speech now leaves through a hidden `<audio>` element, which the OS treats as real playback and keeps running, with the lieutenant's name and a working stop on the lock screen. Same technique proven on the voxbench page (chatterbox_server `becd4c8`).

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added: the sink is used, the lock-screen stop aborts the engine, and a refused element falls back to the speakers.
- `node --test test/*.test.js harness/test/*.test.js` — 391 pass.
- Real Chrome against live voxcpm2 on 8883:
  - **Time to first audible sample, median of 3 on a 57 s message: 96 ms before, 97 ms after.** No regression.
  - 360 buffers, 57.28 s of audio, worst seam **0 ms** — contiguous end to end.
  - The element really consumes the stream (`currentTime` advances 0.5 → 3.0 in step with the clock), and is released when speech ends: paused, `srcObject` null, `playbackState` `none`.
  - Five cancel-then-speak cycles → engine `/health` still `{"status":"ok","engine":"voxcpm2"}`.
  - Engine unreachable → `speak()` still rejects, so the browser voice takes the message.
- Not covered here: headless Chrome never flips `visibilityState`, so the desktop hidden-tab check could not exercise the suspend path. The closest available run — the tab backgrounded behind another selected tab — played 51 s uninterrupted with the audio clock tracking wall clock 1:1.

## What the captain should press

On his phone, over the tailnet: turn voice on, tap **🔊** on any lieutenant message, and lock the screen while it is talking. It should keep speaking, and the lock screen should show the lieutenant's name with a stop control — pressing that stop must silence it *and* free the GPU (the next message should start normally, not stall).

## Any specific deployment considerations

- Board UI only; no server change. Needs a board server restart to serve the new `ui/js`.
