### PR TITLE
One door for writing a co-edited artifact, and the screen it tells

### DIFF
--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -40,6 +40,32 @@ handoff so the captain reads the result, not the history. Progress belongs in ev
 Questions on a card go through its thread (`bc-axi say card:<id>`); you are the interlocutor
 for your cards' threads, always.
 
+## A co-edited artifact is written through the board, never straight to disk
+
+A card artifact can have the captain's **editor open on it right now** — the board's file
+screen is a real editor and he saves from it. So an artifact under joint editing is not an
+ordinary file. Read and write it through the board:
+
+```
+bc-axi artifact read <uri> > /tmp/a.md            # content on stdout, "version: <sha256>" on stderr
+# ...edit /tmp/a.md...
+bc-axi artifact write <uri> --file /tmp/a.md --version <that version>
+```
+
+The version is the whole point. If he saved while you were thinking, the write is **refused**
+(409, nothing written, exit 1) and you redo your change on top of his text. Writing the file
+directly checks nothing and destroys his edit silently. A write that lands also updates his
+open editor live, with the changed lines marked — that is why the door is worth using even
+when nobody is racing you. Hand a worker an artifact to edit and this goes in its brief.
+
+**Scope: only files under joint editing** — card artifacts. Worktree code, reports, notes,
+anything nobody has open on the board: ordinary files, ordinary tools. There is no general
+rule here and there should not be one.
+
+This is **discipline, not mechanism**. Your file-writing tool still exists and still reaches
+those paths; nothing makes the wrong door impossible. That is exactly why the rule is written
+down.
+
 ## Conversation etiquette
 
 The captain talks to you through your chats — main chat and card threads — and expects

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -50,7 +50,7 @@ const opts = {
   level: null, kind: null, actor: null, reason: null, note: null, attrs: [], labels: [], json: false,
   worker: null, ttl: null, spawn: false, harness: null,
   mode: null, briefFile: null, resume: false, outcome: null, model: null, effort: null, park: false,
-  uri: null,
+  uri: null, file: null, version: null,
 };
 const positional = [];
 for (let i = 0; i < argv.length; i++) {
@@ -90,11 +90,13 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--park') opts.park = true;
   else if (a === '--outcome') opts.outcome = argv[++i];
   else if (a === '--uri') opts.uri = argv[++i];
+  else if (a === '--file') opts.file = argv[++i];
+  else if (a === '--version') opts.version = argv[++i];
   else positional.push(a);
 }
 let cmd = positional.shift();
 // Two-word verbs mirror the DNA operation names: `card create`, `lieutenant list`, …
-if ((cmd === 'card' || cmd === 'lieutenant' || cmd === 'project' || cmd === 'worker') && positional.length) cmd = cmd + ' ' + positional.shift();
+if ((cmd === 'card' || cmd === 'lieutenant' || cmd === 'project' || cmd === 'worker' || cmd === 'artifact') && positional.length) cmd = cmd + ' ' + positional.shift();
 // Three-word verb: `card artifact add|rm`.
 if (cmd === 'card artifact' && positional.length) cmd = cmd + ' ' + positional.shift();
 
@@ -161,8 +163,15 @@ function request(method, urlPath, body, timeoutMs) {
       res.on('data', (c) => (out += c));
       res.on('end', () => {
         let parsed; try { parsed = JSON.parse(out); } catch (e) { parsed = out; }
-        if (res.statusCode >= 400) reject(new Error('HTTP ' + res.statusCode + ': ' + out));
-        else resolve(parsed);
+        if (res.statusCode >= 400) {
+          // The status and the parsed body ride on the error: a caller that has
+          // something specific to say about one status (the artifact write's
+          // 409) can, and everything else still prints the raw line.
+          const err = new Error('HTTP ' + res.statusCode + ': ' + out);
+          err.status = res.statusCode;
+          err.body = parsed;
+          reject(err);
+        } else resolve(parsed);
       });
     });
     req.on('timeout', () => { req.destroy(new Error('timeout')); });
@@ -647,6 +656,55 @@ async function cmdArtifactRemove() {
   console.log((r.removed ? 'removed' : 'not present') + ' artifact -> ' + id + ': ' + opts.uri);
 }
 
