### PR TITLE
Speak the markdown, do not spell it

### DIFF
--- a/test/voice.test.js
+++ b/test/voice.test.js
@@ -14,7 +14,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let speak, stopSpeaking;
+let speak, stopSpeaking, stripForSpeech;
 
 const ENGINE = 'http://127.0.0.1:8883';
 const tick = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -153,7 +153,7 @@ test.before(async () => {
   fakePage();
   fakeEngine();
   answer = () => said();
-  ({ speak, stopSpeaking } =
+  ({ speak, stopSpeaking, stripForSpeech } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'voice.js')).href));
   // The catalogue lands a few promises after import; the board is mute (and says
   // so) until it does, so every test would otherwise be testing that instead.
@@ -168,6 +168,86 @@ test.beforeEach(async () => {
   asked.length = 0;
   made.length = 0;
   answer = () => said();
+});
+
+// ── what is left of the markdown when it has to be heard ──────────────────
+// Every assertion below is an EAR test written down. The thing being checked is
+// never "the character is gone" — it is what a person would hear: no pipes read
+// out, no "greater than" in front of a quotation, a pause where the writing had
+// a heading or a list, and the words of a link without the URL after them.
+//
+// A pause is a full stop or a newline, because those are the two things the
+// engine breathes on. That is why these tests look at punctuation and line
+// breaks so closely: for speech they ARE the content.
+test('a table is not read out — it is announced', () => {
+  const said = stripForSpeech('Antes.\n\n| Nome | Idade |\n| --- | --- |\n| Ana | 30 |\n| Bo | 41 |\n\nDepois.');
+  assert.ok(!/\|/.test(said), 'no pipe survives to be spoken: ' + JSON.stringify(said));
+  assert.match(said, /Antes\.\s+table\.\s+Depois\./,
+    'the whole table collapses to ONE announcement — not one per row');
+});
+
+test('a quotation is spoken as speech, not as "greater than"', () => {
+  const said = stripForSpeech('Ele disse:\n\n> a pressa é inimiga\n> da perfeição\n\nE foi.');
+  assert.equal(said, 'Ele disse:\n\na pressa é inimiga\nda perfeição\n\nE foi.',
+    'the markers are gone and the words are untouched');
+});
+
+test('underscore emphasis gives up its underscores; an identifier keeps them', () => {
+  assert.equal(stripForSpeech('isso é _assim_ e também __assim__.'), 'isso é assim e também assim.');
+  assert.equal(stripForSpeech('a chave bc_voice_on fica.'), 'a chave bc_voice_on fica.',
+    'snake_case is one spoken word, not a pair of emphasis marks');
+});
+
+test('a heading ends in a full stop instead of colliding with the next line', () => {
+  const said = stripForSpeech('## Recomendação\nMantida: pipeline em YAML.');
+  assert.equal(said, 'Recomendação.\nMantida: pipeline em YAML.',
+    'the hashes are gone AND there is something to breathe on between the two');
+});
+
+test('a link says its words and never its URL', () => {
+  assert.equal(stripForSpeech('Clique em [abre o card](https://exemplo.com/x?a=1) agora.'),
+    'Clique em abre o card agora.',
+    'no trailing "link" after the text — the URL had nothing to say');
+});
+
+test('list items stay separate items, not one long breath', () => {
+  const said = stripForSpeech('Três coisas:\n\n- primeira\n- segunda\n* terceira\n\n1. um\n2. dois');
+  assert.equal(said, 'Três coisas:\n\nprimeira.\nsegunda.\nterceira.\n\num.\ndois.',
+    'bullets and numbers are gone, and every item is its own sentence');
+});
+
+test('a horizontal rule is a silence, not three dashes', () => {
+  assert.equal(stripForSpeech('Acima.\n\n---\n\nAbaixo.'), 'Acima.\n\nAbaixo.');
+  assert.equal(stripForSpeech('Acima.\n\n***\n\nAbaixo.'), 'Acima.\n\nAbaixo.');
+});
+
+test('a code fence is still "code" and a bare URL is still "link"', () => {
+  const said = stripForSpeech('Rode:\n\n```sh\nnpm test\n```\n\nveja https://ex.com/a pra mais.');
+  assert.match(said, /Rode:\s+code\s+veja link pra mais\./,
+    'these two were already right and were left alone: ' + JSON.stringify(said));
+});
+
+test('a real message from the board comes out as prose', () => {
+  const said = stripForSpeech([
+    '**Correção: eu procurei mal.** Achei: [`mattpocock/sandcastle`](https://github.com/mattpocock/sandcastle).',
+    '',
+    '## O que o Sandcastle faz',
+    '',
+    '- cria e limpa **git worktree**',
+    '- **retoma sessão**: `resumeSession`',
+    '',
+    'Mantida: pipeline em YAML nosso.',
+  ].join('\n'));
+  assert.equal(said, [
+    'Correção: eu procurei mal. Achei: mattpocock/sandcastle .',
+    '',
+    'O que o Sandcastle faz.',
+    '',
+    'cria e limpa git worktree.',
+    'retoma sessão: resumeSession .',
+    '',
+    'Mantida: pipeline em YAML nosso.',
+  ].join('\n'));
 });
 
 test('a burst past the cap drops the MIDDLE of the queue and keeps the newest', async () => {

--- a/ui/js/voice.js
+++ b/ui/js/voice.js
@@ -80,11 +80,53 @@ function stripEmoji(s) { // spoken text only
     .replace(/[\u{1F1E6}-\u{1F1FF}]/gu, ' ')
     .replace(/\p{Extended_Pictographic}/gu, ' ')
     .replace(/[\u{FE00}-\u{FE0F}\u{200D}\u{1F3FB}-\u{1F3FF}\u{20E3}]/gu, '')
-    .replace(/[←-⇿⌀-⏿■-◿☀-➿⬀-⯿]/g, ' ')
-    .replace(/\s{2,}/g, ' ').trim();
+    .replace(/[←-⇿⌀-⏿■-◿☀-➿⬀-⯿]/g, ' ');
 }
-function stripForSpeech(text) {
-  return stripEmoji(text.replace(/```[\s\S]*?```/g, ' code ').replace(/[`*#\[\]()]/g, ' ').replace(/https?:\S+/g, ' link '));
+// Line breaks SURVIVE this. They are not decoration left over from the source:
+// a newline and a full stop are the only two things the engine breathes on, so
+// throwing them away is throwing away every pause in the message.
+function tidy(s) {
+  return s
+    .replace(/[^\S\n]+/g, ' ')      // runs of space/tab, never the newlines
+    .replace(/ ?\n ?/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+// A line that carried a block mark is a sentence, and it has to end like one —
+// otherwise "## Recomendação" runs straight into the paragraph under it and six
+// list items come out as one breathless paragraph.
+function sentence(s) {
+  return /[.!?:;…]\s*$/.test(s) ? s : s.replace(/\s*$/, '.');
+}
+// Markdown is written to be READ. This is what is left of it when it must be
+// HEARD instead. The old version deleted CHARACTERS — which is why a table
+// spoke its pipes, `> ` came out as "maior que", `_assim_` kept its
+// underscores, and a link said its text and then the word "link" for the URL
+// behind it. Marks are structure, so each one is answered by what it means out
+// loud: the ones that carry words give the words up, the blocks that cannot be
+// spoken at all collapse to the one word that says what was there.
+//
+// A table becomes the single word "table" rather than sentences. Read aloud,
+// even a small one is a chant of column headings repeated per row; the captain
+// is being told a table exists in the card, and can look.
+//
+// This is the ONE function the speech paths call. `code` and `link` are
+// unchanged — they were already right.
+export function stripForSpeech(text) {
+  const t = String(text == null ? '' : text)
+    .replace(/```[\s\S]*?```/g, ' code ')                       // a fence is not read out
+    .replace(/(?:^[ \t]*\|.*\|[ \t]*\n?)+/gm, '\ntable.\n')     // a whole table, once
+    .replace(/^[ \t]*([-*_])(?:[ \t]*\1){2,}[ \t]*$/gm, '')     // --- is a page break, silent
+    .replace(/^[ \t]*#{1,6}[ \t]+(.*)$/gm, (m, h) => sentence(h))
+    .replace(/^[ \t]*>[ \t]?/gm, '')                            // a quote is just someone talking
+    .replace(/^[ \t]*(?:[-*+]|\d+[.)])[ \t]+(.*)$/gm, (m, i) => sentence(i))
+    .replace(/!?\[([^\]\n]*)\]\([^)\n]*\)/g, '$1')              // the link's words, never its URL
+    .replace(/https?:\S+/g, ' link ')                           // a bare one has no words to say
+    // emphasis gives up its delimiters and keeps the word — but only when they
+    // really are delimiters, so snake_case survives as one spoken word.
+    .replace(/(^|[\s("'])([*_]{1,3}|~~)(?=\S)(.+?)\2(?=[\s.,;:!?)"']|$)/gm, '$1$3')
+    .replace(/[`*#\[\]()~]/g, ' ');                             // leftovers, as before
+  return tidy(stripEmoji(t));
 }
 
 // ---------- the speech queue ----------


### PR DESCRIPTION
`stripForSpeech` deleted characters, so the board read its own formatting out loud: tables spoke their pipes, `> ` became "maior que", `_assim_` kept its underscores, links said their text and then "link" for the URL, and headings and list items ran together with no pause. It now answers each mark with what it means out loud, and preserves the full stops and newlines the engine breathes on.

Tables collapse to the single word `table` rather than becoming sentences — read aloud, even a small one is a chant of column headings repeated once per row; the captain is told a table exists and can look. `code` and `link` were already right and are unchanged. One case per symptom in `test/voice.test.js`, plus a real board message.