### PR TITLE
The artifacts list stops eating its own filenames

### DIFF
--- a/test/artifacts-table.test.js
+++ b/test/artifacts-table.test.js
@@ -1,0 +1,67 @@
+'use strict';
+// The ARTIFACTS block on the card detail screen. It used to be a stack of flex
+// rows that each sized themselves — labels never lined up, and a long filename
+// truncated to an ellipsis the captain could not read. It is now a two-column
+// table inside a horizontally scrolling wrapper: columns align down the list,
+// long filenames stay whole and scroll into view.
+// util.js is browser ES-module code but touches no DOM at import time, so the
+// renderer can be imported and asserted on directly (detail.js cannot — it
+// binds DOM elements at import). The overflow-x claim lives in app.css, so it
+// is asserted against the stylesheet source.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const utilMod = import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'util.js')).href);
+const css = fs.readFileSync(path.join(__dirname, '..', 'ui', 'app.css'), 'utf8');
+
+const ARTS = [
+  { uri: 'file:///w/validated-pr-pipeline-design.md', label: 'design' },
+  { uri: '/w/pipeline-journal-sample.jsonl', label: 'journal' },
+  { uri: 'https://github.com/tonylampada/bridge-commander/pull/32', label: 'pr' },
+  { uri: '/w/a-really-quite-long-artifact-filename.png' },
+  { uri: '/w/notes.md', label: 'notes' },
+];
+
+test('artifacts render as a table with one row per artifact', async () => {
+  const { artifactsHtml } = await utilMod;
+  const html = artifactsHtml(ARTS);
+  assert.match(html, /<table[ >]/, 'artifacts are a table');
+  const rows = html.match(/<tr>/g) || [];
+  assert.strictEqual(rows.length, ARTS.length, 'one row per artifact');
+  // two aligned columns per row: label cell, then the filename cell
+  assert.strictEqual((html.match(/<td class="a-label">/g) || []).length, ARTS.length);
+  assert.strictEqual((html.match(/class="a-uri"/g) || []).length, ARTS.length);
+  // no label falls back to the basename
+  assert.ok(html.includes('<td class="a-label">a-really-quite-long-artifact-filename.png</td>'));
+});
+
+test('the table sits in a scroll container that scrolls sideways', async () => {
+  const { artifactsHtml } = await utilMod;
+  const html = artifactsHtml(ARTS);
+  const m = html.match(/<div class="([\w-]*arts-scroll[\w-]*)">\s*<table/);
+  assert.ok(m, 'the table is wrapped in a scroll container: ' + html.slice(0, 200));
+  const rule = css.match(new RegExp('\\.' + m[1] + '\\s*\\{[^}]*\\}'));
+  assert.ok(rule, '.' + m[1] + ' is styled in app.css');
+  assert.match(rule[0], /overflow-x:\s*auto/, 'the wrapper scrolls horizontally');
+  // filenames must never be clipped again
+  assert.doesNotMatch(css.match(/\.dt-artifacts \.a-uri\s*\{[^}]*\}/)[0], /text-overflow/);
+});
+
+test('behaviour kept: http links open in a new tab, everything else opens the viewer', async () => {
+  const { artifactsHtml } = await utilMod;
+  const html = artifactsHtml(ARTS);
+  assert.match(html, /<a class="a-uri" href="https:\/\/github\.com[^"]*" target="_blank" rel="noopener"/);
+  assert.match(html, /<code class="a-uri" data-view="\/w\/notes\.md"/);
+  assert.strictEqual(artifactsHtml([]), '', 'no artifacts renders nothing');
+  assert.match(html, /<div class="dt-arts-head">artifacts<\/div>/, 'the head is kept');
+});
+
+test('escaping is kept', async () => {
+  const { artifactsHtml } = await utilMod;
+  const html = artifactsHtml([{ uri: '/w/<img src=x>.md', label: '"><script>' }]);
+  assert.doesNotMatch(html, /<script>|<img /);
+  assert.match(html, /&lt;img src=x&gt;\.md/);
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -683,11 +683,14 @@ body.resizing { user-select: none; cursor: col-resize; }
   font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px;
   color: var(--faint); border-top: 1px solid var(--line); padding-top: 12px; margin-top: 4px;
 }
-.dt-artifacts .art { display: flex; align-items: baseline; gap: 8px; padding: 7px 0 0; min-width: 0; }
-.dt-artifacts .art:last-child { padding-bottom: 14px; }
-.dt-artifacts .a-label { flex: none; font-size: 13px; }
+/* Two aligned columns; the wrapper — not the page — scrolls sideways when the
+   filenames are wider than the pane, so nothing gets clipped. */
+.arts-scroll { overflow-x: auto; -webkit-overflow-scrolling: touch; padding-bottom: 14px; }
+.dt-artifacts .arts { border-collapse: collapse; }
+.dt-artifacts .arts td { padding: 7px 0 0; vertical-align: baseline; white-space: nowrap; }
+.dt-artifacts .a-label { font-size: 13px; padding-right: 8px; }
 .dt-artifacts .a-uri {
-  flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  white-space: nowrap;
   font-family: var(--mono); font-size: 11.5px; color: var(--dim);
   background: var(--panel); border: 1px solid var(--line); border-radius: 4px; padding: 1px 6px;
 }

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -1,6 +1,6 @@
 // card detail: attributes header + markdown body + event timeline (chat lives in the chat panel)
 import { S, card, lieutenant, lieutenants, lieutenantColor, cardStatus, cardActivityTs, cardRecency, kindEmoji, render, toggleFilter, filterSelected } from './state.js';
-import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, uriBasename, setHtmlIfChanged, isImageMime } from './util.js';
+import { esc, hhmm, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, cardArtifacts, artifactsHtml, uriBasename, setHtmlIfChanged, isImageMime } from './util.js';
 import { md, mdEnhance, copyText } from './md.js';
 import { api } from './api.js';
 import { labelChipHtml, openLabelPicker, saveCardLabels } from './labels.js';
