### PR TITLE
Board lock screen: pause, play and stop are three different things

### DIFF
--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -21,12 +21,14 @@ test.before(async () => {
 function fakeAudioContext(withStream) {
   const scheduled = [];
   const nodes = {};
+  const ctxs = [];
   let closed = false;
   class Ctx {
-    constructor(opts) { this.sampleRate = opts && opts.sampleRate; this.state = 'running'; nodes.destination = this.destination = {}; }
+    constructor(opts) { this.sampleRate = opts && opts.sampleRate; this.state = 'running'; nodes.destination = this.destination = {}; ctxs.push(this); }
     get currentTime() { return 0; }
-    resume() { return Promise.resolve(); }
-    close() { closed = true; return Promise.resolve(); }
+    resume() { this.state = 'running'; return Promise.resolve(); }
+    suspend() { this.state = 'suspended'; this.suspends = (this.suspends || 0) + 1; return Promise.resolve(); }
+    close() { closed = true; this.state = 'closed'; return Promise.resolve(); }
     createGain() { return (nodes.gain = { to: null, connect(n) { this.to = n; }, disconnect() { this.to = null; } }); }
     createMediaStreamDestination() { return (nodes.msd = { stream: { id: 'live' } }); }
     createBuffer(ch, len, rate) {
@@ -45,7 +47,7 @@ function fakeAudioContext(withStream) {
   }
   if (!withStream) { delete Ctx.prototype.createGain; delete Ctx.prototype.createMediaStreamDestination; }
   global.window = { AudioContext: Ctx, MediaMetadata: function (m) { Object.assign(this, m); } };
-  return { scheduled, nodes, closed: () => closed };
+  return { scheduled, nodes, ctxs, closed: () => closed };
 }
 
 // The hidden <audio>. remote.js keeps ONE for the life of the page — iOS blesses
@@ -263,6 +265,87 @@ test('the lock screen stop aborts the ENGINE, not just this page’s speakers', 
   await done;                                    // stopped is finished, not failed
   assert.ok(posts[0].signal.aborted, 'the abort has to reach the GPU');
   assert.ok(sinkEl.paused, 'and the lock screen player goes away with it');
+});
+
+// Pause used to be wired to the same cancel() as stop: it aborted the request,
+// closed the context and dropped the buffers, so play never brought the message
+// back. Pause suspends instead — and it has to stop BOTH halves, element first:
+// a suspended context with the element still pulling on the stream chews the
+// last fragment over and over, which is a syllable repeating mid-word.
+test('the lock screen pause freezes the message, and play brings it back', async () => {
+  const audio = fakeAudioContext(true);
+  const session = fakeDom();
+  let feed;
+  const posts = fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); feed = c; },   // more to come
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  const done = remoteSpeaker({ url: 'http://e' }).speak('olá', { who: 'Ana' });
+  await new Promise((r) => setTimeout(r, 10));
+  const ctx = audio.ctxs[0];
+  assert.equal(session.playbackState, 'playing');
+
+  session.handlers.pause();
+  assert.ok(sinkEl.paused, 'the element stops pulling — otherwise it repeats the last fragment');
+  assert.equal(ctx.state, 'suspended', 'and the clock freezes');
+  assert.equal(session.playbackState, 'paused', 'or the lock screen offers the wrong button');
+  assert.equal(posts[0].signal.aborted, false, 'pause is NOT destructive: the engine keeps synthesizing');
+
+  // Chunks arriving during the pause queue against a stopped clock: nothing lost.
+  const queued = audio.scheduled.length;
+  feed.enqueue(new Uint8Array([0, 2, 0, 2]));
+  await new Promise((r) => setTimeout(r, 10));
+  assert.ok(audio.scheduled.length > queued, 'what arrived while paused was queued, not dropped');
+
+  const plays = sinkEl.plays;
+  session.handlers.play();
+  assert.equal(ctx.state, 'running', 'the clock first');
+  assert.ok(sinkEl.plays > plays, 'then the element');
+  assert.equal(session.playbackState, 'playing');
+
+  session.handlers.stop();
+  await done;
+  assert.ok(posts[0].signal.aborted, 'stop stays the only destructive verb, and reaches the GPU');
+});
+
+// Stop while paused has to abort too — a frozen message left synthesizing on the
+// GPU is exactly the abandoned synthesis that kills voxcpm2 on the next request.
+test('stop while paused aborts the engine as well', async () => {
+  fakeAudioContext(true);
+  const session = fakeDom();
+  const posts = fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); },
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  const done = remoteSpeaker({ url: 'http://e' }).speak('olá', { who: 'Ana' });
+  await new Promise((r) => setTimeout(r, 10));
+  session.handlers.pause();
+  session.handlers.stop();
+  await done;
+  assert.ok(posts[0].signal.aborted);
+  assert.equal(session.playbackState, 'none', 'and the lock screen player goes away');
+});
+
+// A paused message must not survive the one that replaces it: the captain hears
+// the new message, never a resumed middle of the old one.
+test('a new message while paused supersedes it and speaks', async () => {
+  const audio = fakeAudioContext(true);
+  const session = fakeDom();
+  const posts = fakeFetch((body) => (body.input === 'first'
+    ? new Response(new ReadableStream({ start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); } }),
+      { status: 200, headers: { 'x-sample-rate': '24000' } })
+    : pcmResponse([0, 100, -100, 0], 4, 24000)));
+  const s = remoteSpeaker({ url: 'http://e' });
+  const first = s.speak('first', { who: 'Ana' });
+  await new Promise((r) => setTimeout(r, 10));
+  session.handlers.pause();
+  const before = audio.scheduled.length;
+
+  await s.speak('second', { who: 'Bea' });
+  await first;
+  assert.ok(posts[0].signal.aborted, 'the paused one was cut at the engine');
+  assert.ok(audio.scheduled.length > before, 'and the new one actually played');
+  assert.notEqual(audio.ctxs[1], audio.ctxs[0], 'on its own context — never resumed into the frozen one');
+  assert.ok(!audio.ctxs[1].suspends, 'and that one was never frozen');
+  assert.deepEqual(session.titles, ['Ana', 'Bea']);
 });
 
 // Everything is scheduled onto a bus rather than onto a node picked per chunk,

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -44,8 +44,11 @@ function primeSink() {
 // is over. Dropping srcObject is what ends it — pause alone leaves the sheet up.
 function closeSink() {
   if (el) { el.pause(); el.srcObject = null; }
-  const s = typeof navigator !== 'undefined' && navigator.mediaSession;
+  const s = session();
   if (s) { s.playbackState = 'none'; s.metadata = null; }
+}
+function session() {
+  return (typeof navigator !== 'undefined' && navigator.mediaSession) || null;
 }
 
 export function remoteSpeaker(cfg) {
@@ -71,16 +74,40 @@ export function remoteSpeaker(cfg) {
     if (done) done();                           // a cancelled message is finished, not failed
   }
   function cancel() { gen++; stop(); }
-  // The lock screen: WHO is speaking, and a stop that IS the stop button — the
-  // same path, so the abort reaches the ENGINE. A stop that only mutes the page
-  // leaves the GPU synthesizing an abandoned message into the next one, which is
-  // the exact overlap that kills voxcpm2.
+  // BOTH halves stop, element first. Suspending the context alone freezes the
+  // buffers but leaves the element pulling on a MediaStream with nothing new in
+  // it, and it chews the last fragment over and over — a syllable repeating
+  // mid-word on the lock screen. Chunks still arriving queue against a stopped
+  // clock, so nothing is lost and nothing plays.
+  function pauseLive() {
+    if (el) el.pause();
+    if (ctx) { try { ctx.suspend(); } catch (e) {} }
+    playbackState('paused');
+  }
+  // Back in the opposite order, inside out: the clock first, then the element.
+  function resumeLive() {
+    if (ctx) { try { ctx.resume(); } catch (e) {} }
+    if (el) { const p = el.play(); if (p && p.catch) p.catch(() => {}); }
+    playbackState('playing');
+  }
+  function playbackState(v) {
+    const s = session();
+    if (s) s.playbackState = v;
+  }
+  // The lock screen: WHO is speaking, and three different verbs for it. pause
+  // and play are reversible; stop is the only destructive one and IS the stop
+  // button — the same path, so the abort reaches the ENGINE. A stop that only
+  // mutes the page leaves the GPU synthesizing an abandoned message into the
+  // next one, which is the exact overlap that kills voxcpm2.
   function announce(who) {
-    const s = typeof navigator !== 'undefined' && navigator.mediaSession;
+    const s = session();
     if (!s) return;
     if (window.MediaMetadata) s.metadata = new window.MediaMetadata({ title: who || 'Bridge Commander', artist: 'Bridge Commander' });
     s.playbackState = 'playing';
-    for (const a of ['stop', 'pause']) { try { s.setActionHandler(a, cancel); } catch (e) {} }
+    const on = (a, fn) => { try { s.setActionHandler(a, fn); } catch (e) {} };
+    on('pause', pauseLive);
+    on('play', resumeLive);
+    on('stop', cancel);
   }
   // The workspace defaults fill in here now. voice implies lang for the engine, so
   // only send lang when there is no voice — sending both is a 400 when they disagree.


### PR DESCRIPTION
# Description

The board's lock-screen pause was wired to the same `cancel()` as stop, so pausing a message on the phone destroyed it — the captain's play never brought it back. Pause and play are now reversible; stop stays the only destructive verb, because its abort has to reach the engine.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added (pause/play/stop, stop-while-paused, supersede-while-paused).
- Chrome against voxcpm2 on 8883: element clock frozen at 3.02 s across a 3031 ms pause (drift 0), resumed 0.03 s later and advanced 1:1 to the end. Suspending the context alone leaves the element advancing 2.000 s per 2 s — the repeated syllable this pauses away. Both stops froze the engine's synthesis (unchanged 8 s later) and `/health` stayed ok. Time to first audible sample 47/38/38 ms.

## Any specific deployment considerations

- Board server restart to pick up `ui/js/tts/remote.js`.
