### PR TITLE
One key grammar, and a test that can actually fail

### DIFF
--- a/test/panekeys.test.js
+++ b/test/panekeys.test.js
@@ -9,10 +9,15 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let keyForEvent;
+// The server-side guard ITSELF, not a copy of it: the whole point of the last
+// test in this file is that client and server cannot drift apart.
+const { KEY_RE } = require('../harness/port.js');
+
+let keyForEvent, panekeys;
 test.before(async () => {
-  ({ keyForEvent } = await import(
-    pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'panekeys.js')).href));
+  panekeys = await import(
+    pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'panekeys.js')).href);
+  ({ keyForEvent } = panekeys);
 });
 
 // A KeyboardEvent stand-in: only the fields the mapper reads.
@@ -74,15 +79,15 @@ test('Alt/Meta chords and unmappable keys are never stolen', () => {
 });
 
 test('every key name it emits is one tmux would accept as a key, never as a flag', () => {
-  const KEY_RE = /^(C-|M-|S-)*[A-Za-z0-9]+$/; // the server-side guard, verbatim
-  const keys = ['Enter', 'Backspace', 'Tab', 'Escape', 'ArrowUp', 'ArrowDown', 'ArrowLeft',
-    'ArrowRight', 'Home', 'End', 'PageUp', 'PageDown', 'Delete', 'Insert'];
-  for (const k of keys) {
-    const out = keyForEvent(ev(k));
-    assert.match(out.key, KEY_RE, k);
+  // Both loops walk what the client REALLY emits, not a hand-typed subset:
+  // add a character the server rejects and this test is what says so.
+  for (const dom of Object.keys(panekeys.NAMED)) {
+    assert.match(keyForEvent(ev(dom)).key, KEY_RE, dom);
   }
   assert.match(keyForEvent(ev('Tab', { shift: true })).key, KEY_RE);
-  for (const c of 'abcdefghijklmnopqrstuwxyz') { // v is excluded on purpose
-    assert.match(keyForEvent(ev(c, { ctrl: true })).key, KEY_RE, 'C-' + c);
+  for (const c of panekeys.CTRL_KEYS) {
+    const out = keyForEvent(ev(c, { ctrl: true }));
+    if (!out) continue; // C-v alone is left to the browser, so it emits nothing
+    assert.match(out.key, KEY_RE, 'C-' + c);
   }
 });

--- a/ui/js/panekeys.js
+++ b/ui/js/panekeys.js
@@ -10,7 +10,7 @@
 
 // The named keys worth having in a terminal. tmux spells several of them
 // differently from the DOM (BSpace, DC), which is the whole point of the table.
-const NAMED = {
+export const NAMED = {
   Enter: 'Enter',
   Backspace: 'BSpace',
   Tab: 'Tab',
@@ -28,8 +28,10 @@ const NAMED = {
 };
 
 // Ctrl-<x> combos tmux understands: the letters plus the five punctuation
-// controls (C-[ is Escape, C-\ quits, C-_ undoes).
-const CTRL_RE = /^[a-z[\\\]^_]$/;
+// controls (C-[ is Escape, C-\ quits, C-_ undoes). A plain string, and exported
+// with NAMED, because the test iterates exactly this to check every name we emit
+// against the server's KEY_RE — a set it cannot read is a set it cannot pin.
+export const CTRL_KEYS = 'abcdefghijklmnopqrstuvwxyz[\\]^_';
 
 export function keyForEvent(e) {
   // Alt/Meta chords belong to the browser and the OS (⌘W, Alt-Tab). Never steal
@@ -50,7 +52,7 @@ export function keyForEvent(e) {
     // better than sending a bare C-v. Ctrl-C is NOT excluded — interrupting a
     // runaway agent is the headline reason this pane became typeable at all.
     if (c === 'v') return null;
-    return CTRL_RE.test(c) ? { key: 'C-' + c } : null;
+    return CTRL_KEYS.includes(c) ? { key: 'C-' + c } : null;
   }
 
   // Any single printable character (letters, digits, punctuation, space, and


### PR DESCRIPTION
# Description

PR #84 shipped five key names the client emitted and the server rejected, and the rejections vanished silently — the test meant to catch exactly that drift kept its own hand-typed copy of the server's guard and only ever walked the letters, never the punctuation the bug lived in. Proof it was still blind: adding `~` to the client's control-key set left the whole suite green. Now the test imports the guard instead of copying it and iterates what the client really emits, so the client's key set can no longer grow past what the server accepts without something going red.

## Type of change

- [x] Bug fix / test hardening (non-breaking)

## How has this change been tested?

- Existing suite green (498/498).
- Drift verified to fail on purpose and then reverted: `~` added to the client's control keys → `AssertionError: C-~`; a bad name added to the DOM→tmux table → fails too.

## Any specific deployment considerations

None.
