### PR TITLE
Lieutenant switcher orders by most recent conversation

### DIFF
--- a/test/ltswitcher-sort.test.js
+++ b/test/ltswitcher-sort.test.js
@@ -1,0 +1,74 @@
+'use strict';
+// ui/js/state.js — lieutenantsByRecent(), the order the lieutenant switcher
+// captures when its dropdown opens: most recent conversation first, the silent
+// ones last by name. Pure derivation over the doc, so it's imported directly
+// (filters.test.js pattern). The FREEZE lives in ltswitcher.js, which touches
+// the DOM at import — it is exercised in the browser, not here.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let S, lieutenantsByRecent;
+test.before(async () => {
+  ({ S, lieutenantsByRecent } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'state.js')).href));
+});
+
+function seed(lieutenants) { S.doc = { lieutenants }; }
+function order() { return lieutenantsByRecent().map((l) => l.id).join(' '); }
+
+test('no doc: empty, no throw', () => {
+  S.doc = null;
+  assert.strictEqual(order(), '');
+});
+
+test('most recent chat message first, regardless of registration order', () => {
+  seed([
+    { id: 'monica', name: 'Monica', chat: [{ ts: '2026-07-27T10:00:00Z' }] },
+    { id: 'rex', name: 'Rex', chat: [{ ts: '2026-07-27T09:00:00Z' }] },
+    { id: 'quill', name: 'Quill', chat: [{ ts: '2026-07-27T12:00:00Z' }] },
+  ]);
+  assert.strictEqual(order(), 'quill monica rex');
+});
+
+test('the last message wins even if the chat is not in timestamp order', () => {
+  seed([
+    { id: 'a', name: 'A', chat: [{ ts: '2026-07-27T12:00:00Z' }, { ts: '2026-07-27T08:00:00Z' }] },
+    { id: 'b', name: 'B', chat: [{ ts: '2026-07-27T10:00:00Z' }] },
+  ]);
+  assert.strictEqual(order(), 'a b');
+});
+
+test('never spoke goes last, in name order — no oscillating between equals', () => {
+  seed([
+    { id: 'z', name: 'Zoe' },
+    { id: 'a', name: 'Ada', chat: [] },
+    { id: 'm', name: 'Moss', chat: [{ ts: '2026-07-27T09:00:00Z' }] },
+    { id: 'b', name: 'Bo', chat: [] },
+  ]);
+  assert.strictEqual(order(), 'm a b z');
+});
+
+test('ties break by name, and the same doc always yields the same order', () => {
+  seed([
+    { id: 'r', name: 'Rex', chat: [{ ts: '2026-07-27T09:00:00Z' }] },
+    { id: 'a', name: 'Ada', chat: [{ ts: '2026-07-27T09:00:00Z' }] },
+  ]);
+  assert.strictEqual(order(), 'a r');
+  assert.strictEqual(order(), 'a r');
+});
+
+test('nameless lieutenants fall back to id for the tie-break', () => {
+  seed([{ id: 'zed' }, { id: 'abe' }]);
+  assert.strictEqual(order(), 'abe zed');
+});
+
+test('does not mutate the doc order', () => {
+  seed([
+    { id: 'old', name: 'Old', chat: [{ ts: '2026-07-27T08:00:00Z' }] },
+    { id: 'new', name: 'New', chat: [{ ts: '2026-07-27T12:00:00Z' }] },
+  ]);
+  lieutenantsByRecent();
+  assert.deepStrictEqual(S.doc.lieutenants.map((l) => l.id), ['old', 'new']);
+});

--- a/ui/js/ltswitcher.js
+++ b/ui/js/ltswitcher.js
@@ -4,7 +4,7 @@
 // conversations in place, without leaving the chat. The rows also carry the
 // per-lieutenant controls that used to live on the lane chips: 👁 watch
 // terminal, ⋯ actions (settings / retire), and the ＋ lieutenant row.
-import { S, cards, lieutenants, lieutenant, lieutenantColor, lieutenantAvatar, lieutenantUnread, targetOwedState, targetOwedStale } from './state.js';
+import { S, cards, lieutenants, lieutenantsByRecent, lieutenant, lieutenantColor, lieutenantAvatar, lieutenantUnread, targetOwedState, targetOwedStale } from './state.js';
 import { api } from './api.js';
 import { esc, setHtmlIfChanged, ctxBarHtml, owedIndHtml } from './util.js';
 import { avatarHtml, avatarGridHtml, wireAvatarGrid } from './avatars.js';
