### PR TITLE
The board speaks through a transport, not a bubble

### DIFF
--- a/test/tts-remote.test.js
+++ b/test/tts-remote.test.js
@@ -307,6 +307,36 @@ test('the lock screen pause freezes the message, and play brings it back', async
   assert.ok(posts[0].signal.aborted, 'stop stays the only destructive verb, and reaches the GPU');
 });
 
+// The board's own transport presses the SAME two verbs the lock screen does —
+// they are on the speaker interface, not private to the media-session handlers.
+// That is what makes a visible player possible, and a visible player is what
+// keeps WebKit answering the lock screen at all.
+test('the page transport pauses and resumes the same message the lock screen does', async () => {
+  const audio = fakeAudioContext(true);
+  const session = fakeDom();
+  const posts = fakeFetch(() => new Response(new ReadableStream({
+    start(c) { c.enqueue(new Uint8Array([0, 1, 0, 1])); },        // never closes on its own
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+  const s = remoteSpeaker({ url: 'http://e' });
+  const done = s.speak('olá', { who: 'Ana' });
+  await new Promise((r) => setTimeout(r, 10));
+  const ctx = audio.ctxs[0];
+
+  s.pause();
+  assert.ok(sinkEl.paused);
+  assert.equal(ctx.state, 'suspended');
+  assert.equal(posts[0].signal.aborted, false, 'the page pause is no more destructive than the lock screen one');
+
+  const plays = sinkEl.plays;
+  s.resume();
+  assert.equal(ctx.state, 'running');
+  assert.ok(sinkEl.plays > plays);
+
+  s.cancel();
+  await done;
+  assert.ok(posts[0].signal.aborted, 'and the transport stop is still the cancel that reaches the engine');
+});
+
 // Stop while paused has to abort too — a frozen message left synthesizing on the
 // GPU is exactly the abandoned synthesis that kills voxcpm2 on the next request.
 test('stop while paused aborts the engine as well', async () => {

--- a/test/tts-speaker.test.js
+++ b/test/tts-speaker.test.js
@@ -16,7 +16,7 @@ test.before(async () => {
 
 // A recording speaker: `fail` makes speak() reject the way a dead engine does.
 function fake(id, fail) {
-  const calls = { speak: [], cancel: 0, voices: 0 };
+  const calls = { speak: [], cancel: 0, voices: 0, pause: 0, resume: 0 };
   return {
     calls,
     id,
@@ -27,6 +27,8 @@ function fake(id, fail) {
       return fail ? Promise.reject(new Error(id + ' is down')) : Promise.resolve();
     },
     cancel() { calls.cancel++; },
+    pause() { calls.pause++; },
+    resume() { calls.resume++; },
   };
 }
 
@@ -66,6 +68,17 @@ test('the picker follows the primary; cancel reaches both', async () => {
   s.cancel();
   assert.equal(a.calls.cancel, 1);
   assert.equal(b.calls.cancel, 1);
+});
+
+// The board's transport presses these, and so does the phone's lock screen. Which
+// of the two speakers is actually mid-utterance is not knowable from up here, so
+// both hear it — same rule as cancel.
+test('pause and resume reach both speakers', () => {
+  const a = fake('remote'), b = fake('browser');
+  const s = withFallback(a, b);
+  s.pause(); s.resume();
+  assert.deepEqual([a.calls.pause, a.calls.resume], [1, 1]);
+  assert.deepEqual([b.calls.pause, b.calls.resume], [1, 1]);
 });
 
 test('speakerFor: no tts config is the browser speaker, plain', () => {

--- a/ui/app.css
+++ b/ui/app.css
@@ -1045,26 +1045,23 @@ a.a-uri { color: var(--accent); }
 #av-download { flex: none; color: var(--dim); font-size: 15px; padding: 2px 6px; text-decoration: none; }
 #av-download:hover { color: var(--accent); }
 
-/* ---------- TTS speaking indicator ---------- */
+/* ---------- TTS transport ---------- */
+/* Up while the board speaks: who is talking, and three buttons for it. Plain on
+   purpose — a player WebKit can see is what keeps the lock screen answering. */
 #tts-bubble {
   position: fixed; right: 16px; bottom: 16px; z-index: 88;
-  display: inline-flex; align-items: center; gap: 9px; padding: 8px 14px;
+  display: inline-flex; align-items: center; gap: 7px; padding: 7px 8px 7px 14px;
   border-radius: 999px; background: var(--panel2); border: 1px solid var(--accent2);
   color: var(--accent); box-shadow: var(--shadow); font-size: 12px; font-weight: 600;
-  cursor: pointer; animation: pop-in .16s ease-out; transition: background .15s, color .15s;
+  animation: pop-in .16s ease-out;
 }
-#tts-bubble:hover { background: var(--panel3); color: var(--text); }
-/* sound-wave bars — gentle staggered pulse, drawn in the current text color */
-#tts-bubble .wave { display: inline-flex; align-items: center; gap: 2px; height: 15px; }
-#tts-bubble .wave i {
-  width: 3px; height: 100%; border-radius: 2px; background: currentColor;
-  transform: scaleY(.35); animation: tts-wave 1s ease-in-out infinite;
+#tts-bubble .lbl { max-width: 34vw; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#tts-bubble button {
+  width: 30px; height: 30px; border-radius: 50%; padding: 0; cursor: pointer;
+  background: var(--panel); border: 1px solid var(--line2); color: var(--text);
+  font-size: 11px; line-height: 1;
 }
-#tts-bubble .wave i:nth-child(2) { animation-delay: .15s; }
-#tts-bubble .wave i:nth-child(3) { animation-delay: .3s; }
-#tts-bubble .wave i:nth-child(4) { animation-delay: .45s; }
-@keyframes tts-wave { 0%, 100% { transform: scaleY(.35); opacity: .6; } 50% { transform: scaleY(1); opacity: 1; } }
-@media (prefers-reduced-motion: reduce) { #tts-bubble .wave i { animation: none; transform: scaleY(.7); } }
+#tts-bubble button:hover { border-color: var(--accent); color: var(--accent); }
 
 /* ---------- mobile ---------- */
 @media (max-width: 760px) {

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -81,7 +81,7 @@ document.addEventListener('click', (e) => {
     t.closest('#label-picker') ||
     t.closest('#av-overlay') ||               // artifact viewer sits above the detail
     t.closest('#mmd-overlay') ||              // fullscreen mermaid diagram overlay
-    t.closest('#tts-bubble') ||               // floating stop-speaking control
+    t.closest('#tts-bubble') ||               // floating speech transport (and its buttons)
     t.closest('[data-label-add]')
   )) return;
   if (editingTitle) commitTitleEdit();        // save the in-progress rename first

--- a/ui/js/tts/browser.js
+++ b/ui/js/tts/browser.js
@@ -31,12 +31,14 @@ export function browserSpeaker() {
   let retried = false;
   let keepalive = null;
   let settle = null;     // resolve of the in-flight speak()
+  let paused = false;    // the transport asked for silence — the keepalive must respect it
 
   function stopKeepalive() { if (keepalive) { clearInterval(keepalive); keepalive = null; } }
   function startKeepalive() {
     stopKeepalive();
     keepalive = setInterval(() => {
       if (!window.speechSynthesis) return stopKeepalive();
+      if (paused) return;                      // else the anti-idle resume() would undo the pause
       if (speechSynthesis.speaking || speechSynthesis.pending) speechSynthesis.resume();
       else stopKeepalive();
     }, 7000);
@@ -98,6 +100,7 @@ export function browserSpeaker() {
         current = opts || {};
         queue = chunkText(text);
         retried = false;
+        paused = false;                        // a new message always starts speaking
         settle = resolve;
         startKeepalive();
         // Only do the cancel-then-wait dance when something is actually in
@@ -109,10 +112,20 @@ export function browserSpeaker() {
       });
     },
     cancel() {
-      gen++; queue = []; stopKeepalive();
+      gen++; queue = []; paused = false; stopKeepalive();
       try { if (window.speechSynthesis) speechSynthesis.cancel(); } catch (e) {}
       const done = settle; settle = null;
       if (done) done();                        // a cancelled message is finished, not failed
+    },
+    // The engine's own pause/resume. Reversible, unlike cancel(): the queue and
+    // the utterance mid-flight are untouched, so resume picks the word back up.
+    pause() {
+      paused = true;
+      try { if (window.speechSynthesis) speechSynthesis.pause(); } catch (e) {}
+    },
+    resume() {
+      paused = false;
+      try { if (window.speechSynthesis) speechSynthesis.resume(); } catch (e) {}
     },
   };
 }

--- a/ui/js/tts/index.js
+++ b/ui/js/tts/index.js
@@ -1,6 +1,11 @@
 // The speaker seam. One interface, two implementations, one composition:
 //
-//   { id, key, voices(), speak(text, {voice, who}), cancel() }
+//   { id, key, voices(), speak(text, {voice, who}), cancel(), pause(), resume() }
+//
+// cancel() is destructive and ends the message; pause()/resume() are the
+// reversible pair behind the board's transport (and the phone's lock screen),
+// which is why they are part of the interface and not one speaker's private
+// detail.
 //
 // `who` is the author of what is being spoken. The browser speaker ignores it;
 // the remote one shows it on the lock screen, because a phone with its screen
@@ -27,6 +32,10 @@ export function withFallback(primary, secondary) {
     voices: () => primary.voices(),
     speak: (text, opts) => primary.speak(text, opts).catch(() => secondary.speak(text, {})),
     cancel: () => { primary.cancel(); secondary.cancel(); },
+    // Both, like cancel: which of the two is actually speaking is not knowable
+    // from here, and asking an idle speaker to pause costs nothing.
+    pause: () => { primary.pause(); secondary.pause(); },
+    resume: () => { primary.resume(); secondary.resume(); },
   };
 }
 

--- a/ui/js/tts/remote.js
+++ b/ui/js/tts/remote.js
@@ -227,5 +227,9 @@ export function remoteSpeaker(cfg) {
       }
     },
     cancel,
+    // The same two verbs the lock screen presses, now reachable from the page's
+    // own transport — one pause, one resume, whoever asks.
+    pause: pauseLive,
+    resume: resumeLive,
   };
 }

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -111,7 +111,7 @@ function speakPlain(plain, who) {
   const my = ++session;
   speaker.cancel();
   speaking = true;
-  speakingBubble.show();
+  speakingBubble.show(who);
   // `who` is the author, and it is not decoration: it picks the voice that
   // speaks (each lieutenant may own one), and the remote speaker puts it on the
   // phone's lock screen, which is where the captain sees WHO is talking to him
@@ -134,27 +134,38 @@ export function stopSpeaking() {
   speakingBubble.hide();
 }
 
-// ---------- floating "speaking" indicator ----------
-// A small fixed bubble shown ONLY while a speech session is live: up when one
+// ---------- floating transport ----------
+// A small fixed transport shown ONLY while a speech session is live: up when one
 // starts, down when the speaker settles it (natural end, error, or cancel).
-// Clicking the bubble cancels all speech immediately.
+// Three buttons — play, pause, stop — and a label saying WHO is speaking.
+//
+// It used to be a pill with four animated wave bars, and that is exactly what
+// broke the phone: the lock screen goes deaf behind a page that shows no player.
+// WebKit wants a transport it can SEE, so this is one — plain on purpose, here to
+// be seen and pressed by a thumb, not admired.
 const speakingBubble = (() => {
   let el = null;
   function ensureEl() {
     if (el) return el;
-    el = document.createElement('button');
+    el = document.createElement('div');
     el.id = 'tts-bubble';
-    el.type = 'button';
-    el.title = 'click to stop speaking';
-    el.setAttribute('aria-label', 'stop speaking');
     el.hidden = true;
-    el.innerHTML = '<span class="wave"><i></i><i></i><i></i><i></i></span><span class="lbl">speaking…</span>';
-    el.onclick = () => stopSpeaking();
+    el.innerHTML = '<span class="lbl"></span>'
+      + '<button type="button" class="t-play" title="play" aria-label="play">▶</button>'
+      + '<button type="button" class="t-pause" title="pause" aria-label="pause">❚❚</button>'
+      + '<button type="button" class="t-stop" title="stop" aria-label="stop">■</button>';
+    el.querySelector('.t-play').onclick = () => speaker.resume();
+    el.querySelector('.t-pause').onclick = () => speaker.pause();
+    el.querySelector('.t-stop').onclick = () => stopSpeaking();
     document.body.appendChild(el);
     return el;
   }
   return {
-    show() { ensureEl().hidden = false; },
+    show(who) {
+      const e = ensureEl();
+      e.querySelector('.lbl').textContent = who || 'speaking…';
+      e.hidden = false;
+    },
     hide() { if (el) el.hidden = true; },
   };
 })();


### PR DESCRIPTION
# Description

The captain listens to the board with his phone locked, and behind the animated "speaking…" bubble the lock screen goes deaf — the bench probes on his iPhone showed `mini` (a visible transport) keeps answering while `hidden` does not, and that `hidden` never removed an element, only the visible row, so presence was never the difference: WebKit wants a player it can see. The bubble becomes one — who is speaking, plus play, pause and stop — which also means the captain can work the speech from the page and not only from the lock screen.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added (`pause`/`resume` forwarded by `withFallback`; the page transport driving the same suspend/resume path as the lock screen).
- Driven in a real browser against the captain's engine at `100.114.197.65:8883`: the transport is up while speaking, labelled with the author, and pause/play/stop move the sink `<audio>` and `mediaSession.playbackState` (`playing` → `paused` → `playing` → `none`); pressing it does not close an open card.
- Not exercised: the press on the iPhone with the screen locked. The markup and wiring are a port of `console/test.html`'s `#mini`, already proven on that phone.

## Any specific deployment considerations

- None — static UI assets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