+// ---------- artifact read / write (the one door for a co-edited artifact) ----------
+// A card artifact can have the captain's editor open on it RIGHT NOW. Writing it
+// with a plain file write is a lost update waiting to happen: it checks nothing,
+// tells nobody. These two go through the server, which means the same version
+// check the captain's save gets — and the same 409 when the file moved.
+//
+// The honest cycle is three steps and the middle one is yours:
+//   bc-axi artifact read <uri> > /tmp/a.md      # prints the version on stderr
+//   ...edit /tmp/a.md...
+//   bc-axi artifact write <uri> --file /tmp/a.md --version <that version>
+async function cmdArtifactRead() {
+  const uri = positional[0];
+  if (!uri) {
+    die('usage: bc-axi artifact read <uri> [--json]\n' +
+      '  Read a card artifact THROUGH the board (uri exactly as the card lists it).\n' +
+      '  Content on stdout, "version: <sha256>" on stderr — hand that version back to\n' +
+      '  artifact write. --json prints {name, version, content} on stdout instead.');
+  }
+  const r = await request('GET', '/api/artifact?uri=' + encodeURIComponent(uri));
+  if (opts.json) return console.log(JSON.stringify({ name: r.name, version: r.version, content: r.content }, null, 2));
+  process.stdout.write(r.content);
+  console.error('version: ' + r.version);
+}
+async function cmdArtifactWrite() {
+  const uri = positional[0];
+  if (!uri || !opts.file || !opts.version) {
+    die('usage: bc-axi artifact write <uri> --file <f|-> --version <sha256>\n' +
+      '  Write a card artifact THROUGH the board — the ONLY way to write one that\n' +
+      '  someone may have open in the editor. --version is the one artifact read\n' +
+      '  handed you: if the file moved since, NOTHING is written and this exits 1.\n' +
+      '  (No --version on purpose: a write that re-reads the version itself would\n' +
+      '  silently overwrite whatever landed while you were thinking.)');
+  }
+  const content = readInput(opts.file);
+  let r;
+  try {
+    r = await request('PUT', '/api/artifact', { uri, content, version: opts.version });
+  } catch (e) {
+    if (e.status !== 409) throw e;
+    // NEVER swallowed: the whole point of the door is that the writer finds out.
+    const now = (e.body && e.body.version) || '?';
+    die('NOT WRITTEN — ' + uri + ' changed on disk since version ' + opts.version + '.\n' +
+      '  it is now at version ' + now + ' (someone else, probably the captain, wrote it).\n' +
+      '  Re-read it, redo your change on top of THAT text, and write with the new version:\n' +
+      '    bc-axi artifact read ' + uri);
+  }
+  console.log('wrote ' + uri + '\n  ' + r.bytes + ' bytes, version ' + r.version);
+}
+
 // ---------- card.start / workers (F5) ----------
 async function cmdStart() {
   const id = positional[0];
@@ -954,6 +1012,7 @@ const commands = {
   'card archive': cmdArchive, 'card restore': cmdRestore, 'card show': cmdShow,
   'card start': cmdStart, 'card park': cmdCardPark,
   'card artifact add': cmdArtifactAdd, 'card artifact rm': cmdArtifactRemove,
+  'artifact read': cmdArtifactRead, 'artifact write': cmdArtifactWrite,
   'worker signal': cmdWorkerSignal, 'worker done': cmdWorkerDone, 'worker send': cmdWorkerSend,
   'worker pause': cmdWorkerPause,
   show: cmdShow, // alias for card show
@@ -1029,6 +1088,16 @@ if (!commands[cmd]) {
     '                                         promote a file to the card\'s curated artifacts list\n' +
     '                                         (deliberate — a chat upload alone never does this). Idempotent\n' +
     '  card artifact rm <card-id> --uri <...>  remove an artifact entry by uri\n' +
+    '\nartifact (co-edited files — the captain may have one open RIGHT NOW):\n' +
+    '  artifact read <uri> [--json]           read a card artifact through the board: content on\n' +
+    '                                         stdout, "version: <sha256>" on stderr\n' +
+    '  artifact write <uri> --file <f|-> --version <sha256>\n' +
+    '                                         write it back through the board — the ONLY way to\n' +
+    '                                         write an artifact someone may be editing. A stale\n' +
+    '                                         --version writes NOTHING and exits 1 (never silent);\n' +
+    '                                         a write that lands updates the captain\'s open editor\n' +
+    '                                         live. Writing the file directly on disk instead skips\n' +
+    '                                         both — see DOCTRINE.md\n' +
     '  worker send <card-id> "<instructions>" [--text-file f|-]\n' +
     '                                         hand a LIVE worker new instructions: typed into its\n' +
     '                                         session with verified submission (run by the lieutenant)\n' +

--- a/server/server.js
+++ b/server/server.js
@@ -766,10 +766,18 @@ function setStatus(card, body) {
 
 // ---------- SSE clients ----------
 const sseClients = new Set();
-function broadcast() {
-  const payload = 'event: board\ndata: ' + JSON.stringify(publicBoard('user')) + '\n\n';
+function sseSend(event, data) {
+  const payload = 'event: ' + event + '\ndata: ' + JSON.stringify(data) + '\n\n';
   for (const res of sseClients) res.write(payload);
 }
+function broadcast() { sseSend('board', publicBoard('user')); }
+// A file an editor may have open changed on disk (through PUT /api/artifact —
+// the one door). Tiny event on the SAME stream, not a channel of its own: which
+// uri, which version now, and `by` = the writer's own client tag (a random
+// per-page string the browser sends, absent for a CLI write) so the tab that
+// just saved recognizes its echo instead of flashing at itself. The screen
+// fetches the content itself if it cares.
+function broadcastArtifact(uri, version, by) { sseSend('artifact', { uri, version, by: by || '' }); }
 
 // ---------- pane hub (👁 peek: live pane frames over a per-target SSE) ----------
 // The harness port's OPTIONAL openPane capability, ref-counted per pane key:
@@ -2306,7 +2314,11 @@ const server = http.createServer(async (req, res) => {
     //   - attachment:// is immutable: an upload is the record of what was sent.
     // Lost-update guard: the client sends the version it read. If disk has
     // moved since, nothing is written and the answer is 409 carrying what is
-    // there now — the captain's text stays on his screen either way.
+    // there now — the captain's text stays on his screen either way. It applies
+    // to EVERY writer, agent included (`bc-axi artifact write`): the door is
+    // locked on both sides or it is not locked.
+    // A write that lands also announces itself on the board SSE (event
+    // `artifact`), so an editor already open on the file follows along.
     if (route === 'PUT /api/artifact') {
       let raw;
       try { raw = await readBodyUpto(req, ARTIFACT_MAX_BYTES + 65536); }
@@ -2352,7 +2364,12 @@ const server = http.createServer(async (req, res) => {
         try { fs.unlinkSync(tmp); } catch (e2) {}
         return sendJson(res, 500, { error: 'write failed: ' + e.message });
       }
-      return sendJson(res, 200, { ok: true, version: sha256(next), bytes: next.length });
+      const newVersion = sha256(next);
+      // Whoever has this file open hears about it right away — that is what
+      // makes four hands four hands instead of two taking turns around a
+      // reload button. The writer's own client recognizes the echo.
+      broadcastArtifact(uri, newVersion, String(body.client || ''));
+      return sendJson(res, 200, { ok: true, version: newVersion, bytes: next.length });
     }
 
     // ----- chat attachments (uploads) -----

--- a/test/artifact-live.test.js
+++ b/test/artifact-live.test.js
@@ -1,0 +1,218 @@
+'use strict';
+// The one door for writing a co-edited artifact, and the screen it tells.
+//
+// PR #79 locked the artifact write on ONE side: the captain saves through
+// PUT /api/artifact and gets a 409 when the file moved, while an agent wrote the
+// same file straight to disk, checking nothing and telling nobody. This suite
+// pins the other side shut and the live update open:
+//   - `bc-axi artifact read/write` go through the server, so the agent gets the
+//     SAME version check — and a refused write is REPORTED (exit 1), never
+//     swallowed, which is the one failure that would make this worse than before;
+//   - a write that lands announces itself on the board SSE (event `artifact`),
+//     carrying the writer's client tag so the tab that saved ignores its own echo;
+//   - changedLines is what turns "it changed" into "these lines changed".
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { pathToFileURL } = require('node:url');
+const { startServerWithLieutenant, withOwner, runCli } = require('./helper');
+
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+
+async function cardWithArtifact(s, uri, label) {
+  const cr = await s.api('POST', '/api/cards', withOwner({ title: 'Deliverable' }));
+  assert.strictEqual(cr.status, 200, JSON.stringify(cr.body));
+  const add = await s.api('POST', '/api/cards/' + cr.body.card.id + '/artifacts', { uri, label });
+  assert.strictEqual(add.status, 200, JSON.stringify(add.body));
+  return { id: cr.body.card.id, uri: add.body.artifact.uri };
+}
+
+// Keep an SSE stream open and pull frames one at a time; next(ms) resolves the
+// next non-ping frame as {event, data}, or null when the window closes quiet.
+async function sseReader(base) {
+  const res = await fetch(base + '/api/events');
+  assert.strictEqual(res.status, 200);
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  let pending = null;
+  async function next(timeoutMs) {
+    const deadline = Date.now() + timeoutMs;
+    for (;;) {
+      const end = buf.indexOf('\n\n');
+      if (end !== -1) {
+        const frame = buf.slice(0, end);
+        buf = buf.slice(end + 2);
+        const event = (/^event: (.*)$/m.exec(frame) || [])[1];
+        if (event === 'ping') continue;
+        const raw = (/^data: (.*)$/m.exec(frame) || [])[1];
+        return { event, data: raw ? JSON.parse(raw) : null };
+      }
+      const left = deadline - Date.now();
+      if (left <= 0) return null;
+      if (!pending) pending = reader.read();
+      const r = await Promise.race([pending, new Promise((ok) => setTimeout(() => ok('timeout'), left))]);
+      if (r === 'timeout') return null;
+      pending = null;
+      if (r.done) return null;
+      buf += dec.decode(r.value, { stream: true });
+    }
+  }
+  return { next, close: () => reader.cancel().catch(() => {}) };
+}
+
+test('a landed write announces itself on the board SSE — uri, new version, and who wrote it', async () => {
+  const s = await startServerWithLieutenant();
+  const sse = await sseReader(s.base);
+  try {
+    const file = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(file, 'one\n');
+    const { uri } = await cardWithArtifact(s, 'file://' + file, 'brief');
+    assert.strictEqual((await sse.next(2000)).event, 'board'); // the on-connect hello
+    assert.strictEqual((await sse.next(2000)).event, 'board'); // card created
+    assert.strictEqual((await sse.next(2000)).event, 'board'); // artifact promoted
+
+    const v = (await s.api('GET', '/api/artifact?uri=' + encodeURIComponent(uri))).body.version;
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'two\n', version: v, client: 'tab-7' });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+
+    const ev = await sse.next(2000);
+    assert.strictEqual(ev.event, 'artifact', 'the write is announced on the stream that already exists');
+    assert.strictEqual(ev.data.uri, uri);
+    assert.strictEqual(ev.data.version, sha256('two\n'), 'the new version, so an open editor can tell it from its own');
+    assert.strictEqual(ev.data.by, 'tab-7', 'the writer is named — that is how a tab ignores its own echo');
+    assert.strictEqual(await sse.next(400), null, 'and nothing else — no board re-push for a file write');
+  } finally {
+    sse.close();
+    await s.stop();
+  }
+});
+
+test('a REFUSED write announces nothing — no phantom update on anybody\'s screen', async () => {
+  const s = await startServerWithLieutenant();
+  const sse = await sseReader(s.base);
+  try {
+    const file = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(file, 'on disk\n');
+    const { uri } = await cardWithArtifact(s, 'file://' + file, 'brief');
+    while (await sse.next(300)) {} // drain the board pushes from the setup
+
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'nope\n', version: sha256('stale') });
+    assert.strictEqual(put.status, 409);
+    assert.strictEqual(await sse.next(500), null, 'nothing was written, so nothing is announced');
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'on disk\n');
+  } finally {
+    sse.close();
+    await s.stop();
+  }
+});
+
+test('cli: artifact read hands out content + version; write with it lands', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const file = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(file, '# brief\n\noriginal\n');
+    const { uri } = await cardWithArtifact(s, 'file://' + file, 'brief');
+    const args = ['--workspace', s.dir, '--port', String(s.port)];
+
+    const read = await runCli(['artifact', 'read', uri, ...args]);
+    assert.strictEqual(read.code, 0, read.stderr);
+    assert.strictEqual(read.stdout, '# brief\n\noriginal\n', 'content on stdout, byte for byte');
+    const version = (/version: ([0-9a-f]{64})/.exec(read.stderr) || [])[1];
+    assert.strictEqual(version, sha256('# brief\n\noriginal\n'), 'the version is on stderr, ready to hand back');
+
+    // --json is the same thing in one piece, for a caller that would rather parse
+    const asJson = await runCli(['artifact', 'read', uri, '--json', ...args]);
+    assert.deepStrictEqual(JSON.parse(asJson.stdout), { name: 'brief.md', version, content: '# brief\n\noriginal\n' });
+
+    const edited = path.join(s.dir, 'edited.md');
+    fs.writeFileSync(edited, '# brief\n\nrewritten by the agent\n');
+    const wrote = await runCli(['artifact', 'write', uri, '--file', edited, '--version', version, ...args]);
+    assert.strictEqual(wrote.code, 0, wrote.stderr);
+    assert.match(wrote.stdout, /wrote .*brief\.md/);
+    assert.match(wrote.stdout, new RegExp(sha256('# brief\n\nrewritten by the agent\n')));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), '# brief\n\nrewritten by the agent\n');
+  } finally {
+    await s.stop();
+  }
+});
+
+// THE defect this card exists to prevent: a write that did not happen and does
+// not say so. The exit code and the words both have to carry it.
+test('cli: writing with a stale version writes NOTHING and says so loudly (exit 1)', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const file = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(file, 'as the agent read it\n');
+    const { uri } = await cardWithArtifact(s, 'file://' + file, 'brief');
+    const args = ['--workspace', s.dir, '--port', String(s.port)];
+    const stale = (/version: ([0-9a-f]{64})/.exec((await runCli(['artifact', 'read', uri, ...args])).stderr) || [])[1];
+
+    // the captain saves while the agent is thinking
+    const captain = 'the captain rewrote this paragraph\n';
+    fs.writeFileSync(file, captain);
+
+    const mine = path.join(s.dir, 'mine.md');
+    fs.writeFileSync(mine, 'the agent version\n');
+    const r = await runCli(['artifact', 'write', uri, '--file', mine, '--version', stale, ...args]);
+    assert.strictEqual(r.code, 1, 'a refused write is a FAILED command, not a quiet no-op');
+    assert.match(r.stderr, /NOT WRITTEN/, 'and it says so in words');
+    assert.match(r.stderr, new RegExp(sha256(captain)), 'naming the version that is there now');
+    assert.match(r.stderr, /artifact read/, 'and what to do about it');
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), captain, "the captain's text survives untouched");
+
+    // re-read, redo on top, write with the new version: that lands
+    const fresh = (/version: ([0-9a-f]{64})/.exec((await runCli(['artifact', 'read', uri, ...args])).stderr) || [])[1];
+    fs.writeFileSync(mine, captain + 'plus the agent line\n');
+    const again = await runCli(['artifact', 'write', uri, '--file', mine, '--version', fresh, ...args]);
+    assert.strictEqual(again.code, 0, again.stderr);
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), captain + 'plus the agent line\n');
+  } finally {
+    await s.stop();
+  }
+});
+
+test('cli: artifact write refuses to guess — no --version means no write', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    const file = path.join(s.dir, 'brief.md');
+    fs.writeFileSync(file, 'untouched\n');
+    const { uri } = await cardWithArtifact(s, 'file://' + file, 'brief');
+    const args = ['--workspace', s.dir, '--port', String(s.port)];
+    const mine = path.join(s.dir, 'mine.md');
+    fs.writeFileSync(mine, 'mine\n');
+
+    const r = await runCli(['artifact', 'write', uri, '--file', mine, ...args]);
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /usage: bc-axi artifact write/);
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'untouched\n');
+
+    // and the server's own guards still answer through the CLI: an unlisted path
+    const secret = path.join(s.dir, 'secret.txt');
+    fs.writeFileSync(secret, 'do not touch\n');
+    const bad = await runCli(['artifact', 'write', 'file://' + secret, '--file', mine, '--version', sha256('do not touch\n'), ...args]);
+    assert.strictEqual(bad.code, 1);
+    assert.match(bad.stderr, /not an artifact of any card/);
+    assert.strictEqual(fs.readFileSync(secret, 'utf8'), 'do not touch\n');
+  } finally {
+    await s.stop();
+  }
+});
+
+// What the editor marks after taking an outside write. 0-based line numbers,
+// because that is what CodeMirror counts in.
+test('changedLines names the lines the other hand touched', async () => {
+  const { changedLines } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'util.js')).href);
+
+  assert.deepStrictEqual(changedLines('a\nb\nc\n', 'a\nb\nc\n'), [], 'identical text marks nothing');
+  assert.deepStrictEqual(changedLines('a\nb\nc\n', 'a\nB\nc\n'), [1], 'one line rewritten');
+  assert.deepStrictEqual(changedLines('a\nb\nc\n', 'a\nx\ny\nb\nc\n'), [1, 2], 'two lines inserted — only they are marked');
+  assert.deepStrictEqual(changedLines('a\nb\nc\n', 'a\nb\nc\nd\n'), [3], 'appended at the end');
+  assert.deepStrictEqual(changedLines('', 'hello\n'), [0], 'a file that was empty');
+  // a pure deletion leaves no new line to mark, so the seam carries it — the
+  // captain still gets a mark to look at instead of a silent shrink
+  assert.deepStrictEqual(changedLines('a\nb\nc\n', 'a\nc\n'), [1]);
+  assert.deepStrictEqual(changedLines('a\nb\n', ''), [0]);
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -1067,6 +1067,17 @@ a.a-uri { color: var(--accent); }
 }
 .fs-note-ok { color: var(--ok); background: rgba(62, 207, 142, .07); }
 .fs-note-err { color: var(--warn); background: rgba(230, 192, 74, .09); border-left: 3px solid var(--warn); }
