### PR TITLE
Board speech: a queue, not a shove

### DIFF
--- a/test/voice.test.js
+++ b/test/voice.test.js
@@ -1,0 +1,205 @@
+'use strict';
+// ui/js/voice.js — the board's speech POLICY, which is now mostly a queue: one
+// message at a time, in the order they arrived. speech.js is left REAL
+// underneath (it has its own tests, and faking it would fake away the thing the
+// queue is built on), so what these assert is what the board actually sends: the
+// order of the engine requests, and the fact that there is never a second one in
+// flight.
+//
+// Nothing here waits on speech. Every fake utterance is 240 samples — 10ms of
+// audio — so the queue's "let the buffers finish before the next one" wait is
+// bounded by that. No real clock is raced and no audio is produced.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let speak, stopSpeaking;
+
+const ENGINE = 'http://127.0.0.1:8883';
+const tick = (ms) => new Promise((r) => setTimeout(r, ms));
+// Poll rather than sleep: every test below is waiting for a REQUEST to happen,
+// and a request that never happens should fail loudly, not slowly.
+async function until(what, why, ms = 2000) {
+  for (let waited = 0; waited < ms; waited += 2) {
+    if (what()) return;
+    await tick(2);
+  }
+  assert.fail('timed out waiting for ' + why);
+}
+// toast.js arms a 6s dismiss timer per toast. Nothing here waits for one, but a
+// live timer holds the test runner open long after the assertions are done.
+const realSetTimeout = global.setTimeout;
+global.setTimeout = (fn, ms, ...rest) => {
+  const t = realSetTimeout(fn, ms, ...rest);
+  if (ms >= 1000) t.unref?.();
+  return t;
+};
+
+// ── the page ──────────────────────────────────────────────────────────────
+// One element kind for everything the modules build or look up. It is a real
+// enough tree for toast.js (which counts children and removes the oldest) and
+// for speech.js (which builds its transport and its <audio>).
+const made = [];                  // every element created, which is where toasts are read
+let audioEl = null;               // speech.js makes ONE, for the life of the page
+function el(tag) {
+  const n = {
+    tag, textContent: '', className: '', value: '', type: '', title: '',
+    hidden: true, paused: true, srcObject: null, children: [], parent: null,
+    classList: { toggle() {}, add() {}, remove() {} },
+    play() { n.paused = false; return Promise.resolve(); },
+    pause() { n.paused = true; },
+    querySelectorAll() { return [el('button'), el('button'), el('button')]; },
+    querySelector() { return el('span'); },
+  };
+  n.appendChild = (c) => { c.parent = n; n.children.push(c); return c; };
+  n.append = (...cs) => { cs.forEach(n.appendChild); };
+  n.remove = () => {
+    const i = n.parent ? n.parent.children.indexOf(n) : -1;
+    if (i >= 0) n.parent.children.splice(i, 1);
+  };
+  Object.defineProperty(n, 'firstChild', { get: () => n.children[0] || null });
+  if (tag === 'audio') audioEl = n;
+  return n;
+}
+const byId = {};
+function fakePage() {
+  global.document = {
+    createElement(tag) { const n = el(tag); made.push(n); return n; },
+    getElementById(id) { return (byId[id] ||= el(id)); },
+    head: { appendChild: (n) => n },
+    body: { appendChild: (n) => n },
+  };
+  const store = { 'bc-voice-on': '1', 'bc-tts-voice': 'v1' };   // voice on, a voice picked
+  global.localStorage = {
+    getItem: (k) => (k in store ? store[k] : null),
+    setItem: (k, v) => { store[k] = String(v); },
+    removeItem: (k) => { delete store[k]; },
+  };
+}
+// What the captain was told. mute() is the board's only way to be silent, and it
+// is always a toast — toast.js puts the words in a .tx element.
+const toasts = () => made.filter((n) => n.className === 'tx').map((n) => n.textContent);
+// speech.js's own <audio> — paused is "no sound is leaving the board". It is
+// made once and kept (iOS blesses an element once), so it outlives `made`.
+const speaker = () => audioEl;
+
+// ── the speakers ──────────────────────────────────────────────────────────
+// Enough AudioContext to schedule buffers into. Timing is irrelevant here — the
+// assertions are about requests, not sound.
+class FakeCtx {
+  constructor() { this.state = 'running'; this.destination = {}; }
+  get currentTime() { return 0; }
+  resume() { this.state = 'running'; return Promise.resolve(); }
+  suspend() { this.state = 'suspended'; return Promise.resolve(); }
+  createMediaStreamDestination() { return { stream: { id: 'live' } }; }
+  createBuffer(ch, len, rate) {
+    const data = new Float32Array(len);
+    return { length: len, duration: len / rate, getChannelData: () => data };
+  }
+  createBufferSource() {
+    let cb = null;
+    return {
+      connect() {}, start() { setTimeout(() => cb && cb(), 1); },
+      set onended(f) { cb = f; }, get onended() { return cb; },
+    };
+  }
+}
+
+// ── the engine ────────────────────────────────────────────────────────────
+const asked = [];                 // what was asked of the engine, in the order it left
+let answer;                       // how the engine replies, per test
+const json = (o) => Promise.resolve(new Response(JSON.stringify(o), { status: 200 }));
+// 10ms of audio, in one chunk, over in a microtask.
+function said() {
+  const pcm = new Uint8Array(480);
+  return Promise.resolve(new Response(new ReadableStream({
+    start(c) { c.enqueue(pcm); c.close(); },
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+}
+// A synthesis that is still running: it never ends on its own, only when the
+// board aborts it. This is what "stop while it is speaking" needs.
+function stillGoing(signal) {
+  return Promise.resolve(new Response(new ReadableStream({
+    start(c) {
+      c.enqueue(new Uint8Array(480));
+      signal.addEventListener('abort', () => {
+        try { c.error(new DOMException('aborted', 'AbortError')); } catch (e) {}
+      });
+    },
+  }), { status: 200, headers: { 'x-sample-rate': '24000' } }));
+}
+const refused = (why) => Promise.resolve(new Response(JSON.stringify({ detail: why }), { status: 500 }));
+
+function fakeEngine() {
+  global.fetch = (url, opts = {}) => {
+    if (url === '/api/config') {
+      return json({ voices: null, tts: { enabled: true, url: ENGINE, lang: 'pt', voice: null, params: {} } });
+    }
+    if (url === ENGINE + '/v1/voices') return json({ voices: [{ id: 'v1', name: 'Voice One', langs: ['pt-BR'] }] });
+    if (url === ENGINE + '/v1/audio/speech') {
+      const input = JSON.parse(opts.body).input;
+      asked.push(input);
+      // A real fetch rejects when its signal fires, however far along it is.
+      return Promise.race([answer(input, opts.signal), new Promise((_, rej) =>
+        opts.signal.addEventListener('abort', () => rej(new DOMException('aborted', 'AbortError'))))]);
+    }
+    return Promise.reject(new Error('unexpected fetch: ' + url));
+  };
+}
+
+test.before(async () => {
+  global.window = { AudioContext: FakeCtx };
+  fakePage();
+  fakeEngine();
+  answer = () => said();
+  ({ speak, stopSpeaking } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'voice.js')).href));
+  // The catalogue lands a few promises after import; the board is mute (and says
+  // so) until it does, so every test would otherwise be testing that instead.
+  await until(() => byId['voice-select'].value === 'v1', 'the engine catalogue to land');
+});
+
+// The module is a singleton for the life of the file — a queue left running is
+// the next test's problem, so each one starts from stopped and empty.
+test.beforeEach(async () => {
+  stopSpeaking();
+  await tick(10);
+  asked.length = 0;
+  made.length = 0;
+  answer = () => said();
+});
+
+test('a burst past the cap drops the MIDDLE of the queue and keeps the newest', async () => {
+  ['one', 'two', 'three', 'four', 'five', 'six'].forEach((m) => speak(m, 'monica'));
+
+  await until(() => asked.length >= 4, 'the queue to drain');
+  await tick(20);                                  // …and nothing after it
+  assert.deepEqual(asked, ['one', 'two', 'three', 'six'],
+    'the first three and the NEWEST were spoken; four and five were dropped from the middle');
+  assert.equal(toasts().filter((t) => /skipped/.test(t)).length, 2,
+    'each dropped message was announced — nothing is discarded in silence');
+});
+
+test('stop empties the queue: it does not just silence what is speaking', async () => {
+  answer = (input, signal) => stillGoing(signal);   // the first one is still being said
+  ['one', 'two', 'three'].forEach((m) => speak(m, 'monica'));
+  await until(() => asked.length >= 1, 'the first message to reach the engine');
+
+  stopSpeaking();
+
+  await tick(30);
+  assert.deepEqual(asked, ['one'],
+    'the two that were waiting are gone, not merely postponed until the first ends');
+  assert.equal(speaker().paused, true, 'and what was speaking stopped there and then');
+});
+
+test('a speech that fails toasts, and the queue keeps going', async () => {
+  answer = (input, signal) => (input === 'two' ? refused('engine is out of memory') : said());
+  ['one', 'two', 'three'].forEach((m) => speak(m, 'monica'));
+
+  await until(() => asked.length >= 3, 'the message after the failing one to be spoken');
+  assert.deepEqual(asked, ['one', 'two', 'three'], 'the failure took only its own message down');
+  assert.ok(toasts().some((t) => /speech failed: engine is out of memory/.test(t)),
+    'and the captain was told why he did not hear it: ' + JSON.stringify(toasts()));
+});

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -4,7 +4,8 @@
 // the engine request, the streaming playback, the <audio> the OS can see, the
 // lock screen and the visible transport — and it is the module that was proven
 // on the captain's phone. This file is the board's policy on top of it: WHICH
-// messages get spoken, WHOSE voice speaks them, and the on/off toggle.
+// messages get spoken, WHOSE voice speaks them, WHEN — one at a time, in a
+// queue — and the on/off toggle.
 //
 // There is no second way to speak. When the engine refuses, or no voice is
 // chosen, the board is silent AND says so on screen. It used to fall through to
@@ -47,7 +48,7 @@ export function voiceOptions(keep) {
 }
 function populatePicker() {
   // The workspace may name a voice; that is the board's until the captain picks
-  // another. Nothing at all is a real state, and a loud one — see speakPlain.
+  // another. Nothing at all is a real state, and a loud one — see enqueue.
   const saved = savedVoiceId() || (engine && engine.voice) || '';
   const sorted = sortedVoices(voiceList, voiceFilter, saved);
   voiceSelect.textContent = '';
@@ -86,17 +87,25 @@ function stripForSpeech(text) {
   return stripEmoji(text.replace(/```[\s\S]*?```/g, ' code ').replace(/[`*#\[\]()]/g, ' ').replace(/https?:\S+/g, ' link '));
 }
 
-// ---------- speech sessions ----------
-// One session at a time: a new message supersedes the old (speech.js stops the
-// previous one itself), so the newest is always what you hear. `speaking` is
-// what the per-message speak button toggles against.
-let session = 0;
-let speaking = false;
+// ---------- the speech queue ----------
+// One message at a time, in the order they arrived: the one speaking finishes,
+// the next starts. Asking speech.js to speak while it is speaking does not
+// queue — it stops what it was saying — so a burst of three used to play only
+// the third, with the first two cut mid-sentence. It cost the engine too: an
+// aborted request keeps synthesizing until the disconnect lands, so the overlap
+// was two generations on one GPU, which is what killed voxcpm2 on 27/07.
+//
+// The board never asks for a second speech while one is in flight. Stopping —
+// and turning the voice off, which stops — empties the queue as well: silence
+// means silence, not a pause before the backlog resumes.
+const QUEUE_MAX = 3;      // waiting messages, NOT counting the one being spoken
+const queue = [];         // [{plain, who, voice}], oldest first
+let draining = false;     // a message is being spoken, or is about to be
+let session = 0;          // bumped by stopSpeaking: a drain past its session is stale
 
 // A silence the captain can see. Every way this board can fail to speak comes
 // through here — no path ends in nothing happening.
 function mute(text) {
-  speaking = false;
   toast({ emoji: '🔇', text });
 }
 
@@ -105,37 +114,76 @@ function mute(text) {
 // a shorter wait by throwing the rest of the answer away. Streaming removed the
 // wait, so the cap only truncated: a 2664-character reply stopped mid-sentence,
 // at 45% of itself. Stopping early is the transport's job, not a slice().
-function speakPlain(plain, who) {
-  const my = ++session;
+function enqueue(plain, who) {
   if (!engine) return mute('no speech engine configured — the board cannot speak');
-  const voice = voiceForAuthor(who);
-  if (!voice) return mute('no voice chosen — pick one in settings; the board will not guess');
-  speaking = true;
   // `who` is the author, and it is not decoration: it picks the voice that
   // speaks (each lieutenant may own one) and it is what the phone's lock screen
   // shows, which is where the captain sees WHO is talking while the screen is off.
-  engineSpeak({
-    url: engine.url + '/v1/audio/speech',
-    voice,
-    input: plain,
-    params: engine.params && Object.keys(engine.params).length ? engine.params : undefined,
-    title: who || 'Bridge Commander',
-    artist: 'Bridge Commander',
-  }).then(
-    () => { if (my === session) speaking = false; },
-    (err) => { if (my === session) mute('speech failed: ' + (err && err.message ? err.message : err)); },
-  );
+  const voice = voiceForAuthor(who);
+  if (!voice) return mute('no voice chosen — pick one in settings; the board will not guess');
+  queue.push({ plain, who, voice });
+  // Over the top, the MIDDLE goes and the newest stays. A burst of ten cannot
+  // become ten minutes of backlog, and by the time the board is that far behind
+  // the newest message is the one worth hearing — the ones it skips over are
+  // already answered by the one it keeps.
+  if (queue.length > QUEUE_MAX) {
+    const n = queue.splice(QUEUE_MAX - 1, queue.length - QUEUE_MAX).length;
+    toast({ emoji: '⏭️', text: n + (n > 1 ? ' messages' : ' message') + ' skipped — too many waiting to be spoken' });
+  }
+  // Straight into drain(), not through a promise: on the paths that ride a real
+  // user gesture (the speak button, the voice test) speech.js needs its play()
+  // inside the tap, and drain() reaches engineSpeak() before its first await.
+  if (!draining) drain();
+}
+
+// What is still coming out of the speakers after the engine's last byte. speak()
+// resolves when the STREAM ends, not when the sound does: the buffers are
+// scheduled ahead, so an engine faster than realtime finishes the request while
+// most of the message is still unheard. Starting the next one then would stop
+// those buffers — exactly the cut this queue exists to prevent. bytes/rate IS
+// the length of the audio, and speech.js hands both back.
+function tailMs(said, heardAt) {
+  if (!said || said.stopped || !said.bytes || !heardAt) return 0;
+  return Math.max(0, (said.bytes / 2 / (said.rate || 24000)) * 1000 - (performance.now() - heardAt));
+}
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function drain() {
+  draining = true;
+  try {
+    while (queue.length) {
+      const { plain, who, voice } = queue.shift();
+      const my = session;
+      let heardAt = 0;
+      try {
+        const said = await engineSpeak({
+          url: engine.url + '/v1/audio/speech',
+          voice,
+          input: plain,
+          params: engine.params && Object.keys(engine.params).length ? engine.params : undefined,
+          title: who || 'Bridge Commander',
+          artist: 'Bridge Commander',
+          onFirstSound: () => { heardAt = performance.now(); },
+        });
+        if (my === session) await wait(tailMs(said, heardAt));
+      } catch (err) {
+        // One message lost, said out loud — and the queue moves on. A refusal in
+        // the middle of a burst cannot take the rest of the burst with it.
+        if (my === session) mute('speech failed: ' + (err && err.message ? err.message : err));
+      }
+    }
+  } finally { draining = false; }
 }
 export function speak(text, who) {
   if (!voiceOn) return;
   const plain = stripForSpeech(text);
   if (!plain) return;
   manualSpeakingKey = null;                  // an auto-speak supersedes any manual toggle state
-  speakPlain(plain, who);
+  enqueue(plain, who);
 }
 export function stopSpeaking() {
-  session++;
-  speaking = false;
+  session++;              // whatever the engine still owes us is stale
+  queue.length = 0;       // stop stops what is waiting too, not just what is heard
   engineStop();
 }
 
@@ -143,16 +191,18 @@ export function stopSpeaking() {
 // toggle: this call happens inside a real user gesture (the speak-button click),
 // so the speak() it fires is itself the gesture that unlocks audio — no separate
 // primer needed. Returns true if it spoke, false if there was nothing to say.
-// Clicking again while this message is speaking stops it (cheap toggle).
+// Clicking again while this message is speaking — or while it waits its turn —
+// stops it (cheap toggle), and with it everything else in the queue: stop means
+// stop, and there is one stop.
 let manualSpeakingKey = null;
 export function speakMessage(text, key, who) {
-  if (key != null && manualSpeakingKey === key && speaking) {
+  if (key != null && manualSpeakingKey === key && draining) {
     manualSpeakingKey = null; stopSpeaking(); return false; // toggle off
   }
   const plain = stripForSpeech(text);
   if (!plain) return false;
   manualSpeakingKey = key != null ? key : null;
-  speakPlain(plain, who);
+  enqueue(plain, who);
   return true;
 }
 function setVoiceOn(on) {
@@ -170,7 +220,7 @@ function setVoiceOn(on) {
 // real in-gesture utterance is itself the unlock.
 voiceBtn.onclick = () => setVoiceOn(!voiceOn);
 try { if (localStorage.getItem(VOICE_ON_KEY) === '1') setVoiceOn(true); } catch (e) {} // restore toggle
-document.getElementById('voice-test').onclick = () => speakPlain('Hello, this is my voice.');
+document.getElementById('voice-test').onclick = () => enqueue('Hello, this is my voice.');
 
 // ---------- speak only NEW lieutenant messages ----------
 let firstLoad = true;


### PR DESCRIPTION
`ui/js/voice.js` only. The board now speaks one message at a time, in arrival order.

## What was wrong

A new message superseded the one being spoken (`const my = ++session`) — speech.js stops what it is saying when asked to speak again. A burst of three played only the third, cutting the first two mid-sentence. And the aborted request keeps the engine synthesizing until the disconnect lands, so the overlap was two generations on one GPU.

## Waiting on `speak()` is not enough

It resolves when the **stream** ends, not when the sound does — buffers are scheduled ahead. Measured against a fake engine at 5× realtime: request 0.64s, audio 3s. Chaining on the promise alone would still cut 2.4s off every message. `bytes / 2 / rate` is the audio length and speech.js returns both, so the queue waits out what is left after the last byte (`onFirstSound` marks when the sound started). No change to `speech.js`.

## Decisions

- **Cap: 3 waiting**, not counting the one speaking. At ~20-30s a message that is already a minute and a half of lag; past that the board is reading old news. When it overflows, **the middle is dropped and the newest kept**, with a toast naming how many were skipped.
- **Stop empties the queue.** So does turning the voice off (it stops). Silence means silence, not a pause before the backlog resumes.
- **The per-message speak button is still a toggle** — it enqueues instead of shoving, and clicking it again stops everything, as it did before.
- **A failure toasts and the queue moves on** (`mute()` already toasts); one refusal cannot take the rest of the burst with it.

## Proved in the browser

`dev/ui-server.js` on a private port against a fake engine that streams 3s of audio in 0.64s (5× realtime) and refuses any input containing BOOM. Engine-side request log, times relative to the first request:

| scenario | before | after |
|---|---|---|
| burst of three | 3 requests at `0.00s` — three concurrent generations, only the third audible | `0.00s` ONE, `3.04s` TWO, `6.09s` THREE — never two at once, none cut |
| stop during the second | — | ONE, TWO, then nothing; the third never requested |
| voice off during the second | — | same: ONE, TWO, silence |
| failing middle | — | ONE, BOOM refused → toast `speech failed: engine refuses this one`, THREE spoken immediately after |
| six in a burst (cap 3) | — | ONE, TWO, THREE, **SIX** — FOUR and FIVE dropped, two skip toasts |

## Tests

`test/voice.test.js`, in the style of `test/speech.test.js` — fake page, fake engine, **real `speech.js`** underneath (faking it would fake away the thing the queue is built on). What is asserted is what the board actually sends the engine, and in what order:

1. a burst past the cap drops the MIDDLE and keeps the newest — `one, two, three, six`, plus a skip toast per drop
2. stop empties the queue, it does not just silence what is speaking
3. a speech that fails toasts, and the one behind it still speaks

No audio and no clock to race: every fake utterance is 240 samples (10ms), so the queue's wait-for-the-buffers is bounded by that. The file runs in ~0.2s. All three fail against the pre-queue `voice.js`, each on its own assertion.

`node --test test/*.test.js harness/test/*.test.js` -> 404 pass.

## Known edge

Pausing from the lock screen freezes playback but not the queue's clock, so a long pause lets the next message start. Rare, and it never overlaps — it supersedes, which is what pause+ignore would have done anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
