### PR TITLE
Pipelines live in one folder, and reuse is written down

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -53,6 +53,20 @@ detached, registers YOUR tmux session as the founding lieutenant, installs the t
 at startup), scaffolds `AGENTS.md`, `captain.md`, `learnings/`, and prints the board URL.
 Give the user that URL — the board is the captain's cockpit.
 
+## 3b. Seed the workspace's pipelines (idempotent)
+
+```sh
+<checkout>/pipeline/seed.js --workspace "$(pwd)"
+```
+
+Copies the pipeline files that ship with the tool into
+`<workspace>/.bridge-commander/pipelines/`. From then on that folder is the only place a
+pipeline is read from, and the copies are the workspace's to edit. It never overwrites an
+existing file, so re-running is safe and tells you what it kept.
+
+This copies files and starts nothing. Cards still run through a pipeline only when a
+lieutenant asks for one by name.
+
 ## 4. Load your operating knowledge, in this order
 
 1. `DOCTRINE.md` (checkout root, per step 0) — how a lieutenant behaves. It is your job description.

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -38,7 +38,8 @@ prompts it would send. Nothing is spawned.
 ## What it does, in order
 
 1. Reads the card (`bc-axi card show --json`).
-2. Resolves the pipeline file: factory → workspace → project, key by key.
+2. Resolves the pipeline file in `<workspace>/.bridge-commander/pipelines/`, following
+   `extends: <name>` and merging the chain base-first, key by key.
 3. **Validates before spending a token.** Unknown key, misspelled variable, malformed
    stage, `{{run.output}}` where nothing runs — refused, naming the file and the key.
 4. Composes `preamble` + the stage's prompt, variables substituted.
@@ -127,13 +128,14 @@ implementer's work, quietly — `test/pipeline-run.test.js` pins that it does no
 | file | what |
 |---|---|
 | `run.js` | the entry and the loop: stages, rounds, escalation |
-| `config.js` | layer resolution, key-by-key merge, and the refusals |
+| `config.js` | the one folder, the `extends` chain, key-by-key merge, and the refusals |
 | `template.js` | `{{name}}` and `{{#name}}…{{/name}}`, and nothing else |
 | `stage.js` | run the commands, open the agent as a window, wait for the answer |
 | `state.js` | everything a restart needs to know, on disk |
 | `board.js` | the five things it may say to the board, through `bc-axi` |
 | `verdict.js` | `done` / `reject`, the stage agent's side |
-| `pipelines/validated-pr.yaml` | the factory default, and the document that explains it |
+| `seed.js` | copy the shipped pipelines into a workspace once, never overwriting |
+| `pipelines/validated-pr.yaml` | the seed copy, and the document that explains it |
 | `vendor/` | js-yaml, committed (the repo has no install step) |
 
 Tests live with the board's (`test/pipeline-*.test.js`) so the one suite command still

--- a/pipeline/config.js
+++ b/pipeline/config.js
@@ -1,20 +1,29 @@
 'use strict';
-// config — find the pipeline file, merge the layers, and REFUSE a bad one
+// config — find the pipeline file, walk what it extends, and REFUSE a bad one
 // before a single token is spent.
 //
-// Three layers, each optional except the factory one, merged key by key
-// (later wins; nested maps merge, lists replace):
+// ONE folder holds every pipeline this board can run:
 //
-//   1. <repo>/pipeline/pipelines/<name>.yaml          ships here, the default
-//   2. <workspace>/.bridge-commander/pipelines/<name>.yaml   this board's taste
-//   3. <project>/.bridge-commander/pipelines/<name>.yaml     this repo's needs
+//   <workspace>/.bridge-commander/pipelines/<name>.yaml
+//
+// The files are seeded there at setup (`pipeline/seed.js`) from the ones that
+// ship with the executor, and from then on they belong to the board. There is
+// no second place to look, so "which file is this?" always has one answer.
+//
+// Reuse is written down, never positional. A file that wants another as its
+// base says so by name, on a line you can read:
+//
+//   extends: validated-pr
+//
+// The chain is merged base-first, key by key (nested maps merge, lists
+// replace), so an extending file restates only what it changes. Bases resolve
+// by NAME inside the folder — never by path, because a path is how a second
+// place to look gets in.
 //
 // The file is meant to be edited by hand, which means it will be edited
 // wrongly. Validation is not politeness: every prompt in it becomes an agent
 // launch, so a typo caught here costs nothing and the same typo caught later