+/* the other hand wrote the file: taken in place (live) or waiting on his call (warn) */
+.fs-note-live { color: var(--accent); background: var(--accent-soft); border-left: 3px solid var(--accent2); }
+.fs-note-warn { color: var(--warn); background: rgba(230, 192, 74, .09); border-left: 3px solid var(--warn); }
+.fs-note-act {
+  margin-left: 8px; padding: 2px 8px; border-radius: 7px; font-size: 12px;
+  background: var(--panel); border: 1px solid var(--line); color: var(--dim); white-space: nowrap;
+}
+.fs-note-act:hover { color: var(--text); border-color: var(--line2); }
+/* lines the other hand touched, in the editor gutter-to-edge — the point of
+   updating in place is that he SEES what moved */
+.cm-s-bc .fe-chg { background: rgba(88, 182, 255, .13); box-shadow: inset 2px 0 0 var(--accent2); }
 .fe-bar { flex: none; display: flex; align-items: center; gap: 6px; padding: 8px 12px; border-bottom: 1px solid var(--line); }
 .fe-bar .fe-gap { flex: 1; }
 .fe-bar button {

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -18,7 +18,13 @@ async function j(method, url, body) {
   return r.json();
 }
 
+// Who this tab is, for one purpose only: recognizing the echo of its own
+// artifact write on the shared SSE stream, so the screen doesn't flash at itself.
+// Per page load, thrown away with it — never persisted, never an identity.
+const CLIENT_ID = 'c' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+
 export const api = {
+  clientId: CLIENT_ID,
   createLieutenant: (lt) => j('POST', '/api/lieutenants', Object.assign({ actor: 'user' }, lt)),
   updateLieutenant: (id, patch) => j('PATCH', '/api/lieutenants/' + encodeURIComponent(id), patch),
   retireLieutenant: (id) => j('DELETE', '/api/lieutenants/' + encodeURIComponent(id), { actor: 'user' }),
@@ -55,8 +61,10 @@ export const api = {
   labels: (body) => j('POST', '/api/labels', body),
   artifact: (uri) => j('GET', '/api/artifact?uri=' + encodeURIComponent(uri)),
   // Write an artifact back. `version` is what the GET handed out (sha256 of the
-  // content read); a stale one comes back 409 and nothing is written.
-  saveArtifact: (uri, content, version) => j('PUT', '/api/artifact', { uri, content, version }),
+  // content read); a stale one comes back 409 and nothing is written. `client`
+  // comes back on the SSE `artifact` event as `by`, so this tab can tell its own
+  // write from someone else's.
+  saveArtifact: (uri, content, version) => j('PUT', '/api/artifact', { uri, content, version, client: CLIENT_ID }),
   board: () => j('GET', '/api/board'),
   // archived (frozen) card snapshots, newest first, paged over the append-only
   // log: {archive: [...], total}; restore resurrects one

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -5,7 +5,7 @@ import { md, mdEnhance, copyText } from './md.js';
 import { api } from './api.js';
 import { labelChipHtml, openLabelPicker, saveCardLabels } from './labels.js';
 import { openCardThread, syncChatToMain } from './chat.js';
-import { openFile, closeFile } from './filepane.js';
+import { openFile, closeFile, fileKey, fileDirty, fileUpdate, fileNotice } from './filepane.js';
 import { openMoveMenu } from './board.js';
 import { archivedCard, unarchive } from './archive.js';
 
@@ -304,6 +304,7 @@ avEditBtn.onclick = () => {
     name,
     markdown,
     content: drafts.has(uri) ? drafts.get(uri) : content,
+    saved: content, // what is on disk — a restored draft is still unsaved typing
     crumb: c && {
       label: cardEmoji(c) + ' ' + (c.title || c.id),
       title: 'back to this card',
@@ -335,6 +336,39 @@ async function saveArtifactText(uri, text) {
     throw e;
   }
 }
+// The other hand wrote a file (SSE `artifact` from a landed PUT: {uri, version,
+// by}). Four hands means the screen follows by itself — a reload button here
+// would make this two hands taking turns.
+//   buffer clean → take the new text in place, changed lines marked. No asking:
+//                  there is nothing of his to lose, so there is no decision.
+//   buffer dirty → say it and let HIM choose. The one case that earns a click.
+// The write's own client hears its echo and does nothing (`by`), and the version
+// check covers the case where two clients already agree on the text.
+export async function artifactWritten(ev) {
+  const uri = ev && ev.uri;
+  if (!uri || (ev.by && ev.by === api.clientId)) return; // our own save coming back
+  if (fileKey() !== uri) return; // nothing of ours is open on it; a later open re-reads anyway
+  if (versions.get(uri) === ev.version) return;
+  let r;
+  try { r = await api.artifact(uri); } catch (e) { return; } // gone or unreadable — the save will say so
+  if (fileKey() !== uri) return; // he left the screen while we were fetching
+  const take = (note) => {
+    versions.set(uri, r.version);
+    drafts.delete(uri);
+    if (avEditable && avEditable.uri === uri) avEditable.content = r.content;
+    fileUpdate(r.content, note);
+  };
+  if (!fileDirty()) return take('↻ the other hand wrote this file');
+  // Dirty: his text is NOT touched and the version stays pinned to what his
+  // draft started from, so saving it is still a 409 — the last line of defense
+  // holds even if he ignores this line entirely.
+  fileNotice('⚠ the other hand wrote this file while you have unsaved text here — nothing of yours was touched.',
+    'warn', [
+      { label: '↻ show me theirs', title: 'load the version on disk, changed lines marked — your unsaved text goes', onClick: () => take('↻ loaded the version on disk') },
+      { label: '✋ keep mine', title: 'leave your text alone (saving it will ask you to confirm the overwrite)', onClick: () => {} },
+    ]);
+}
+
 // An artifact entry may carry a content-type hint ({uri, label, type}) — e.g.
 // the auto-attached worker brief is markdown in a `.prompt` file. The hint
 // wins; the extension regex is the fallback.

--- a/ui/js/fileedit.js
+++ b/ui/js/fileedit.js
@@ -75,10 +75,30 @@ export function mountFileEditor(host, opts) {
   prevWrap.hidden = true;
   host.append(bar, edWrap, prevWrap);
 
-  let cm = null, sel = null;
+  let cm = null, sel = null, external = false;
+  // Replace the buffer from OUTSIDE — the file changed under us and the host
+  // decided we should follow. `changed` (0-based line numbers) get a marked
+  // background, because "it was updated" is not information; "these lines" is.
+  // The cursor and the scroll position stay where the reader left them: the
+  // point of updating in place is that he does not lose his spot.
+  function replace(text, changed) {
+    if (!cm) { o.content = text; return; } // vendor still loading — it mounts with this
+    const scroll = cm.getScrollInfo();
+    const cur = cm.getCursor();
+    cm.eachLine((h) => cm.removeLineClass(h, 'background', 'fe-chg')); // the previous round's marks
+    external = true; // this is not the captain typing — onChange must not read it as an edit
+    try { cm.setValue(text); } finally { external = false; }
+    for (const n of changed || []) {
+      if (n >= 0 && n < cm.lineCount()) cm.addLineClass(n, 'background', 'fe-chg');
+    }
+    cm.setCursor({ line: Math.min(cur.line, cm.lastLine()), ch: cur.ch });
+    cm.scrollTo(scroll.left, scroll.top);
+    if (!prevWrap.hidden) showPreview(true); // the preview is showing — re-render it
+  }
   const handle = {
     getValue: () => (cm ? cm.getValue() : o.content || ''),
     selection: () => sel,
+    replace,
     destroy: () => { cm = null; sel = null; host.textContent = ''; },
   };
 
@@ -146,7 +166,7 @@ export function mountFileEditor(host, opts) {
       CM.autoLoadMode(cm, info.mode); // fetches ui/vendor/codemirror/mode/<mode>/<mode>.js
     }
     cm.on('cursorActivity', emitSel);
-    cm.on('change', () => { if (o.onChange) o.onChange(); });
+    cm.on('change', () => { if (o.onChange && !external) o.onChange(); });
     cm.focus();
   }).catch((e) => { edWrap.textContent = '⚠ editor failed to load — ' + e.message; });
 

--- a/ui/js/filepane.js
+++ b/ui/js/filepane.js
@@ -15,6 +15,7 @@
 import { S } from './state.js';
 import { mountFileEditor } from './fileedit.js';
 import { refreshQuote } from './chat.js';
+import { changedLines } from './util.js';
 
 const el = document.getElementById('filepane');
 
@@ -25,6 +26,27 @@ export function onModeSwitch(fn) { modeSwitch = fn; }
 
 export function fileOpen() { return !!open; }
 export function fileName() { return open ? open.name : ''; }
+// Which file is up (the host's own key — a uri, for today's host), and whether
+// there is typing in it that is not on disk yet. `open.saved` is the text this
+// screen believes is on disk: what the host handed it as `saved`, moved forward
+// by every save that landed and every outside update it took. It is NOT the
+// text the editor mounted with — a restored draft is unsaved typing from an
+// earlier visit, and it has to keep counting as unsaved.
+export function fileKey() { return open ? open.key : ''; }
+export function fileDirty() { return !!(open && handle && handle.getValue() !== open.saved); }
+// The file changed underneath us and the host decided we follow: swap the text
+// in place, mark the lines that moved, and say so in the note. No reload, no
+// button — the captain keeps his cursor and sees what the other hand did.
+export function fileUpdate(text, note) {
+  if (!open) return;
+  const changed = changedLines(open.saved, text);
+  open.saved = text;
+  if (handle) handle.replace(text, changed);
+  say((note || 'updated on disk') + ' — ' + changed.length + (changed.length === 1 ? ' line' : ' lines') + ' marked', 'live');
+}
+// Say something on the note line, optionally with the choices it demands:
+// actions = [{ label, onClick }]. Clicking one clears the note.
+export function fileNotice(text, kind, actions) { say(text, kind, actions); }
 // What rides along with the next chat message: the file always, plus the
 // highlighted lines when there is a selection.
 export function fileQuote() {
@@ -35,12 +57,15 @@ export function fileQuote() {
     : { name: open.name };
 }
 
-// spec: { key, name, content, markdown, crumb: { label, title, onClick },
+// spec: { key, name, content, saved, markdown, crumb: { label, title, onClick },
 //         onChange(text), onSave(text) -> Promise<string> (the line to show) }
+// `content` is what the editor mounts with (a restored draft, when there is
+// one); `saved` is what is on disk (defaults to content).
 export function openFile(spec) {
   const back = S.boardMode === 'file' ? (open && open.backMode) || 'board' : S.boardMode;
   drop();
   open = Object.assign({}, spec, { backMode: back });
+  if (open.saved == null) open.saved = open.content;
   build();
   S.view = 'board'; // mobile: the file screen lives in the board tab (renamed to it)
   modeSwitch('file'); // renders
@@ -122,20 +147,34 @@ function build() {
 // knows nothing about what it is saving to — it prints the line it is handed.
 let saving = false;
 let noteEl = null;
-function say(text, kind) {
+function say(text, kind, actions) {
   if (!noteEl) return;
   noteEl.hidden = !text;
-  noteEl.textContent = text || '';
+  noteEl.textContent = '';
   noteEl.className = 'fs-note' + (kind ? ' fs-note-' + kind : '');
+  if (!text) return;
+  const line = document.createElement('span');
+  line.textContent = text;
+  noteEl.appendChild(line);
+  for (const a of actions || []) {
+    const b = document.createElement('button');
+    b.type = 'button';
+    b.className = 'fs-note-act';
+    b.textContent = a.label;
+    if (a.title) b.title = a.title;
+    b.onclick = () => { say(''); a.onClick(); };
+    noteEl.appendChild(b);
+  }
 }
 function save(h, btn) {
   if (saving || !open || !open.onSave) return;
   saving = true;
+  const text = h.getValue();
   const was = btn.textContent;
   btn.textContent = '💾 saving…';
   btn.disabled = true;
-  Promise.resolve(open.onSave(h.getValue())).then(
-    (msg) => { say(msg || 'saved', 'ok'); },
+  Promise.resolve(open.onSave(text)).then(
+    (msg) => { if (open) open.saved = text; say(msg || 'saved', 'ok'); },
     (e) => { say('⚠ ' + (e && e.message ? e.message : 'save failed'), 'err'); },
   ).then(() => {
     saving = false;

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -12,7 +12,7 @@ import { renderFilterUI, filterPanelOpen, closeFilterPanel } from './filterpop.j
 import { renderChat, onOpenCard as chatOnOpenCard, openCardConversation, openLieutenantChat, onQuoteSource } from './chat.js';
 import { onModeSwitch, forgetFile, fileOpen, fileName, fileQuote } from './filepane.js';
 import { renderLtSwitcher, ltSwitcherOpen, closeLtSwitcher, ltSettingsOpen, closeLtSettings } from './ltswitcher.js';
-import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen } from './detail.js';
+import { renderDetail, openDetail, closeDetail, detailOpen, closeArtifact, artifactOpen, onArtifactClose, closeOwnerMenu, ownerMenuOpen, artifactWritten } from './detail.js';
 import { closePane, paneOpen } from './pane.js';
 import { openMonitor, closeMonitor, monitorOpen } from './monitor.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
@@ -263,6 +263,12 @@ function connect() {
     const restarted = serverBoot && doc.boot && doc.boot !== serverBoot;
     applyBoard(doc);
     if (restarted) refetchBoard(); // new server instance — make sure we hold its current state
+  });
+  // An artifact was written through the board — a file screen open on it follows
+  // along by itself. Not a board payload: no re-render, nothing else reacts.
+  es.addEventListener('artifact', (e) => {
+    lastEventAt = Date.now();
+    try { artifactWritten(JSON.parse(e.data)); } catch (err) {}
   });
   es.addEventListener('ping', () => { lastEventAt = Date.now(); });
   es.onopen = () => {

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -93,6 +93,26 @@ export function uriBasename(uri) {
   return i >= 0 ? s.slice(i + 1) : s;
 }
 
+// Which lines of `next` the other hand touched, as 0-BASED line numbers: trim
+// the identical head and the identical tail, and what is left in the middle is
+// the change. Deliberately not a real diff — nothing here needs to know which
+// old line a new line came from, and marking a couple of extra lines when a
+// paragraph moves is a fine price for eight lines instead of an LCS. A pure
+// deletion leaves no new lines to mark, so the seam gets the mark instead.
+export function changedLines(prev, next) {
+  const a = String(prev == null ? '' : prev).split('\n');
+  const b = String(next == null ? '' : next).split('\n');
+  let head = 0;
+  while (head < a.length && head < b.length && a[head] === b[head]) head++;
+  let tail = 0;
+  while (tail < a.length - head && tail < b.length - head &&
+         a[a.length - 1 - tail] === b[b.length - 1 - tail]) tail++;
+  const out = [];
+  for (let i = head; i < b.length - tail; i++) out.push(i);
+  if (!out.length && prev !== next) out.push(Math.min(head, b.length - 1));
+  return out;
+}
+
 // human token count for the context bar tooltip (185709 → "186k", 1e6 → "1M")
 export function fmtTokens(n) {
   if (!Number.isFinite(n)) return '?';


### PR DESCRIPTION
## The hole

The artifact version lock from #79 protected **one side only**. The captain saves through `PUT /api/artifact`, which checks the sha256 and refuses with 409 if the disk moved. The agent wrote **straight to disk**, checking nothing. So if the captain saved while the agent was thinking, the agent's write took his text and nothing stopped it. Today's behavior, not a hypothesis.

## Three things

**1. `bc-axi artifact read` / `artifact write`** — the agent's door through the server, so it gets the same check the captain gets:

```
bc-axi artifact read <uri> > /tmp/a.md            # content on stdout, "version: <sha256>" on stderr
# ...edit...
bc-axi artifact write <uri> --file /tmp/a.md --version <that version>
```

A stale version means **exit 1** and `NOT WRITTEN`, naming the version that is there now and the way out. Never swallowed — a write that didn't happen and doesn't say so would be worse than the bug it replaces.

`--version` is required. The card sketched `write` re-reading the version itself; that would reintroduce the hole (silently overwriting whatever landed during the thinking window), so the version the agent actually read is what it has to hand back.

**2. The server tells the screen.** A landed PUT emits on the SSE that already exists — `event: artifact`, `{uri, version, by}`. The editor:

- **clean buffer** → takes the new text **in place**, changed lines marked, cursor and scroll kept. No asking, no button, no reload.
- **dirty buffer** → says so and offers the choice (`↻ show me theirs` / `✋ keep mine`). Nothing of his is touched, and the version stays pinned so his save is still a 409 — the last line of defense holds even if he ignores the line.
- the tab that just saved recognizes its own echo (`by` = a random per-page client tag) and stays still.

`changedLines` is a trimmed head/tail comparison, not an LCS: nothing here needs to know which old line a new line came from.

**3. The rule in `DOCTRINE.md`** — scoped to artifacts under joint editing only (worktree code, reports and notes stay ordinary files), naming the command, and saying plainly that this is **discipline, not mechanism**: the old tool still exists, which is exactly why it is written down.

## Verified

Real browser against a scratch board on its own port (production untouched):

1. stale version → `NOT WRITTEN`, exit 1, captain's text intact on disk ✓
2. editor open, clean buffer, agent writes → screen updated itself, lines 5–7 marked, **nothing clicked** ✓
3. real keystrokes in the buffer, agent writes → warning + both choices, his text untouched; `keep mine` then save → 409 with the overwrite-again message; `show me theirs` → disk version loaded, changed lines marked ✓
4. captain's own save → `saved — N bytes on disk` and no self-notice ✓

None of #79's guards were loosened (allowlist, file:// only, no `..`, no symlink, atomic tmp+rename). A **refused** write announces nothing — no phantom update on anyone's screen.

`node --test test/*.test.js harness/test/*.test.js` → **422 pass, 0 fail** (416 + 6 new in `test/artifact-live.test.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)