@@ -18,6 +18,11 @@ const panelEl = document.getElementById('lt-switcher');
 const menuEl = document.getElementById('move-menu'); // shared with the board's move menu
 
 let open = false;
+// The row order, in ids, captured when the panel opens and FROZEN while it
+// stays open. The panel re-renders on every board push, so a message landing
+// mid-tap would otherwise re-sort the rows under the captain's finger and he
+// taps the wrong lieutenant. Row content stays live; only the order is pinned.
+let frozenOrder = [];
 export function ltSwitcherOpen() { return open; }
 export function closeLtSwitcher() { if (open) { open = false; renderLtSwitcher(); } }
 
@@ -26,6 +31,7 @@ export function closeLtSwitcher() { if (open) { open = false; renderLtSwitcher()
 trigEl.onclick = () => {
   if (!lieutenants().length) { openNewLieutenant(); return; }
   open = !open;
+  if (open) frozenOrder = lieutenantsByRecent().map((l) => l.id);
   renderLtSwitcher();
 };
 // tap-out closes (the trigger's own click toggled already — exclude it)
@@ -82,12 +88,20 @@ function rowHtml(l) {
     '</div>';
 }
 
+// The frozen order, resolved against the live doc: retired lieutenants drop
+// out, and any that appeared since the panel opened land at the end.
+function panelLieutenants() {
+  const frozen = new Set(frozenOrder);
+  return frozenOrder.map(lieutenant).filter(Boolean)
+    .concat(lieutenants().filter((l) => !frozen.has(l.id)));
+}
+
 // Rendered on every board push while open, so unread/owed/context stay live.
 export function renderLtSwitcher() {
   trigEl.setAttribute('aria-expanded', open ? 'true' : 'false');
   panelEl.hidden = !open;
   if (!open) return;
-  setHtmlIfChanged(panelEl, lieutenants().map(rowHtml).join('') +
+  setHtmlIfChanged(panelEl, panelLieutenants().map(rowHtml).join('') +
     '<button class="lts-add" type="button">＋ lieutenant</button>');
 }
 

--- a/ui/js/state.js
+++ b/ui/js/state.js
@@ -33,6 +33,23 @@ export function card(id) { return cards().find((c) => c.id === id); }
 export function columns() { return (S.doc && S.doc.columns) || []; }
 export function lieutenants() { return (S.doc && S.doc.lieutenants) || []; }
 export function lieutenant(id) { return lieutenants().find((l) => l.id === id); }
+// Lieutenants by most recent conversation — the chat's last message first, and
+// whoever never spoke at the end, ordered by name so equals never swap places.
+// The switcher freezes this at open (ltswitcher.js): rows must not slide under
+// a finger mid-tap.
+export function lieutenantsByRecent() {
+  return lieutenants().slice().sort((a, b) => {
+    const ta = lieutenantChatTs(a), tb = lieutenantChatTs(b);
+    if (ta !== tb) return ta < tb ? 1 : -1;
+    return (a.name || a.id).localeCompare(b.name || b.id);
+  });
+}
+function lieutenantChatTs(l) {
+  const chat = (l && l.chat) || [];
+  let ts = '';
+  for (const m of chat) if (m.ts > ts) ts = m.ts;
+  return ts;
+}
 // The lieutenant behind an event's `actor`, if any. The server stamps chat-say
 // events with the author NAME (not the id — server.js's msg.author), so match
 // both; 'user'/'server'/'worker' actors resolve to nothing.


### PR DESCRIPTION
The lieutenant dropdown rendered `lieutenants()` raw — registration order, so whoever was created first stayed on top forever.

It now opens ordered by the last message in each lieutenant's chat, descending; lieutenants that never spoke go last, by name, so equals never swap.

**The order freezes while the dropdown is open.** The panel re-renders on every board push (`setHtmlIfChanged`), so re-sorting per render would slide the rows under the captain's finger when a message lands mid-tap — on a phone that means tapping the wrong lieutenant. The order is captured at open; row content (unread, context, model) stays live.

- `state.js`: `lieutenantsByRecent()` — pure derivation, 7 unit tests.
- `ltswitcher.js`: freeze the id order at open; retired lieutenants drop out, new ones land at the end.

Proven in `dev/ui-server.js` (own port): fixture order monica/rex/ada/quill opens as monica/quill/ada/rex; a reply arriving for rex with the panel open leaves the rows untouched while its unread goes 0 → 1; closing and reopening puts rex on top; two fresh lieutenants sit at the end in name order.

Suite: 423/423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)