-// costs a worker's turn. Every error names the FILE and the KEY it came from —
-// with three layers in play, "max_rounds must be a positive integer" without a
-// filename is a scavenger hunt.
+// costs a worker's turn. Every error names the FILE and the KEY it came from.
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -30,57 +39,118 @@ const VARIABLES = [
   'bc', 'done', 'reject',
 ];
 
-const TOP_KEYS = ['name', 'worktree', 'max_rounds', 'preamble', 'working', 'validating'];
+const TOP_KEYS = ['name', 'extends', 'worktree', 'max_rounds', 'preamble', 'working', 'validating'];
 const STAGE_KEYS = ['prompt', 'run'];
 const STAGES = ['working', 'validating'];
+
+// How deep an extends chain may go before we call it a mistake. Nobody needs
+// eight levels of pipeline inheritance; a number this size only ever appears
+// by accident.
+const MAX_CHAIN = 8;
 
 function isPlainObject(v) {
   return !!v && typeof v === 'object' && !Array.isArray(v);
 }
 
-// layerFiles(opts) -> [path] — factory first, most specific last.
-function layerFiles({ repoRoot, workspace, projectPath, name }) {
-  const files = [path.join(repoRoot, 'pipeline', 'pipelines', name + '.yaml')];
-  if (workspace) files.push(path.join(workspace, '.bridge-commander', 'pipelines', name + '.yaml'));
-  if (projectPath) files.push(path.join(projectPath, '.bridge-commander', 'pipelines', name + '.yaml'));
-  return files;
+// pipelinesDir(workspace) -> the one folder. Exported because the seeder and
+// the error messages both need to name it, and they must never disagree.
+function pipelinesDir(workspace) {
+  return path.join(workspace, '.bridge-commander', 'pipelines');
+}
+function pipelineFile(workspace, name) {
+  return path.join(pipelinesDir(workspace), name + '.yaml');
 }
 
-// loadLayers(files) -> { layers: [{file, data}], errors: [] }
-// A file that is not there is not an error (layers 2 and 3 are opt-in); a file
-// that is there and unparseable is, with the line js-yaml points at.
-function loadLayers(files) {
-  const layers = [];
-  const errors = [];
-  for (const file of files) {
-    let text;
-    try {
-      text = fs.readFileSync(file, 'utf8');
-    } catch {
-      continue;
-    }
-    let data;
-    try {
-      data = yaml.load(text, { filename: file });
-    } catch (e) {
-      const line = e && e.mark && Number.isInteger(e.mark.line) ? e.mark.line + 1 : null;
-      errors.push(`${file}${line ? ':' + line : ''} — not valid YAML: ${String(e.reason || e.message).split('\n')[0]}`);
-      continue;
-    }
-    if (data === null || data === undefined) continue; // an empty override file overrides nothing
-    if (!isPlainObject(data)) {
-      errors.push(`${file} — a pipeline file must be a map of keys, got ${Array.isArray(data) ? 'a list' : typeof data}`);
-      continue;
-    }
-    layers.push({ file, data });
+// available(workspace) -> [name] — what is actually in the folder. A refusal
+// that lists the real alternatives beats one that only says "not found".
+function available(workspace) {
+  try {
+    return fs.readdirSync(pipelinesDir(workspace))
+      .filter((f) => f.endsWith('.yaml'))
+      .map((f) => f.slice(0, -'.yaml'.length))
+      .sort();
+  } catch {
+    return [];
   }
-  return { layers, errors };
+}
+
+// readOne(file) -> { data } | { error }
+function readOne(file) {
+  let text;
+  try {
+    text = fs.readFileSync(file, 'utf8');
+  } catch {
+    return { missing: true };
+  }
+  let data;
+  try {
+    data = yaml.load(text, { filename: file });
+  } catch (e) {
+    const line = e && e.mark && Number.isInteger(e.mark.line) ? e.mark.line + 1 : null;
+    return { error: `${file}${line ? ':' + line : ''} — not valid YAML: ${String(e.reason || e.message).split('\n')[0]}` };
+  }
+  if (data === null || data === undefined) return { data: {} }; // an empty file adds nothing
+  if (!isPlainObject(data)) {
+    return { error: `${file} — a pipeline file must be a map of keys, got ${Array.isArray(data) ? 'a list' : typeof data}` };
+  }
+  return { data };
+}
+
+// chain(workspace, name) -> { layers, files, errors }
+// Layers come back BASE FIRST, so merging them in order lets the file the
+// caller actually asked for win. `extends` is followed by name in the same
+// folder; a loop, a missing base or a silly depth is refused by name.
+function chain(workspace, name) {
+  const layers = [];
+  const files = [];
+  const seen = [];
+  let current = name;
+
+  while (current) {
+    const file = pipelineFile(workspace, current);
+    files.push(file);
+
+    if (seen.includes(current)) {
+      return {
+        layers: [], files,
+        errors: [`${file}: extends — loops back to "${current}" (${seen.concat(current).join(' → ')})`],
+      };
+    }
+    seen.push(current);
+
+    if (seen.length > MAX_CHAIN) {
+      return { layers: [], files, errors: [`${file}: extends — chain is more than ${MAX_CHAIN} files deep (${seen.join(' → ')})`] };
+    }
+
+    const r = readOne(file);
+    if (r.error) return { layers: [], files, errors: [r.error] };
+    if (r.missing) {
+      const known = available(workspace);
+      const where = layers.length
+        ? `${files[files.length - 2]}: extends — no pipeline named "${current}" in ${pipelinesDir(workspace)}`
+        : `no pipeline named "${current}" — ${pipelinesDir(workspace)} has no ${current}.yaml`;
+      return {
+        layers: [], files,
+        errors: [where + (known.length ? `\n  it holds: ${known.join(', ')}` : '\n  the folder is empty — seed it with pipeline/seed.js')],
+      };
+    }
+
+    const base = r.data.extends;
+    if (base !== undefined && (typeof base !== 'string' || !base.trim())) {
+      return { layers: [], files, errors: [`${file}: extends — must be the name of another pipeline in ${pipelinesDir(workspace)}`] };
+    }
+
+    layers.unshift({ file, data: r.data }); // base first
+    current = base ? base.trim() : '';
+  }
+
+  return { layers, files, errors: [] };
 }
 
 // merge(layers) — key by key, later layers winning. Nested maps merge so an
-// override can change one stage's prompt without restating the other stage;
-// lists (a stage's `run`) replace wholesale, because appending to someone
-// else's command list is never what you meant.
+// extending file can change one stage's prompt without restating the other
+// stage; lists (a stage's `run`) replace wholesale, because appending to
+// someone else's command list is never what you meant.
 function merge(layers) {
   const out = {};
   for (const { data } of layers) mergeInto(out, data);
@@ -180,22 +250,21 @@ function validate(pipeline, layers) {
   return errors;
 }
 
-// resolve(opts) -> { pipeline, layers, files, errors }
+// resolve({ workspace, name }) -> { pipeline, layers, files, errors }
 // errors non-empty = refuse. The caller reports them and stops; nothing is
 // spawned, nothing is spent.
-function resolve(opts) {
-  const files = layerFiles(opts);
-  const { layers, errors: loadErrors } = loadLayers(files);
-  if (!layers.length) {
-    return {
-      pipeline: null, layers, files,
-      errors: loadErrors.length ? loadErrors
-        : [`no pipeline named "${opts.name}" — looked in:\n  ` + files.join('\n  ')],
-    };
-  }
+function resolve({ workspace, name }) {
+  const { layers, files, errors: chainErrors } = chain(workspace, name);
+  if (chainErrors.length) return { pipeline: null, layers, files, errors: chainErrors };
+
   const pipeline = merge(layers);
-  const errors = loadErrors.concat(validate(pipeline, layers));
-  return { pipeline, layers, files, errors };
+  // `extends` did its job during the walk; it is not a runtime key, and leaving
+  // it in would put a name nothing reads into the thing agents are launched from.
+  delete pipeline.extends;
+  return { pipeline, layers, files, errors: validate(pipeline, layers) };
 }
 
-module.exports = { VARIABLES, TOP_KEYS, STAGE_KEYS, STAGES, layerFiles, loadLayers, merge, sourceOf, validate, resolve };
+module.exports = {
+  VARIABLES, TOP_KEYS, STAGE_KEYS, STAGES, MAX_CHAIN,
+  pipelinesDir, pipelineFile, available, chain, merge, sourceOf, validate, resolve,
+};

--- a/pipeline/pipelines/validated-pr.yaml
+++ b/pipeline/pipelines/validated-pr.yaml
@@ -1,14 +1,25 @@
 # ─────────────────────────────────────────────────────────────────────────────
-# pipeline: validated-pr   (factory default)
+# pipeline: validated-pr   (the seed copy)
 #
 # This file IS the pipeline's behaviour, and also the whole worker brief for
 # both of its stages. Edit here: no code change, no restart.
 #
-# Precedence, per key (nested maps merge, lists replace):
-#   1. this file                                          ships with the executor
-#   2. <workspace>/.bridge-commander/pipelines/validated-pr.yaml
-#   3. <project>/.bridge-commander/pipelines/validated-pr.yaml
-# Delete your copy and the factory one you are reading comes back.
+# You are reading one of two things. In the executor's own `pipeline/pipelines/`
+# it is a seed, copied into a workspace once by `pipeline/seed.js`. In
+# `<workspace>/.bridge-commander/pipelines/` it is the live file — the only
+# place a pipeline is ever read from, and yours to edit.
+#
+# To reuse this rather than fork it, leave it alone and write a new file beside
+# it that names it (nested maps merge, lists replace):
+#
+#   # validated-pr-mine.yaml
+#   extends: validated-pr
+#   validating:
+#     run:
+#       - node --test
+#
+# Then start the card with `--pipeline validated-pr-mine`. Bases resolve by name
+# in this same folder — a path is not a name, and will not resolve.
 #
 # Check it before you spend anything on it:
 #   pipeline/run.js <card-id> --workspace <dir> --check

--- a/pipeline/run.js
+++ b/pipeline/run.js
@@ -294,9 +294,7 @@ async function main(argv) {
   if (!project) throw new Error(`card ${card.id} has no registered project (repo attribute: ${repo || 'unset'})`);
 
   const pipelineName = opts.pipeline || project.pipeline || DEFAULT_PIPELINE;
-  const r = resolve({
-    repoRoot: REPO_ROOT, workspace: opts.workspace, projectPath: project.path, name: pipelineName,
-  });
+  const r = resolve({ workspace: opts.workspace, name: pipelineName });
 
   const runDir = path.join(opts.workspace, '.bridge-commander', 'pipeline', card.id);
   if (r.errors.length) {
@@ -372,7 +370,9 @@ async function main(argv) {
   }
 
   if (opts.check) {
-    process.stdout.write(`pipeline ${pipelineName} is valid (layers: ${r.layers.map((l) => l.file).join(', ')})\n`);
+    // Base first, in merge order: the last file named is the one that wins a
+    // conflict, which is the question anybody reading this line actually has.
+    process.stdout.write(`pipeline ${pipelineName} is valid (${r.layers.map((l) => l.file).join('\n  merged into ')})\n`);
     for (const name of ['working', 'validating']) {
       if (skipped(r.pipeline[name])) { process.stdout.write(`\n=== ${name}: skipped ===\n`); continue; }
       process.stdout.write(`\n=== ${name} (round ${state.round}) ===\n` + compose(ctx, name, state.round, '<run output>') + '\n');

--- a/pipeline/seed.js
+++ b/pipeline/seed.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+'use strict';
+// seed — copy the pipelines that ship with the executor into a workspace, once.
+//
+//   pipeline/seed.js --workspace <dir>
+//
+// After this runs, <workspace>/.bridge-commander/pipelines/ is the ONLY place
+// a pipeline is read from. The copies belong to the board: edit them, add to
+// them, extend them. That is the point — a file you can edit beats a factory
+// default you have to override from somewhere else.
+//
+// It NEVER overwrites. A file you have edited is the whole value of the folder,
+// and a seeder that clobbers it on the next setup run is a seeder nobody can
+// afford to run twice. Re-running is safe and says what it kept.
+//
+// The cost of copying instead of layering is drift: a newer executor may ship
+// keys your copy has never heard of. That is why `--check` validates every key
+// against the executor's current schema and names the file — a stale copy fails
+// loudly at the door instead of quietly at round three.
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { pipelinesDir } = require('./config.js');
+
+const SHIPPED = path.join(__dirname, 'pipelines');
+
+function parseArgs(argv) {
+  const out = { workspace: process.env.BC_WORKSPACE || '' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--workspace') out.workspace = argv[++i];
+    else throw new Error(`unexpected argument ${argv[i]}`);
+  }
+  if (!out.workspace) {
+    throw new Error('usage: pipeline/seed.js --workspace <dir>   (or BC_WORKSPACE)\n'
+      + '  copies the shipped pipelines into <dir>/.bridge-commander/pipelines/, never overwriting.');
+  }
+  return out;
+}
+
+// seed(workspace) -> { dir, written: [name], kept: [name] }
+function seed(workspace) {
+  const dir = pipelinesDir(workspace);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const written = [];
+  const kept = [];
+  for (const file of fs.readdirSync(SHIPPED).filter((f) => f.endsWith('.yaml')).sort()) {
+    const dest = path.join(dir, file);
+    if (fs.existsSync(dest)) { kept.push(file); continue; }
+    fs.copyFileSync(path.join(SHIPPED, file), dest);
+    written.push(file);
+  }
+  return { dir, written, kept };
+}
+
+function main(argv) {
+  const { workspace } = parseArgs(argv);
+  const r = seed(workspace);
+  process.stdout.write(`pipelines: ${r.dir}\n`);
+  for (const f of r.written) process.stdout.write(`  seeded ${f}\n`);
+  for (const f of r.kept) process.stdout.write(`  kept   ${f} (yours — not overwritten)\n`);
+  if (!r.written.length && !r.kept.length) process.stdout.write('  nothing shipped to seed\n');
+  return 0;
+}
+
+module.exports = { seed, SHIPPED };
+
+if (require.main === module) {
+  try {
+    process.exit(main(process.argv.slice(2)));
+  } catch (e) {
+    process.stderr.write(String(e.message || e) + '\n');
+    process.exit(1);
+  }
+}

--- a/test/pipeline-config.test.js
+++ b/test/pipeline-config.test.js
@@ -3,67 +3,131 @@
 // it WILL be edited wrongly. Every prompt in it becomes an agent launch, so a
 // mistake caught here costs nothing and the same mistake caught later costs a
 // worker's turn. What is pinned below is that the refusal happens, and that it
-// says WHERE — with three layers in play, an error without a filename is a
-// scavenger hunt.
+// says WHERE — an error without a filename is a scavenger hunt.
+//
+// It also pins the shape of the lookup itself: ONE folder, and reuse that is
+// written down (`extends: <name>`) instead of inferred from which directory a
+// file happens to sit in.
 const test = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { resolve, merge, sourceOf, validate } = require('../pipeline/config.js');
+const { resolve, merge, sourceOf, validate, chain, available, pipelinesDir, MAX_CHAIN } = require('../pipeline/config.js');
+const { seed } = require('../pipeline/seed.js');
 const { render, refs } = require('../pipeline/template.js');
 
-const REPO = path.join(__dirname, '..');
-
-// A workspace/project layer on disk, so precedence is tested the way it runs.
-function layerDir(root, kind, name, body) {
-  const dir = kind === 'workspace'
-    ? path.join(root, 'ws', '.bridge-commander', 'pipelines')
-    : path.join(root, 'proj', '.bridge-commander', 'pipelines');
+// A workspace on disk, so resolution is tested the way it runs.
+function write(ws, name, body) {
+  const dir = pipelinesDir(ws);
   fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(path.join(dir, name + '.yaml'), body);
-  return dir;
 }
-function withRoot(fn) {
-  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-pipe-cfg-'));
-  try { return fn(root); } finally { fs.rmSync(root, { recursive: true, force: true }); }
-}
-function resolveIn(root, name = 'validated-pr') {
-  return resolve({
-    repoRoot: REPO, workspace: path.join(root, 'ws'), projectPath: path.join(root, 'proj'), name,
-  });
+function withWorkspace(fn, { seeded = true } = {}) {
+  const ws = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-pipe-cfg-'));
+  try {
+    if (seeded) seed(ws);
+    return fn(ws);
+  } finally {
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
 }
 
-test('the factory pipeline validates as shipped', () => {
-  const r = resolveIn(path.join(os.tmpdir(), 'no-such-root'));
-  assert.deepStrictEqual(r.errors, []);
-  assert.strictEqual(r.pipeline.name, 'validated-pr');
-  assert.strictEqual(r.pipeline.max_rounds, 3);
-  assert.ok(r.pipeline.working.prompt.includes('{{done}}'), 'the implementer is told how to report');
-  assert.ok(r.pipeline.validating.run.length, 'validation runs something before it judges');
+test('a seeded workspace validates as shipped', () => {
+  withWorkspace((ws) => {
+    const r = resolve({ workspace: ws, name: 'validated-pr' });
+    assert.deepStrictEqual(r.errors, []);
+    assert.strictEqual(r.pipeline.name, 'validated-pr');
+    assert.strictEqual(r.pipeline.max_rounds, 3);
+    assert.ok(r.pipeline.working.prompt.includes('{{done}}'), 'the implementer is told how to report');
+    assert.ok(r.pipeline.validating.run.length, 'validation runs something before it judges');
+  });
 });
 
-test('layers merge key by key: nested maps merge, lists replace, later wins', () => {
-  withRoot((root) => {
-    layerDir(root, 'workspace', 'validated-pr', 'max_rounds: 5\nvalidating:\n  run:\n    - echo ws\n');
-    layerDir(root, 'project', 'validated-pr', 'working:\n  prompt: |\n    just do it, {{card.id}}\n');
-    const r = resolveIn(root);
+test('seeding is a copy into the workspace, and it never clobbers your edits', () => {
+  withWorkspace((ws) => {
+    const mine = path.join(pipelinesDir(ws), 'validated-pr.yaml');
+    assert.ok(fs.existsSync(mine), 'the first seed wrote it');
+
+    fs.writeFileSync(mine, 'max_rounds: 9\nworking:\n  prompt: mine\nvalidating: none\n');
+    const again = seed(ws);
+    assert.deepStrictEqual(again.written, [], 'nothing was written the second time');
+    assert.ok(again.kept.includes('validated-pr.yaml'), 'and it says what it kept');
+    assert.strictEqual(resolve({ workspace: ws, name: 'validated-pr' }).pipeline.max_rounds, 9,
+      'the edited file survived — that is the whole point of the folder');
+  });
+});
+
+test('extends merges base first: nested maps merge, lists replace, the extender wins', () => {
+  withWorkspace((ws) => {
+    write(ws, 'ours', 'extends: validated-pr\nmax_rounds: 5\nvalidating:\n  run:\n    - node --test\n');
+    const r = resolve({ workspace: ws, name: 'ours' });
     assert.deepStrictEqual(r.errors, []);
-    assert.strictEqual(r.pipeline.max_rounds, 5, 'the workspace layer won');
-    assert.strictEqual(r.pipeline.working.prompt.trim(), 'just do it, {{card.id}}', 'the project layer won');
-    assert.deepStrictEqual(r.pipeline.validating.run, ['echo ws'], 'a list replaces, it does not append');
+    assert.strictEqual(r.pipeline.max_rounds, 5, 'the extending file won');
+    assert.deepStrictEqual(r.pipeline.validating.run, ['node --test'], 'a list replaces, it does not append');
     assert.ok(r.pipeline.validating.prompt.includes('{{run.output}}'),
-      'the untouched half of the overridden stage still comes from the factory');
+      'the untouched half of the overridden stage still comes from the base');
     assert.ok(r.pipeline.preamble.includes('Ground rules'), 'and so does everything nobody overrode');
+    assert.strictEqual(r.pipeline.extends, undefined, 'extends did its job during the walk; it is not a runtime key');
+    assert.deepStrictEqual(r.layers.map((l) => path.basename(l.file)),
+      ['validated-pr.yaml', 'ours.yaml'], 'layers come back base first, in merge order');
+  });
+});
+
+test('a chain of three resolves, and depth is bounded', () => {
+  withWorkspace((ws) => {
+    write(ws, 'mid', 'extends: validated-pr\nmax_rounds: 7\n');
+    write(ws, 'top', 'extends: mid\nname: top\n');
+    const r = resolve({ workspace: ws, name: 'top' });
+    assert.deepStrictEqual(r.errors, []);
+    assert.strictEqual(r.pipeline.max_rounds, 7, 'inherited through the middle file');
+    assert.strictEqual(r.pipeline.name, 'top');
+    assert.ok(r.pipeline.working.prompt.includes('{{done}}'), 'and the root is still in there');
+
+    for (let i = 0; i < MAX_CHAIN + 2; i++) write(ws, 'deep' + i, `extends: deep${i + 1}\n`);
+    const deep = resolve({ workspace: ws, name: 'deep0' });
+    assert.match(deep.errors[0], new RegExp(`more than ${MAX_CHAIN} files deep`));
+  });
+});
+
+test('a loop is refused by name, not by running out of stack', () => {
+  withWorkspace((ws) => {
+    write(ws, 'a', 'extends: b\n');
+    write(ws, 'b', 'extends: a\n');
+    const r = resolve({ workspace: ws, name: 'a' });
+    assert.strictEqual(r.pipeline, null);
+    assert.match(r.errors[0], /extends — loops back to "a"/);
+    assert.match(r.errors[0], /a → b → a/);
+  });
+});
+
+test('extending something that is not there names the file that asked for it', () => {
+  withWorkspace((ws) => {
+    write(ws, 'ours', 'extends: no-such-base\n');
+    const r = resolve({ workspace: ws, name: 'ours' });
+    assert.match(r.errors[0], /ours\.yaml: extends — no pipeline named "no-such-base"/);
+    assert.match(r.errors[0], /it holds: .*validated-pr/, 'and it lists what you could have meant');
+  });
+});
+
+test('extends must be a name in the folder — never a path', () => {
+  withWorkspace((ws) => {
+    write(ws, 'ours', 'extends: 4\n');
+    assert.match(resolve({ workspace: ws, name: 'ours' }).errors[0], /extends — must be the name of another pipeline/);
+
+    write(ws, 'pathy', 'extends: "../../elsewhere/validated-pr"\n');
+    const r = resolve({ workspace: ws, name: 'pathy' });
+    assert.ok(r.errors.length, 'a path does not resolve to a pipeline');
+    assert.match(r.errors[0], /no pipeline named/);
   });
 });
 
 test('an error names the file the key actually came from', () => {
-  withRoot((root) => {
-    layerDir(root, 'workspace', 'validated-pr', 'max_rounds: 0\n');
-    const r = resolveIn(root);
+  withWorkspace((ws) => {
+    write(ws, 'ours', 'extends: validated-pr\nmax_rounds: 0\n');
+    const r = resolve({ workspace: ws, name: 'ours' });
     assert.strictEqual(r.errors.length, 1, r.errors.join('\n'));
-    assert.match(r.errors[0], /ws\/\.bridge-commander\/pipelines\/validated-pr\.yaml: max_rounds/);
+    assert.match(r.errors[0], /pipelines\/ours\.yaml: max_rounds/);
     assert.match(r.errors[0], /1 or more/);
   });
 });
@@ -75,6 +139,7 @@ test('refusals: unknown keys, malformed stages, and a stage that cannot report',
   let e = errs({ max_rounds: 3, rounds: 4, working: { prompt: 'x' }, validating: 'none' });
   assert.strictEqual(e.length, 1);
   assert.match(e[0], /rounds — unknown key/);
+  assert.match(e[0], /known: name, extends/, 'and extends is listed as a thing you may write');
 
   e = errs({ max_rounds: 3, working: { prompt: 'x', retry: true }, validating: 'none' });
   assert.match(e[0], /working\.retry — unknown stage key/);
@@ -118,30 +183,48 @@ test('a misspelled variable is an error, because a rendered typo is invisible', 
 });
 
 test('broken YAML is refused with the line, not a stack trace', () => {
-  withRoot((root) => {
-    layerDir(root, 'workspace', 'validated-pr', 'max_rounds: 3\nworking:\n  prompt: [unclosed\n');
-    const r = resolveIn(root);
-    assert.match(r.errors[0], /validated-pr\.yaml:\d+ — not valid YAML/);
+  withWorkspace((ws) => {
+    write(ws, 'ours', 'max_rounds: 3\nworking:\n  prompt: [unclosed\n');
+    const r = resolve({ workspace: ws, name: 'ours' });
+    assert.match(r.errors[0], /ours\.yaml:\d+ — not valid YAML/);
   });
 });
 
-test('a pipeline nobody wrote is a refusal that lists where it looked', () => {
-  withRoot((root) => {
-    const r = resolveIn(root, 'no-such-pipeline');
+test('a pipeline nobody wrote is a refusal that names the one folder', () => {
+  withWorkspace((ws) => {
+    const r = resolve({ workspace: ws, name: 'no-such-pipeline' });
     assert.strictEqual(r.pipeline, null);
     assert.match(r.errors[0], /no pipeline named "no-such-pipeline"/);
-    assert.match(r.errors[0], /pipeline\/pipelines\/no-such-pipeline\.yaml/);
+    assert.match(r.errors[0], /pipelines has no no-such-pipeline\.yaml/);
+    assert.match(r.errors[0], /it holds: .*validated-pr/);
+  });
+});
+
+test('an unseeded workspace says so instead of pointing at a file nobody has', () => {
+  withWorkspace((ws) => {
+    assert.deepStrictEqual(available(ws), [], 'nothing seeded');
+    const r = resolve({ workspace: ws, name: 'validated-pr' });
+    assert.match(r.errors[0], /the folder is empty — seed it with pipeline\/seed\.js/);
+  }, { seeded: false });
+});
+
+test('the chain is the only place a pipeline is read from', () => {
+  withWorkspace((ws) => {
+    const { files } = chain(ws, 'validated-pr');
+    assert.strictEqual(files.length, 1);
+    assert.strictEqual(files[0], path.join(ws, '.bridge-commander', 'pipelines', 'validated-pr.yaml'),
+      'one folder, one file — no repo layer, no project layer');
   });
 });
 
 test('sourceOf points at the LAST layer that set the key', () => {
   const layers = [
-    { file: 'factory.yaml', data: { max_rounds: 3, working: { prompt: 'a', run: ['x'] } } },
-    { file: 'ws.yaml', data: { working: { prompt: 'b' } } },
+    { file: 'base.yaml', data: { max_rounds: 3, working: { prompt: 'a', run: ['x'] } } },
+    { file: 'ours.yaml', data: { working: { prompt: 'b' } } },
   ];
-  assert.strictEqual(sourceOf(layers, 'max_rounds'), 'factory.yaml');
-  assert.strictEqual(sourceOf(layers, 'working.prompt'), 'ws.yaml');
-  assert.strictEqual(sourceOf(layers, 'working.run'), 'factory.yaml');
+  assert.strictEqual(sourceOf(layers, 'max_rounds'), 'base.yaml');
+  assert.strictEqual(sourceOf(layers, 'working.prompt'), 'ours.yaml');
+  assert.strictEqual(sourceOf(layers, 'working.run'), 'base.yaml');
   assert.deepStrictEqual(merge(layers).working, { prompt: 'b', run: ['x'] });
 });
 


### PR DESCRIPTION
## What was wrong

`config.js` resolved a pipeline from three directories at once — the executor's own checkout, the workspace, and the project — merging whatever it found. Which file counted as "the factory default" came from `path.join(__dirname, '..')`, so it depended on which checkout `run.js` was launched from. This machine has two, holding byte-identical copies of `validated-pr.yaml`. Editing the wrong one changed nothing and reported nothing.

The layering was also positional: you could not tell what a file would become by reading it, only by knowing which of three slots it landed in.

## What landed

**One folder.** `<workspace>/.bridge-commander/pipelines/` is the only place a pipeline is read from. `pipeline/seed.js` copies the shipped files in once at setup; from then on they belong to the board and are yours to edit. It never overwrites — an edited pipeline is the whole value of the folder, and a seeder that clobbers it is one nobody can afford to run twice.

**Reuse is written down.** A file that wants another as its base names it:

```yaml
extends: validated-pr
validating:
  run:
    - node --test
```

The chain merges base-first, key by key (nested maps merge, lists replace), so an extending file restates only what it changes. Bases resolve **by name inside the folder** — a path is not a name and will not resolve, because a path is how a second place to look gets back in.

**Refusals name things.** Loops (`a → b → a`), missing bases, non-string `extends`, and chains over 8 deep are all refused before anything is spawned, and a refusal lists what the folder actually holds. `--check` now prints the chain in merge order, so the file that wins a conflict is the last one named.

## The tradeoff, stated

A copy is a fork: a newer executor may ship keys your copy has never heard of. That is why `--check` validates every key against the executor's current schema and names the file — a stale copy fails loudly at the door instead of quietly at round three.

## Inertness is intact

Seeding lives in `SKILL.md`, not in `cli/bc-axi`. It copies files and starts nothing; a card runs through a pipeline only when a lieutenant asks for one by name. `test/pipeline-inert.test.js` passes untouched.

## Tests

Full suite green: **560 passed, 0 failed** (`node --test test/*.test.js harness/test/*.test.js`).

`test/pipeline-config.test.js` rewritten around the new shape — seeding and its non-clobbering, base-first merge order, a three-file chain, depth bound, loop refusal, missing base, `extends`-is-not-a-path, the unseeded-workspace message, and that only one folder is ever read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)