@@ -788,16 +788,7 @@ export function renderDetail() {
   // raw uri. http(s) uris open normally; anything else (file:// / local paths)
   // opens in the artifact viewer popup, served by GET /api/artifact.
   const artEl = document.getElementById('dt-artifacts');
-  const arts = cardArtifacts(c);
-  const artsChanged = setHtmlIfChanged(artEl, !arts.length ? '' :
-    '<div class="dt-arts-head">artifacts</div>' + arts.map((a) => {
-      const name = uriBasename(a.uri) || a.uri;
-      const label = '<span class="a-label">' + esc(a.label || name) + '</span>';
-      const uri = /^https?:\/\//.test(a.uri)
-        ? '<a class="a-uri" href="' + esc(a.uri) + '" target="_blank" rel="noopener" title="' + esc(a.uri) + '">' + esc(name) + '</a>'
-        : '<code class="a-uri" data-view="' + esc(a.uri) + '" title="' + esc(a.uri) + ' — click to view">' + esc(name) + '</code>';
-      return '<div class="art">' + label + uri + '</div>';
-    }).join(''));
+  const artsChanged = setHtmlIfChanged(artEl, artifactsHtml(cardArtifacts(c)));
   if (artsChanged) artEl.querySelectorAll('.a-uri[data-view]').forEach((n) => {
     n.onclick = () => openArtifact(n.dataset.view);
   });

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -93,6 +93,24 @@ export function uriBasename(uri) {
   return i >= 0 ? s.slice(i + 1) : s;
 }
 
+// The ARTIFACTS block: a two-column table (label | filename) so both columns
+// line up down the whole list, wrapped in a container that scrolls SIDEWAYS
+// when it does not fit. Filenames are never clipped to an ellipsis — the
+// captain has to be able to read which file an entry points at.
+// Lives here (not detail.js) because detail.js binds DOM at import time and
+// this is the piece worth rendering in a test.
+export function artifactsHtml(arts) {
+  if (!arts.length) return '';
+  return '<div class="dt-arts-head">artifacts</div><div class="arts-scroll"><table class="arts"><tbody>' +
+    arts.map((a) => {
+      const name = uriBasename(a.uri) || a.uri;
+      const uri = /^https?:\/\//.test(a.uri)
+        ? '<a class="a-uri" href="' + esc(a.uri) + '" target="_blank" rel="noopener" title="' + esc(a.uri) + '">' + esc(name) + '</a>'
+        : '<code class="a-uri" data-view="' + esc(a.uri) + '" title="' + esc(a.uri) + ' — click to view">' + esc(name) + '</code>';
+      return '<tr><td class="a-label">' + esc(a.label || name) + '</td><td>' + uri + '</td></tr>';
+    }).join('') + '</tbody></table></div>';
+}
+
 // Which lines of `next` the other hand touched, as 0-BASED line numbers: trim
 // the identical head and the identical tail, and what is left in the middle is
 // the change. Deliberately not a real diff — nothing here needs to know which


### PR DESCRIPTION
# Description

The captain reads the board on his phone, and the ARTIFACTS block on a card was hiding the one thing it exists to show: every row sized itself, so labels never lined up and any filename wider than its row got chopped to `validated-pr-pipe…` — you could not tell which file an entry pointed at without clicking it. It is now a two-column table inside a wrapper that scrolls sideways, so the columns align down the whole list and filenames stay whole.

## Type of change

- [x] Bug fix / UX fix (non-breaking)

## How has this change been tested?

- New automated tests added (fail on `main`, pass here).
- Looked at it in the dev playground with a 7-artifact card, wide and at 390px: chips align on the same x in both; narrow, only the wrapper scrolls (488px of table in 358px) while the page body stays at 390px, and scrolling right reveals `pipeline-journal-sample.jsonl` whole.

## Any specific deployment considerations

- None — static UI assets.
