### PR TITLE
Board speech: re-arm the sink every message, not just the first

### DIFF
--- a/dev/ui-server.js
+++ b/dev/ui-server.js
@@ -7,8 +7,15 @@
 // and a tiny "fake lieutenant" simulation answers captain messages and acts on
 // start/rework orders after a short delay, so clicking around feels real.
 //
-// It never touches server/server.js or any real workspace state, and binds
-// 127.0.0.1 ONLY. Usage: node dev/ui-server.js [--port N]   (default 4790)
+// It never touches server/server.js or any real workspace state. It binds
+// loopback by default and a SPECIFIC address on request — never all interfaces.
+//
+//   node dev/ui-server.js [--port N] [--host ADDR] [--tts URL]   (default 4790)
+//
+// --tts is the one thing the playground cannot fake: speech needs a real engine,
+// so the fixture's config block points at one when it is given a url, and the
+// board is simply mute when it is not. That is what makes the speech path
+// testable here — on a phone, on a home-screen app — without a real workspace.
 'use strict';
 
 const http = require('http');
@@ -68,7 +75,8 @@ const MIME = {
   '.webp': 'image/webp', '.ico': 'image/x-icon', '.woff2': 'font/woff2',
 };
 
-function createDevServer() {
+function createDevServer(opts) {
+  const ttsUrl = (opts && opts.ttsUrl) || '';
   const base = Date.now();
   const BOOT_ID = 'dev-' + process.pid + '-' + base;
 
@@ -387,7 +395,13 @@ function createDevServer() {
 
       // ----- reads -----
       if (route === 'GET /api/board') return sendJson(res, 200, publicBoard());
-      if (route === 'GET /api/config') return sendJson(res, 200, { voices: null });
+      // Same shape the real server sends (server.js ttsConfig): no tts key at
+      // all when there is no engine, so the UI sees exactly what it sees today.
+      if (route === 'GET /api/config') {
+        const cfg = { voices: null };
+        if (ttsUrl) cfg.tts = { enabled: true, url: ttsUrl, lang: 'pt', voice: null, params: {} };
+        return sendJson(res, 200, cfg);
+      }
       if (route === 'GET /api/status') {
         return sendJson(res, 200, {
           workspace: '/fake/ws (dev playground)', port: server.address() && server.address().port,
@@ -737,10 +751,12 @@ module.exports = { createDevServer };
 if (require.main === module) {
   let port = 4790;
   let host = '';
+  let ttsUrl = '';
   const argv = process.argv.slice(2);
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === '--port') port = parseInt(argv[++i], 10);
     else if (argv[i] === '--host') host = String(argv[++i] || '').trim();
+    else if (argv[i] === '--tts') ttsUrl = String(argv[++i] || '').trim();
   }
   if (!Number.isInteger(port) || port <= 0) { console.error('bad --port'); process.exit(1); }
   if (host && !/^[\w.:-]+$/.test(host)) { console.error('bad --host'); process.exit(1); }
@@ -748,10 +764,12 @@ if (require.main === module) {
   if (host === '0.0.0.0' || host === '::') { console.error('refusing to bind all interfaces — give a specific address'); process.exit(1); }
   const LOOPBACKS = ['127.0.0.1', 'localhost', '::1'];
   const BIND_HOST = host || '127.0.0.1';
-  const { server } = createDevServer();
+  if (ttsUrl && !/^https?:\/\//.test(ttsUrl)) { console.error('bad --tts (want http://host:port)'); process.exit(1); }
+  const { server } = createDevServer({ ttsUrl });
   server.on('error', (e) => { console.error('server error: ' + e.message); process.exit(1); });
   server.listen(port, BIND_HOST, () => {
     console.log('[dev-playground] http://' + BIND_HOST + ':' + port + '  (fixture board, nothing persists)');
+    console.log('[dev-playground] speech: ' + (ttsUrl || 'no engine (--tts URL to give it one) — the board stays mute'));
   });
   // Non-loopback bind: also listen on loopback, the same way server.js does it,
   // so the local browser/curl keep working alongside the tailscale address.

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -20,10 +20,12 @@ const tick = (ms) => new Promise((r) => setTimeout(r, ms));
 // ── the page ──────────────────────────────────────────────────────────────
 // The hidden <audio> the sound leaves through. `refuse` is a browser that will
 // not autoplay: the module drops to the speakers rather than to silence.
+// `fed` counts how many times it was handed a stream, because "was it armed for
+// THIS message" is a different question from "does it hold a stream".
 const sinkEl = {
-  tag: 'audio', plays: 0, paused: true, refuse: false, _src: null,
+  tag: 'audio', plays: 0, fed: 0, paused: true, refuse: false, _src: null,
   get srcObject() { return this._src; },
-  set srcObject(v) { this._src = v; },
+  set srcObject(v) { this._src = v; if (v) this.fed++; },
   play() { this.plays++; this.paused = false; return this.refuse ? Promise.reject(new Error('autoplay blocked')) : Promise.resolve(); },
   pause() { this.paused = true; },
 };
@@ -38,9 +40,11 @@ const bar = {
 const styles = [];
 let session;
 function fakePage() {
-  // Only what a new test needs fresh: the element itself is the module's, made
-  // once and fed once, and resetting its stream would be resetting the module.
-  Object.assign(sinkEl, { plays: 0, paused: true, refuse: false });
+  // Only what a new test needs fresh. The element itself is the module's, made
+  // once for the life of the page — but it is re-fed the stream every session,
+  // so the counters reset and `_src` does not: what it holds between messages is
+  // the module's business, and one of the tests below is exactly about that.
+  Object.assign(sinkEl, { plays: 0, fed: 0, paused: true, refuse: false });
   bar.hidden = true;
   bar.what.textContent = '';
   global.document = {
@@ -218,6 +222,57 @@ test('the sound leaves through a media element, behind a transport the captain c
   assert.equal(bar.hidden, true, 'and gone when it stops');
   assert.ok(sinkEl.paused);
   assert.equal(session.playbackState, 'none');
+});
+
+// ── the SECOND message ────────────────────────────────────────────────────
+// The bug these two are here for: the board spoke once per page load and then
+// went quiet, with nothing to show for it — no toast, no console error, the
+// element still holding its stream, still in the document, at readyState 4. An
+// element WebKit has stopped does not play the stream it is already holding, and
+// says so nowhere: play() resolves, the context renders the whole message into a
+// sink nobody is listening to, and speak() reports a clean success over silence.
+// So neither test may settle for "it spoke" — each asserts the element was
+// ARMED AGAIN for the second message, which is the part that was missing.
+test('a second message re-arms the element — a stream the element already holds is not enough', async () => {
+  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
+  // The stream being read is over before the SOUND is: the last buffer still has
+  // to be heard, and that is what closes the sink. Every await below is for that
+  // beat, not for the fetch.
+  const said = async (input, title) => { await speak({ ...ASK, input, title }); await tick(10); };
+
+  await said('first', 'Ana');
+  assert.equal(sinkEl.srcObject, null, 'the element lets the stream go when the speech is over');
+
+  const fed = sinkEl.fed, plays = sinkEl.plays;
+  await said('second', 'Bea');
+  assert.ok(sinkEl.fed > fed, 'the second message feeds the element the stream again');
+  assert.equal(sinkEl.srcObject, null, 'and lets it go again at the end');
+  assert.ok(sinkEl.plays > plays, 'and it played — silence here is the whole bug');
+
+  // Third, because "works twice" was never the claim: it has to keep working.
+  const fed2 = sinkEl.fed;
+  await said('third', 'Cida');
+  assert.ok(sinkEl.fed > fed2, 'and the one after that, and the one after that');
+  assert.deepEqual(session.titles, ['Ana', 'Bea', 'Cida']);
+});
+
+// The captain's own path to it: speak, press stop, ask again. stop() is the
+// destructive verb, so it is the one most likely to leave the element unusable.
+test('a message after stop() re-arms the element too', async () => {
+  fakeFetch((b, sig) => (b.input === 'stopped mid-word'
+    ? openStream(sig)
+    : pcmResponse([0, 100, -100, 0], 4, 24000)));
+  const cut = speak({ ...ASK, input: 'stopped mid-word', title: 'Ana' });
+  await tick(10);
+  assert.ok(!sinkEl.paused, 'playing before the stop');
+  stop();
+  assert.equal((await cut).stopped, true);
+  assert.equal(sinkEl.srcObject, null, 'stop lets the element go');
+
+  const fed = sinkEl.fed, plays = sinkEl.plays;
+  await speak({ ...ASK, input: 'and again', title: 'Bea' });
+  assert.ok(sinkEl.fed > fed, 're-armed after a stop, not left holding the old stream');
+  assert.ok(sinkEl.plays > plays, 'and speaking again — no refresh needed');
 });
 
 // An abandoned synthesis keeps the GPU busy for another half-minute, and voxcpm2

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -100,13 +100,29 @@ function openSink() {
   if (!sink) {
     if (!ctx.createMediaStreamDestination) { sink = null; return; }
     sink = ctx.createMediaStreamDestination();
-    element().srcObject = sink.stream;
   }
+  // EVERY session, not just the one that made the sink. An element WebKit has
+  // stopped will not play the stream it is already holding: play() resolves, no
+  // error is thrown and nothing is heard — the element sits at paused with
+  // readyState 4 while the context cheerfully renders into a sink no one is
+  // listening to. The message runs its full length in silence and speak()
+  // reports success, so the board has nothing to complain about either. Handing
+  // it the stream again is what arms it; that is why closeSink() lets go.
+  //
+  // The board's own player did this before speech.js was extracted out of it —
+  // a new stream per message, dropped at the end — and the extraction lost it.
+  // The board then spoke exactly once per page load, and only the captain's
+  // home-screen app showed it: in a plain tab the same code is forgiving.
+  element().srcObject = sink.stream;
   element().play().catch(() => { sink = null; });   // blocked → the speakers
 }
 
+// Let the element go. Pausing alone is not enough in either direction: it leaves
+// the lock screen showing a player for speech that is over, and it leaves the
+// element holding a stream it will never play again (see openSink).
 function closeSink() {
   element().pause();
+  element().srcObject = null;
   transport(false);
   playbackState('none');
 }


### PR DESCRIPTION
The board spoke once per page load, then went silent until the home-screen app was killed and reopened. No toast, no console error — the element still held its stream, still in the document, at readyState 4, and `speak()` resolved successfully over the silence.

`openSink()` attached the MediaStream once, when it first built the sink. Every later message asked an already-stopped element to play the stream it was still holding. WebKit will not: `play()` resolves, nothing is heard, and the AudioContext renders the full message into a sink nobody is listening to.

The board's own player did re-arm — a fresh stream per message, dropped at the end — and extracting it into `speech.js` (#75) dropped that line along with the comment recording why.

## Why the bench looked innocent

Same module, different environment. The captain runs the board as an iPhone **home-screen app** (`display-mode: standalone`); the bench is a normal tab. Neither Chrome nor WebKit-in-a-tab reproduces this — both were measured here, three sessions each, with audio energy sampled off the MediaStream. Standalone is the case.

## Changes

- `openSink()` feeds the element the stream on **every** session; `closeSink()` lets it go. The comment states what breaks without it, so the next extraction cannot drop it silently again.
- `test/speech.test.js` covers the second and third message, after a natural finish and after `stop()`. Both new tests fail without the fix and pass with it.
- `dev/ui-server.js` takes `--tts URL`. Speech is the one thing the fixture playground cannot fake; without it the board's speech path was not testable off a real workspace.

## Verified

Chrome, measured RMS off the module's stream, not inferred: first message audible, silent after stop, **second message audible**, silent while paused, audible after resume, third message audible. Lock-screen metadata tracks the current author across sessions. WebKit (Playwright) reaches `playing` on every session and empties the element between them. Full suite: 393 pass.

`ui/js/speech.js` is a copy of `console/speech.js` in `tonylampada/chatterbox_server` — the same patch is needed there; it is stated verbatim in the worker report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)