### PR TITLE
A lieutenant is a window, not a session

### DIFF
--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -44,10 +44,10 @@ and its cards carry that color stripe.
 |---|---|
 | Workspace | The deployment unit: board state, config (port), shared memory, project clones. Independent of every other workspace |
 | Project | A repo registered in the workspace, with a delivery mode: `no-mistakes` (default) \| `direct-PR` \| `local-only` |
-| Lieutenant | Durable orchestrator: `name` (display, emoji welcome), `color`, `avatar` (optional index 0-63 into the sprite sheet; absent = colored-dot fallback), `voice` (optional TTS-engine voice id; absent = the board's voice speaks for it), `charter` (mission). Its `id` and any derived session name come from the ASCII slug of the name — emoji never reach tmux. Its tmux session is an incarnation, not the entity. Converses with the captain; proactive inside its mission (creates cards, starts them); never writes to projects |
+| Lieutenant | Durable orchestrator: `name` (display, emoji welcome), `color`, `avatar` (optional index 0-63 into the sprite sheet; absent = colored-dot fallback), `voice` (optional TTS-engine voice id; absent = the board's voice speaks for it), `charter` (mission). Its `id` and any derived session name come from the ASCII slug of the name — emoji never reach tmux. It lives in the `lt` **window** of that session — the worker windows it starts cohabit the session with it — and that session is an incarnation, not the entity. Converses with the captain; proactive inside its mission (creates cards, starts them); never writes to projects |
 | Card | Unit of work, owned by one lieutenant. `type`: `plan` 🧠 \| `implementation` 🔥 \| `investigation` 🕵️. `body` = the deliverable, always rewritten to current state. `labels` (tags from the board registry). Work attributes live in an open `attributes{}` map, keys by convention: `repo`, `branch`, `worktree`, `session`, `prs {url, state}`, `artifacts {uri, label}`, plus `harness` and `model` (new-card hints consumed by `card.start`) |
 | CardStatus | Live status hung on a card, UI's real-time signal. Worker lease: `absent \| idle \| working \| needs-you`, written ONLY by `card.status` (worker-side), decayed server-side by TTL; plus server-derived `owed` (latest DELIVERED captain message not yet acked — queue truth, not thread order) with `owedState` `queued \| seen` (boundary: the drained cursor), and `unread` |
-| Worker | Implementation agent bound 1:1 to a Working card: tmux **window** (`w-<card-id>`) inside its lieutenant's session + isolated worktree (+ delivery pipeline per project mode). Ephemeral — dies with the card's Working state; the lieutenant-session coupling (lieutenant dies → its worker windows die) is accepted design |
+| Worker | Implementation agent bound 1:1 to a Working card: tmux **window** (`w-<card-id>`) inside its lieutenant's session + isolated worktree (+ delivery pipeline per project mode). Ephemeral — dies with the card's Working state; the session coupling (the lieutenant's SESSION dying takes its worker windows with it — its own `lt` window dying does not) is accepted design |
 | Event | Card timeline entry: `text`, `level` (1 = bell, 2 = timeline only), `actor`, `kind` (open token; the board's kinds registry maps kind → emoji + default level) |
 | Message | Chat utterance. `target`: a lieutenant's main chat or a card thread. May carry `attachments [{id, name, mime, path}]` (captain uploads); attachments ride the QueueItem to the lieutenant with absolute paths. A card thread is a **context folder**: the interlocutor is always the owning lieutenant, never the worker |
 | QueueItem | One durable delivery to a lieutenant. Kinds: captain `message`, `start-order`, `rework-order`, `card-created` / `card-moved` (captain acts echoed to the owner), `worker-signal`, `worker-said` (a non-owner posted on the card thread), `worker-stopped`, `worker-died`, `worker-stalled`, `worker done`, `pr-merged`, `pr-closed`. `seq`-ordered, at-least-once. (`worker-paused` is an event kind only — pausing is the lieutenant's own act, it never queues) |
@@ -123,7 +123,7 @@ actor strings are honor-system. The network boundary is the auth boundary.
 
 | Verb | Signature | Called by | Purpose |
 |---|---|---|---|
-| `harness.spawn` | `cwd, prompt, opts → HarnessRef` | ⚙️ | birth a lieutenant session or a worker WINDOW inside its lieutenant's session (`opts`: session name, window name — non-numeric, `w-<card-id>` —, state dir, turn-end callback URL, hook install mode) |
+| `harness.spawn` | `cwd, prompt, opts → HarnessRef` | ⚙️ | birth an agent in a named WINDOW of a session (`opts`: session name, window name — non-numeric: `lt` for the lieutenant, `w-<card-id>` for its workers, which share that session —, state dir, turn-end callback URL, hook install mode); no window name = the agent owns the whole session |
 | `harness.send` | `ref, text` | ⚙️ | type into a session (the wake half of delivery) |
 | `harness.alive` | `ref → bool` | ⚙️ | liveness check for supervision |
 | `harness.resumable` | `ref → bool` | ⚙️ | introspection: would `resume` restore memory? The server picks resume vs relaunch-with-charter on it |
@@ -141,7 +141,7 @@ verbs for features not every harness can honor. The port never validates them (r
 one would force every harness, `fake` included, to implement it); the server
 capability-checks at the call site (`typeof impl.openPane === 'function'`) and degrades
 gracefully when the verb is absent. Current optional verbs (pane viewing, slash commands,
-session status):
+session status, window adoption):
 
 | Verb | Signature | Called by | Purpose |
 |---|---|---|---|
@@ -150,6 +150,7 @@ session status):
 | `harness.commands` | `ref → [{name, description}]` | ⚙️ | list the slash commands this session honors (drives the UI's command palette) |
 | `harness.runCommand` | `ref, line → string` | ⚙️ | run one slash-command line in the session (pass-through or emulated per harness) and return the reply text |
 | `harness.status` | `ref → {model, contextUsed, contextWindow, rateLimits?}` | ⚙️ | session vitals; the server caches the result at each turn-end and serves it on the board payload (the lane/card context bars) |
+| `harness.adoptWindow` | `ref, window, taken? → HarnessRef\|null` | ⚙️ supervision | migrate a session-granular ref to window granularity without restarting the agent (the lieutenants registered before their ref carried a window) — `taken` names windows that belong to someone else and must never be adopted; `null` = the agent's window cannot be identified, keep the old ref |
 
 ## Invariants
 

--- a/harness/README.md
+++ b/harness/README.md
@@ -16,7 +16,7 @@ Seven verbs, nothing else:
 All verbs may be async. Zero dependencies — plain Node (>= 18; uses `node:test`, `fetch`).
 Beyond the seven, a harness MAY expose **optional capability verbs** — see below.
 
-## Optional capability verbs (pane viewing)
+## Optional capability verbs (pane viewing, window adoption)
 
 Optional verbs are features not every harness can honor, so `port.js` never
 validates them — adding one to the required list would force every harness
@@ -29,6 +29,7 @@ and degrades gracefully when the verb is absent (the pane endpoints answer
 |---|---|---|
 | `openPane` | `(ref, {onFrame, intervalMs?, lines?}) → {close()}` | deliver the pane's CURRENT RENDERED SCREEN as successive frames: `onFrame(frameString)` fires whenever the content changes (identical frames are skipped); `close()` stops delivery and releases resources |
 | `paneSnapshot` | `(ref, {lines?}) → Promise<string>` | one-shot capture — the initial paint / non-streaming fallback |
+| `adoptWindow` | `(ref, window, taken?) → Promise<HarnessRef\|null>` | migrate a SESSION-granular ref to window granularity **without restarting the agent** — the tmux adapters rename the session's first window; `taken` names windows that belong to someone else and must never be adopted; `null` = the agent's window cannot be identified, keep the old ref |
 
 `intervalMs` defaults to ~1000, `lines` (scrollback depth) to ~200. A frame is
 a string that MAY carry ANSI SGR escapes (colors/bold).
@@ -55,6 +56,12 @@ survive a server restart:
 
 `session` is the tmux session name (`bc-*` — predictable, so `tmux attach -t bc-a1b2c3`
 is the captain's escape hatch). `resumeId` is the harness-native conversation id.
+
+An optional `window` pins the ref to one named WINDOW of that session, for
+agents that cohabit it: a lieutenant in `lt` and its workers in `w-<card-id>`.
+Granularity is not cosmetic — a session-granular ref kills the whole session
+(every sibling window with it) and reads its liveness off whichever window has
+focus, so an agent with siblings must always carry its window.
 
 ## Files
 

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -281,14 +281,15 @@ async function runCommand(ref, command) {
   throw new Error('unknown command ' + name + ' (see /help)');
 }
 
-// onTurnEnd / openPane / paneSnapshot — the shared implementations verbatim
-// (tmux-session.js): the Stop-hook relay writes the same turnend.jsonl shape
-// every tmux adapter tails, and pane viewing is pure capture-pane.
-const { onTurnEnd, openPane, paneSnapshot } = s;
+// onTurnEnd / openPane / paneSnapshot / adoptWindow — the shared
+// implementations verbatim (tmux-session.js): the Stop-hook relay writes the
+// same turnend.jsonl shape every tmux adapter tails, pane viewing is pure
+// capture-pane, and adoption is pure rename-window.
+const { onTurnEnd, openPane, paneSnapshot, adoptWindow } = s;
 
 // installHooks is exported beyond the seven port verbs so `bc-axi init` can
 // install the workspace-level Stop hook (session-agnostic; the server dedupes
 // turn-end POSTs by session_id). openPane/paneSnapshot and
 // commands/runCommand/status are OPTIONAL capability verbs (port.js).
 module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd, installHooks,
-  openPane, paneSnapshot, commands, runCommand, status };
+  openPane, paneSnapshot, commands, runCommand, status, adoptWindow };

--- a/harness/codex-tmux.js
+++ b/harness/codex-tmux.js
@@ -246,10 +246,11 @@ async function runCommand(ref, command) {
   throw new Error('unknown command ' + name + ' (see /help)');
 }
 
-// onTurnEnd / openPane / paneSnapshot — the shared implementations verbatim
-// (tmux-session.js): codex-notify.js writes the same turnend.jsonl shape the
-// claude Stop hook does, and pane viewing is pure capture-pane.
-const { onTurnEnd, openPane, paneSnapshot } = s;
+// onTurnEnd / openPane / paneSnapshot / adoptWindow — the shared
+// implementations verbatim (tmux-session.js): codex-notify.js writes the same
+// turnend.jsonl shape the claude Stop hook does, pane viewing is pure
+// capture-pane, and adoption is pure rename-window.
+const { onTurnEnd, openPane, paneSnapshot, adoptWindow } = s;
 
 module.exports = { spawn, send, alive, resumable, resume, kill, onTurnEnd,
-  openPane, paneSnapshot, commands, runCommand, status };
+  openPane, paneSnapshot, commands, runCommand, status, adoptWindow };

--- a/harness/fake.js
+++ b/harness/fake.js
@@ -76,6 +76,34 @@ function get(ref) {
   return s;
 }
 
+// live(key) — known to THIS process, else the file-backed marker.
+function live(key) {
+  const s = sessions.get(key);
+  if (s) return s.alive;
+  const marker = markerFile(key);
+  return !!(marker && fs.existsSync(marker));
+}
+
+// siblings(session) — every key living in that tmux session: the session
+// itself plus its `session:window` windows (in-process and marker-backed).
+// The two verbs below need it because a SESSION-granular ref addresses a whole
+// tmux session, windows and all — the fidelity that makes the lieutenant's
+// window-granular ref testable without tmux.
+function siblings(session) {
+  const keys = new Set();
+  const mine = (k) => k === session || k.startsWith(session + ':');
+  for (const k of sessions.keys()) if (mine(k)) keys.add(k);
+  const dir = fakeStateDir();
+  if (dir) {
+    for (const f of fs.readdirSync(dir)) {
+      if (!f.endsWith('.json')) continue;
+      const k = f.slice(0, -5);
+      if (mine(k)) keys.add(k);
+    }
+  }
+  return [...keys];
+}
+
 function emitTurnEnd(name) {
   const s = sessions.get(name);
   if (!s || !s.alive) return;
@@ -148,11 +176,13 @@ async function send(ref, text) {
   emitTurnEnd(key);
 }
 
+// alive(ref) — window-granular refs answer for their own window only.
+// A session-granular ref is read the way tmux reads `=session:`: off whichever
+// window has FOCUS, so ANY live window in the session makes it read alive —
+// including a busy worker masking a dead lieutenant beside it.
 async function alive(ref) {
-  const s = sessions.get(refKey(ref));
-  if (s) return s.alive;
-  const marker = markerFile(refKey(ref));
-  return !!(marker && fs.existsSync(marker));
+  if (ref.window) return live(refKey(ref));
+  return siblings(ref.session).some(live);
 }
 
 // resumable — introspection only: memory survives a resume iff this process
@@ -198,11 +228,34 @@ function onTurnEnd(ref, hook) {
 // kill(ref) — port verb: end the session for good. Idempotent (unknown or
 // already-dead sessions are a no-op). File-backed mode also removes the
 // marker so a WATCHING process sees alive() flip false.
+// tmux semantics: a window-granular ref takes ONLY its window; a
+// session-granular one takes the whole session — every sibling window with it.
 function kill(ref) {
-  const s = sessions.get(refKey(ref));
-  if (s) s.alive = false;
-  const marker = markerFile(refKey(ref));
-  if (marker) { try { fs.unlinkSync(marker); } catch { /* already gone */ } }
+  for (const key of (ref.window ? [refKey(ref)] : siblings(ref.session))) {
+    const s = sessions.get(key);
+    if (s) s.alive = false;
+    const marker = markerFile(key);
+    if (marker) { try { fs.unlinkSync(marker); } catch { /* already gone */ } }
+  }
+}
+
+// adoptWindow(ref, window, taken?) -> ref — OPTIONAL capability verb; the real
+// contract is in tmux-session.js. The fake has one pane per key, so there is
+// no window to mis-adopt (`taken` never applies): the live session is simply
+// re-keyed, and the SAME agent (transcript, hooks, marker) answers to
+// `session:window` from now on.
+async function adoptWindow(ref, window) {
+  if (ref.window) return ref;
+  const key = keyOf(ref.session, window);
+  const s = sessions.get(ref.session);
+  if (s) {
+    sessions.delete(ref.session);
+    sessions.set(key, s);
+  }
+  const from = markerFile(ref.session);
+  const to = markerFile(key);
+  if (from && to && fs.existsSync(from)) fs.renameSync(from, to);
+  return { ...ref, window };
 }
 
 // ---------- pane viewing (OPTIONAL capability verbs — see port.js) ----------
@@ -297,7 +350,7 @@ function reset() {
   sessions.clear();
 }
 
-const impl = { spawn, send, alive, resumable, resume, onTurnEnd, kill, transcript, reset };
+const impl = { spawn, send, alive, resumable, resume, onTurnEnd, kill, adoptWindow, transcript, reset };
 // Pane verbs are OPTIONAL by contract; BC_FAKE_NO_PANE simulates a harness
 // that never implemented them (capability-absent degradation under test).
 if (!process.env.BC_FAKE_NO_PANE) {

--- a/harness/port.js
+++ b/harness/port.js
@@ -36,6 +36,14 @@
 //       stops delivery and releases resources. All async-safe.
 //   paneSnapshot(ref, { lines? }) -> Promise<string>
 //       one-shot capture — the initial paint / non-streaming fallback.
+// — migration of a session-granular ref to window granularity (the lieutenant
+// whose session it turned out to cohabit with its worker windows):
+//   adoptWindow(ref, window, taken?) -> Promise<HarnessRef|null>
+//       make the SAME running agent addressable as `session:window` without
+//       restarting it. `taken` names windows that belong to someone else and
+//       must never be adopted. null = the agent's window cannot be identified;
+//       the caller keeps the old ref. Idempotent: a ref that already carries a
+//       window comes back unchanged.
 // — and slash commands + session status (the UI composer's "/" and the
 // context bars; agent-status.js holds the shared machinery):
 //   commands(ref?) -> [{ name, description }]

--- a/harness/test/claude-tmux.test.js
+++ b/harness/test/claude-tmux.test.js
@@ -99,3 +99,63 @@ test('slash commands: the shared trio plus claude-only /autocompact; /help lists
   // unknown commands throw without ever touching tmux
   await assert.rejects(() => claude.runCommand(ref, '/nope'), /unknown command \/nope/);
 });
+
+// adoptWindow — the migration that pins an already-running, session-granular
+// agent (a lieutenant registered before its ref carried a window) to its own
+// window. Pure tmux plumbing, so tryTmux is stubbed and every call inspected;
+// the whole point is that the agent is RENAMED, never killed or relaunched.
+function stubTryTmux(answer) {
+  const tmuxMod = require('../tmux.js');
+  const original = tmuxMod.tryTmux;
+  const calls = [];
+  tmuxMod.tryTmux = async (...args) => { calls.push(args); return answer(args); };
+  return { calls, restore() { tmuxMod.tryTmux = original; } };
+}
+// A session whose windows are `windows` ([[index, name], …]); null session = gone.
+function tmuxWith(windows) {
+  return (args) => {
+    if (args[0] === 'has-session') return windows ? '' : null;
+    if (args[0] === 'list-windows') {
+      if (!windows) return null;
+      const idx = args.indexOf('-F');
+      return windows.map(([i, n]) => (args[idx + 1].includes('window_index') ? i + '\t' + n : n)).join('\n');
+    }
+    if (args[0] === 'rename-window') return '';
+    return null;
+  };
+}
+
+test('adoptWindow renames the session FIRST window and returns a window-granular ref', async () => {
+  const stub = stubTryTmux(tmuxWith([['0', 'node'], ['1', 'w-card-7']]));
+  try {
+    const ref = { harness: 'claude', session: 'bc-lt-ada', cwd: '/tmp', resumeId: 'u1' };
+    assert.deepStrictEqual(await claude.adoptWindow(ref, 'lt', ['w-card-7']), { ...ref, window: 'lt' });
+    const rename = stub.calls.find((c) => c[0] === 'rename-window');
+    assert.deepStrictEqual(rename, ['rename-window', '-t', '=bc-lt-ada:0', 'lt']);
+    assert.ok(!stub.calls.some((c) => c[0] === 'kill-window' || c[0] === 'kill-session'),
+      'the running lieutenant is renamed, never killed');
+  } finally { stub.restore(); }
+});
+
+test('adoptWindow refuses when the first window belongs to a worker', async () => {
+  // the lieutenant's own window is gone; window 1 is a live worker — renaming
+  // THAT would hand a worker's pane to the lieutenant's ref
+  const stub = stubTryTmux(tmuxWith([['1', 'w-card-7']]));
+  try {
+    const ref = { harness: 'claude', session: 'bc-lt-ada', cwd: '/tmp' };
+    assert.strictEqual(await claude.adoptWindow(ref, 'lt', ['w-card-7']), null);
+    assert.ok(!stub.calls.some((c) => c[0] === 'rename-window'), 'nothing renamed');
+  } finally { stub.restore(); }
+});
+
+test('adoptWindow with no live session hands back the window-granular ref (nothing to rename)', async () => {
+  const stub = stubTryTmux(tmuxWith(null));
+  try {
+    const ref = { harness: 'claude', session: 'bc-lt-ada', cwd: '/tmp' };
+    assert.deepStrictEqual(await claude.adoptWindow(ref, 'lt', []), { ...ref, window: 'lt' });
+    assert.ok(!stub.calls.some((c) => c[0] === 'rename-window'));
+    // already window-granular: no tmux call at all
+    const done = { ...ref, window: 'lt' };
+    assert.strictEqual(await claude.adoptWindow(done, 'lt', []), done);
+  } finally { stub.restore(); }
+});

--- a/harness/test/fake.test.js
+++ b/harness/test/fake.test.js
@@ -144,3 +144,37 @@ test('kill ends a session for good; idempotent; file-backed marker removed', asy
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// The fake models tmux's session/window granularity, because that is what the
+// lieutenant/worker cohabitation actually rides on (server supervision tests
+// depend on this fidelity — see test/supervise.test.js).
+test('session-granular kill takes the whole session; window-granular kill takes one window', async () => {
+  const lt = await fake.spawn('/tmp/x', 'lt', { session: 'bc-s' });
+  const w1 = await fake.spawn('/tmp/x', 'w1', { session: 'bc-s', window: 'w-1' });
+  const w2 = await fake.spawn('/tmp/x', 'w2', { session: 'bc-s', window: 'w-2' });
+  fake.kill(w1);
+  assert.strictEqual(await fake.alive(w1), false);
+  assert.strictEqual(await fake.alive(w2), true, 'a sibling window is untouched');
+  fake.kill(lt); // no window: the whole tmux session, every window with it
+  assert.strictEqual(await fake.alive(w2), false);
+});
+
+test('a session-granular ref reads alive while ANY window of its session lives', async () => {
+  const lt = await fake.spawn('/tmp/x', 'lt', { session: 'bc-s' });
+  const w = await fake.spawn('/tmp/x', 'w', { session: 'bc-s', window: 'w-1' });
+  fake.kill(lt); // session-granular: kills everything…
+  assert.strictEqual(await fake.alive(lt), false);
+  await fake.resume(w); // …one window back up
+  assert.strictEqual(await fake.alive(w), true);
+  assert.strictEqual(await fake.alive(lt), true,
+    'the session-granular ref answers for whichever window has focus — the corpse-masking bug');
+});
+
+test('adoptWindow re-keys the SAME live agent to session:window, and is idempotent', async () => {
+  const ref = await fake.spawn('/tmp/x', 'charter', { session: 'bc-s' });
+  const moved = await fake.adoptWindow(ref, 'lt');
+  assert.deepStrictEqual(moved, { ...ref, window: 'lt' });
+  assert.strictEqual(await fake.alive(moved), true);
+  assert.deepStrictEqual(fake.transcript(moved), ['charter'], 'memory follows the agent — never restarted');
+  assert.deepStrictEqual(await fake.adoptWindow(moved, 'lt'), moved, 'idempotent');
+});

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -124,6 +124,35 @@ async function killPane(session, window) {
   }
 }
 
+// adoptWindow(ref, window, taken?) -> ref | null — migrate a SESSION-granular
+// ref to window granularity without restarting the agent it addresses. Born
+// session-granular, an agent that cohabits its session (a lieutenant with its
+// worker windows) is addressed as `=session:`, which resolves to whatever
+// window has FOCUS: killPane takes the whole session and paneCommand reads a
+// sibling's pane. Pinning the ref to the agent's own window fixes both.
+//
+// The agent's window is the session's FIRST (lowest-index) one — it was born
+// with the session, every sibling was appended after it. `taken` names windows
+// that provably belong to someone else (the caller's worker windows), so a
+// session whose original window is gone is never mis-adopted.
+//
+// rename-window also turns tmux's automatic-rename off for that window, so the
+// name sticks. Nothing live to rename (session gone) still returns the
+// window-granular ref — the next spawn/resume creates the window. null means
+// "cannot tell which window is the agent's": the ref is left alone.
+async function adoptWindow(ref, window, taken = []) {
+  if (ref.window) return ref;
+  if (!(await hasSession(ref.session))) return { ...ref, window };
+  if (await hasWindow(ref.session, window)) return { ...ref, window };
+  const out = await t.tryTmux('list-windows', '-t', `=${ref.session}:`, '-F', '#{window_index}\t#{window_name}');
+  const first = out === null ? null : out.split('\n').find((l) => l.trim());
+  if (!first) return null;
+  const [index, name] = first.trim().split('\t');
+  if (!index || taken.includes(name)) return null;
+  if (await t.tryTmux('rename-window', '-t', `=${ref.session}:${index}`, window) === null) return null;
+  return { ...ref, window };
+}
+
 // launchAndSettle — send the launch command into the pane, wait for the agent
 // process and its main UI, auto-accepting the harness's trust dialog if it
 // appears (a fresh cwd shows one even in bypass mode; the accept option is
@@ -306,6 +335,7 @@ module.exports = {
   claimPaneNames,
   createPane,
   killPane,
+  adoptWindow,
   launchAndSettle,
   onTurnEnd,
   openPane,

--- a/server/names.js
+++ b/server/names.js
@@ -41,4 +41,12 @@ function workerWindow(cardId) {
   return 'w-' + safe(cardId);
 }
 
-module.exports = { workspaceDisc, lieutenantSession, workerWindow };
+// LIEUTENANT_WINDOW — the window a lieutenant lives in inside its OWN session.
+// A lieutenant cohabits that session with its worker windows, so its ref must
+// be window-granular too: a session-granular ref kills the whole session on
+// revive (every worker with it) and reads liveness off whichever window has
+// focus (a busy worker masks a dead lieutenant). Same name for every
+// lieutenant — the session name already identifies which one.
+const LIEUTENANT_WINDOW = 'lt';
+
+module.exports = { workspaceDisc, lieutenantSession, workerWindow, LIEUTENANT_WINDOW };

--- a/server/server.js
+++ b/server/server.js
@@ -464,6 +464,7 @@ async function spawnLieutenant(body) {
   try {
     ref = await impl.spawn(WORKSPACE, lieutenantPrompt(name, id, body.charter), {
       session,
+      window: names.LIEUTENANT_WINDOW, // its own window in its own session — see names.js
       stateDir: HARNESS_STATE_DIR,
       callbackUrl: TURNEND_URL,
       installHooks: false,
@@ -867,7 +868,8 @@ function sysloadTargets() {
   }
   for (const lt of board.lieutenants) {
     if (!isHarnessRef(lt.ref)) continue;
-    out.push({ kind: 'lieutenant', id: lt.id, label: lt.name, session: lt.ref.session, window: null });
+    out.push({ kind: 'lieutenant', id: lt.id, label: lt.name,
+      session: lt.ref.session, window: lt.ref.window || null });
   }
   return out;
 }
@@ -1949,8 +1951,25 @@ async function superviseTick() {
     let changed = false;
     for (const lt of board.lieutenants) {
       if (!isHarnessRef(lt.ref)) continue;
+      let impl = null;
+      try { impl = harnessFor(lt.ref); } catch (e) { impl = null; }
+      // A lieutenant's session is shared with its worker windows, so its ref
+      // must name its own window (names.LIEUTENANT_WINDOW) — a session-granular
+      // one would kill every worker on revive and read liveness off whichever
+      // window has focus. Refs registered before that (founders, older boards)
+      // are migrated here, in place: the running lieutenant is renamed into its
+      // window, never restarted. Best-effort — a tick on the old ref is fine.
+      if (impl && !lt.ref.window && typeof impl.adoptWindow === 'function') {
+        try {
+          const taken = board.workers
+            .filter((w) => w.ref.session === lt.ref.session && w.ref.window)
+            .map((w) => w.ref.window);
+          const ref = await impl.adoptWindow(lt.ref, names.LIEUTENANT_WINDOW, taken);
+          if (ref) { lt.ref = ref; changed = true; }
+        } catch (e) { /* keep the old ref; the next tick tries again */ }
+      }
       let up = false;
-      try { up = await harnessFor(lt.ref).alive(lt.ref); } catch (e) { up = false; }
+      try { up = impl ? await impl.alive(lt.ref) : false; } catch (e) { up = false; }
       if (up) {
         respawnAttempts.delete(lt.id);
         // Alive but possibly deaf: a wake that landed in a busy pane never
@@ -1967,18 +1986,21 @@ async function superviseTick() {
         // Resume when memory is recoverable; else relaunch a fresh session with
         // charter + owned cards + pending queue as the prompt (the DNA's
         // auto-respawn side effect) — a bare agent with no context helps nobody.
-        const impl = harnessFor(lt.ref);
         const opts = { stateDir: HARNESS_STATE_DIR, callbackUrl: TURNEND_URL, installHooks: false };
         let ref;
         if (await impl.resumable(lt.ref, opts)) {
           ref = await impl.resume(lt.ref, opts);
         } else {
-          await impl.kill(lt.ref); // clear any dead pane still holding the name
           // Keep the session name (an incarnation, not a new entity) when it is
           // spawnable; a founder's foreign name gets a workspace-scoped one.
           const session = /^bc-[A-Za-z0-9_-]+$/.test(lt.ref.session)
             ? lt.ref.session : names.lieutenantSession(WORKSPACE, lt.id);
-          ref = await impl.spawn(lt.ref.cwd, respawnPrompt(lt), Object.assign({ session }, opts));
+          const window = lt.ref.window || names.LIEUTENANT_WINDOW;
+          // Clear any dead pane still holding the name — the lieutenant's
+          // WINDOW, never its session: the worker windows cohabiting it are
+          // alive and did not ask to die (an unmigrated ref would take them all).
+          await impl.kill({ ...lt.ref, window });
+          ref = await impl.spawn(lt.ref.cwd, respawnPrompt(lt), Object.assign({ session, window }, opts));
         }
         lt.ref = ref;
         respawnAttempts.delete(lt.id);
@@ -2336,7 +2358,14 @@ const server = http.createServer(async (req, res) => {
         if (body.ref !== null && !isHarnessRef(body.ref)) {
           return sendJson(res, 400, { error: 'bad ref (want {harness, session, cwd, resumeId?} or null)' });
         }
-        lt.ref = body.ref;
+        // A re-run of `bc-axi init` re-sends the founder's session-granular ref
+        // (the caller's tmux session is all it can see). Keep the window this
+        // lieutenant was already pinned to — losing it would put the ref back
+        // to killing its whole session, worker windows included, on revive.
+        lt.ref = body.ref && !body.ref.window && lt.ref && lt.ref.window
+          && lt.ref.session === body.ref.session
+          ? { ...body.ref, window: lt.ref.window }
+          : body.ref;
       }
       if (body.name !== undefined && String(body.name).trim()) lt.name = String(body.name).trim().slice(0, 60);
       if (body.color !== undefined && validColor(body.color)) lt.color = body.color;

--- a/server/sysload.js
+++ b/server/sysload.js
@@ -194,9 +194,10 @@ function createSampler(opts) {
     } catch (e) { return null; } // docker absent/broken -> the row hides
   }
 
-  // Attribute each session's panes to its entities: a window-granular worker
-  // claims its own window's panes; every unclaimed pane falls to the session's
-  // window-less target (the lieutenant — or a legacy whole-session worker).
+  // Attribute each session's panes to its entities: a window-granular target
+  // (the lieutenant in its own window, its workers in theirs) claims its own
+  // window's panes; every unclaimed pane falls to the session's window-less
+  // target — a lieutenant or worker still carrying a session-granular ref.
   async function entitySamples(table, elapsedSec) {
     const list = targets();
     const bySession = new Map();

--- a/test/supervise.test.js
+++ b/test/supervise.test.js
@@ -60,17 +60,18 @@ test('dead lieutenant is respawned: ref updated, level-1 respawned event, drain 
     });
     const lt = (await s.api('GET', '/api/lieutenants')).body.lieutenants[0];
     assert.strictEqual(lt.ref.session, 'bc-lt-ada'); // same session name — an incarnation, not a new entity
+    assert.strictEqual(lt.ref.window, 'lt'); // the seeded session-only ref migrated to its own window
     assert.notStrictEqual(lt.ref.resumeId, 'uuid-old'); // fake had no matching memory: fresh id
     // exactly ONE respawn (alive afterwards — attempts reset, no churn) + the drain nudge landed
     await sleep(500);
     const b = (await s.api('GET', '/api/board')).body;
     assert.strictEqual(b.events.filter((e) => e.kind === 'respawned').length, 1);
-    const sends = readSends(fdir, 'bc-lt-ada');
+    const sends = readSends(fdir, 'bc-lt-ada:lt');
     assert.strictEqual(sends.length, 1);
     assert.match(sends[0].text, /respawned — run: bc-axi drain/);
     // no recoverable memory (fake resumable=false) → relaunched with the
     // rebuilt doctrine+charter prompt instead of a bare session
-    const rec = JSON.parse(fs.readFileSync(path.join(fdir, 'bc-lt-ada.json'), 'utf8'));
+    const rec = JSON.parse(fs.readFileSync(path.join(fdir, 'bc-lt-ada:lt.json'), 'utf8'));
     assert.match(rec.prompt, /Respawned without memory/);
     assert.match(rec.prompt, /bc-axi drain/);
   } finally {
@@ -112,7 +113,7 @@ test('non-resumable respawn relaunches with charter + owned cards + pending queu
       const b = (await s.api('GET', '/api/board')).body;
       return b.events.some((e) => e.kind === 'respawned');
     });
-    const rec = JSON.parse(fs.readFileSync(path.join(fdir, 'bc-lt-ada.json'), 'utf8'));
+    const rec = JSON.parse(fs.readFileSync(path.join(fdir, 'bc-lt-ada:lt.json'), 'utf8'));
     assert.match(rec.prompt, /guard the port domain/, 'charter carried');
     assert.match(rec.prompt, /Your cards \(2\)/);
     assert.match(rec.prompt, /- fix-1 \[backlog\] Fix one/);
@@ -159,6 +160,9 @@ test('wake heartbeat: a live lieutenant with pending items is woken by the sweep
   const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
   const nowIso = new Date().toISOString();
   fakeSession(fdir, 'bc-lt-ada'); // ALIVE before the server boots — never enters the respawn branch
+  // ... and session-granular, like every lieutenant registered before the ref
+  // was pinned to a window: the sweep migrates it in place, so the wake lands
+  // on 'bc-lt-ada:lt' without the lieutenant ever being restarted.
   const s = await startServer({
     env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0', BC_WAKE_TTL_MS: '60000' },
     seed: (dir) => {
@@ -179,13 +183,13 @@ test('wake heartbeat: a live lieutenant with pending items is woken by the sweep
   try {
     // the sweep notices the live-but-never-nudged lieutenant and wakes it
     const sends = await until('heartbeat wake', () => {
-      const got = readSends(fdir, 'bc-lt-ada');
+      const got = readSends(fdir, 'bc-lt-ada:lt');
       return got.length ? got : null;
     });
     assert.match(sends[0].text, /1 pending item\(s\) — run: bc-axi drain/);
     // fresh nudge within TTL: further ticks stay coalesced, no wake spam
     await sleep(600);
-    assert.strictEqual(readSends(fdir, 'bc-lt-ada').length, 1, 'coalesced while the nudge is fresh');
+    assert.strictEqual(readSends(fdir, 'bc-lt-ada:lt').length, 1, 'coalesced while the nudge is fresh');
     assert.strictEqual((await s.api('GET', '/api/board')).body.events.filter((e) => e.kind === 'respawned').length, 0);
     // acked -> nothing pending -> the sweep goes quiet. Ack the seeded item by
     // its global seq (1) directly rather than draining first: a GET /api/feed
@@ -195,7 +199,7 @@ test('wake heartbeat: a live lieutenant with pending items is woken by the sweep
     // Acking closes the queue atomically, leaving no pending-but-un-nudged window.
     await s.api('POST', '/api/feed/ack', { seq: 1 });
     await sleep(600);
-    assert.strictEqual(readSends(fdir, 'bc-lt-ada').length, 1, 'no re-nudge after the queue is handled');
+    assert.strictEqual(readSends(fdir, 'bc-lt-ada:lt').length, 1, 'no re-nudge after the queue is handled');
   } finally {
     await s.stop();
     fs.rmSync(fdir, { recursive: true, force: true });
@@ -225,7 +229,7 @@ test('wake heartbeat: a stale nudge lapses after BC_WAKE_TTL_MS and the sweep re
     // never drained: the first wake's nudge outlives its TTL and the next
     // sweep tick fires again — a send-keys that never became a turn self-heals
     const sends = await until('re-fired wake after TTL', () => {
-      const got = readSends(fdir, 'bc-lt-ada');
+      const got = readSends(fdir, 'bc-lt-ada:lt');
       return got.length >= 2 ? got : null;
     });
     for (const snd of sends.slice(0, 2)) assert.match(snd.text, /1 pending item\(s\) — run: bc-axi drain/);
@@ -288,6 +292,92 @@ test('dead worker without done: worker-died QueueItem + card event, card stays W
     assert.strictEqual(items.filter((i) => i.kind === 'worker-died').length, 1);
     assert.ok(!items.some((i) => i.card === 'fine'), 'live worker untouched');
     assert.ok(!items.some((i) => i.card === 'finished'), 'done worker never nagged about');
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+// A lieutenant is a WINDOW, not a session: its worker windows cohabit that
+// session, so a session-granular ref would take every one of them down on
+// revive (and read its own liveness off whichever window has focus). The fake
+// models both tmux behaviors — a session-granular kill takes the siblings, a
+// session-granular alive answers for any live window — so these two pin the
+// real thing without tmux.
+test('reviving a lieutenant kills only its own window: sibling worker windows survive', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const nowIso = new Date().toISOString();
+  fakeSession(fdir, 'bc-lt-ada:w-live'); // a live worker window, alive before boot
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0' },
+    seed: (dir) => seedBoard(dir, {
+      lieutenants: [{
+        id: 'ada', name: 'Ada', color: '#58b6ff', charter: '', chat: [], created: nowIso,
+        // registered BEFORE lieutenant refs carried a window (a founder, an
+        // older board): the sweep migrates it in place
+        ref: { harness: 'fake', session: 'bc-lt-ada', cwd: '/tmp', resumeId: 'uuid-gone' },
+      }],
+      cards: [{
+        id: 'live', title: 'Live', type: 'implementation', owner: 'ada', column: 'working',
+        labels: [], attributes: { repo: 'proj', session: 'bc-lt-ada:w-live' }, body: '',
+        created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
+      }],
+      workers: [
+        { card: 'live', ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-live', cwd: '/tmp', resumeId: 'w1' },
+          worktree: { path: '/tmp/none', tool: 'git' }, branch: 'bc/live', project: 'proj', spawnedAt: nowIso, done: false },
+      ],
+    }),
+  });
+  try {
+    // dead lieutenant, live worker beside it: the sweep must still see a corpse
+    // (session-granular, the worker's pane would mask it) and revive it
+    await until('respawned event', async () => {
+      const b = (await s.api('GET', '/api/board')).body;
+      return b.events.some((e) => e.kind === 'respawned' && /Ada/.test(e.text));
+    });
+    const lt = (await s.api('GET', '/api/lieutenants')).body.lieutenants[0];
+    assert.strictEqual(lt.ref.window, 'lt', 'the ref migrated to the lieutenant window');
+    await sleep(600); // several more ticks — a worker-died would have landed by now
+    assert.ok(fs.existsSync(path.join(fdir, 'bc-lt-ada:w-live.json')), 'the worker window survived the revive');
+    const card = (await s.api('GET', '/api/cards/live')).body;
+    assert.ok(!card.events.some((e) => e.kind === 'worker-died'), 'no false worker-died');
+    const items = (await s.api('GET', '/api/feed?lieutenant=ada')).body.items;
+    assert.ok(!items.some((i) => i.kind === 'worker-died'), 'no worker-died item for the owner');
+  } finally {
+    await s.stop();
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});
+
+test('a dead lieutenant reads dead even while a sibling worker window is alive', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const nowIso = new Date().toISOString();
+  fakeSession(fdir, 'bc-lt-ada:w-busy'); // the busy worker that used to mask the corpse
+  const s = await startServer({
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: TICK, BC_PRWATCH_INTERVAL_MS: '0' },
+    seed: (dir) => seedBoard(dir, {
+      lieutenants: [{
+        id: 'ada', name: 'Ada', color: '#58b6ff', charter: '', chat: [], created: nowIso,
+        // already window-granular, and its window is NOT up
+        ref: { harness: 'fake', session: 'bc-lt-ada', window: 'lt', cwd: '/tmp', resumeId: 'uuid-gone' },
+      }],
+      cards: [{
+        id: 'busy', title: 'Busy', type: 'implementation', owner: 'ada', column: 'working',
+        labels: [], attributes: { repo: 'proj', session: 'bc-lt-ada:w-busy' }, body: '',
+        created: nowIso, updated: nowIso, threadStart: null, pendingOrder: null, events: [], thread: [],
+      }],
+      workers: [
+        { card: 'busy', ref: { harness: 'fake', session: 'bc-lt-ada', window: 'w-busy', cwd: '/tmp', resumeId: 'w1' },
+          worktree: { path: '/tmp/none', tool: 'git' }, branch: 'bc/busy', project: 'proj', spawnedAt: nowIso, done: false },
+      ],
+    }),
+  });
+  try {
+    await until('respawned event', async () => {
+      const b = (await s.api('GET', '/api/board')).body;
+      return b.events.some((e) => e.kind === 'respawned' && /Ada/.test(e.text));
+    });
+    assert.ok(fs.existsSync(path.join(fdir, 'bc-lt-ada:w-busy.json')), 'the worker window survived');
   } finally {
     await s.stop();
     fs.rmSync(fdir, { recursive: true, force: true });

--- a/test/wake.test.js
+++ b/test/wake.test.js
@@ -173,9 +173,13 @@ test('lieutenant.create with spawn: real harness.spawn in the workspace root, re
     assert.match(lt.ref.session, /^bc-[A-Za-z0-9-]+-lt-spawn-bot$/);
     assert.strictEqual(lt.ref.cwd, path.resolve(s.dir)); // spawned in the workspace root
     assert.ok(lt.ref.resumeId, 'resumeId known at birth');
+    // a lieutenant lives in its OWN window of that session — the worker windows
+    // it will host cohabit the session with it (server/names.js)
+    assert.strictEqual(lt.ref.window, 'lt');
+    const key = lt.ref.session + ':' + lt.ref.window;
 
     // launch prompt = doctrine + charter + situating line (recorded by the fake's spawn marker)
-    const rec = JSON.parse(fs.readFileSync(path.join(fdir, lt.ref.session + '.json'), 'utf8'));
+    const rec = JSON.parse(fs.readFileSync(path.join(fdir, key + '.json'), 'utf8'));
     // harness state plumbed through the port is the WORKSPACE's, never global
     assert.strictEqual(rec.stateDir, path.join(s.dir, '.bridge-commander', 'harness'));
     assert.match(rec.prompt, /Lieutenant doctrine/);
@@ -185,7 +189,7 @@ test('lieutenant.create with spawn: real harness.spawn in the workspace root, re
 
     // the ref survives a restart (board is truth) and receives wakes
     await s.api('POST', '/api/feedback', { target: 'lieutenant:spawn-bot', text: 'welcome aboard' });
-    const sends = await waitSends(fdir, lt.ref.session, 1);
+    const sends = await waitSends(fdir, key, 1);
     assert.strictEqual(sends.length, 1);
     assert.match(sends[0].text, /\[bridge-commander\] 1 pending item\(s\)/);
 


### PR DESCRIPTION
# Description

Restarting a lieutenant currently kills every worker in its session, and a busy worker can hide a
dead lieutenant indefinitely — both because the lieutenant's ref names a whole tmux session while
its workers live as windows inside it. Pinning the lieutenant to its own `lt` window fixes both
directions; existing session-only refs migrate in place (the running agent is renamed, never
restarted), so no flag day.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added (supervision regressions over the fake harness, which now models tmux
  session-vs-window granularity; `adoptWindow`'s tmux calls pinned with a stubbed `tryTmux`).
- `node --test test/*.test.js harness/test/*.test.js` — 401/401 green.
- Verified against real tmux in a throwaway session: the session-granular probe read the *worker's*
  pane, the rename sticks (automatic-rename off), and kill-window spared the worker.

## Any specific deployment considerations

- Live lieutenants migrate on the first supervision tick after restart: their first tmux window is
  renamed to `lt`. Worker windows registered on the board are never adopted.
