### PR TITLE
pipeline_runs, because pipeline/ next to pipelines/ is a trap

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -55,7 +55,7 @@ prompts it would send. Nothing is spawned.
 
 `state.json` answers *where am I* and is overwritten on every move. The journal answers
 *what has ever happened* and is never overwritten: one JSON object per line, appended, at
-`<workspace>/.bridge-commander/pipeline/runs.jsonl`, across every run of every card.
+`<workspace>/.bridge-commander/pipeline_runs/runs.jsonl`, across every run of every card.
 
 Verdicts and prompts go in **whole**. A findings text folded into a summary is exactly the
 part worth reading a month later.
@@ -116,7 +116,7 @@ fix is the failure this pipeline exists to prevent, and it hides well.
 ## Resume
 
 The command harness's `resume` re-runs the command from the top, so "where was I" cannot
-live in memory. It lives in `<workspace>/.bridge-commander/pipeline/<card-id>/`: the
+live in memory. It lives in `<workspace>/.bridge-commander/pipeline_runs/<card-id>/`: the
 stage, the round, the last findings, the agent refs, one prompt file and one verdict file
 per stage per round, and the `run` output cached per round so a restart never pays for an
 expensive validation run twice. A restarted executor re-attaches to the agent it was

--- a/pipeline/journal.js
+++ b/pipeline/journal.js
@@ -23,7 +23,7 @@ const path = require('node:path');
 const MAX_FIELD = 64 * 1024;
 
 function journalFile(workspace) {
-  return path.join(workspace, '.bridge-commander', 'pipeline', 'runs.jsonl');
+  return path.join(workspace, '.bridge-commander', 'pipeline_runs', 'runs.jsonl');
 }
 
 function clip(v) {

--- a/pipeline/run.js
+++ b/pipeline/run.js
@@ -296,7 +296,7 @@ async function main(argv) {
   const pipelineName = opts.pipeline || project.pipeline || DEFAULT_PIPELINE;
   const r = resolve({ workspace: opts.workspace, name: pipelineName });
 
-  const runDir = path.join(opts.workspace, '.bridge-commander', 'pipeline', card.id);
+  const runDir = path.join(opts.workspace, '.bridge-commander', 'pipeline_runs', card.id);
   if (r.errors.length) {
     // Refused BEFORE a single token: this file is meant to be edited by hand,
     // and the point of the seatbelt is that a hand slip stays recoverable.

--- a/test/pipeline-run.test.js
+++ b/test/pipeline-run.test.js
@@ -81,7 +81,7 @@ async function boot() {
   fs.mkdirSync(pipes, { recursive: true });
   fs.writeFileSync(path.join(pipes, 'tiny.yaml'), TINY);
 
-  const runDir = path.join(s.dir, '.bridge-commander', 'pipeline', 'demo');
+  const runDir = path.join(s.dir, '.bridge-commander', 'pipeline_runs', 'demo');
   return {
     s, root, fdir, runDir, wt,
     teardown: async () => { await s.stop(); fs.rmSync(root, { recursive: true, force: true }); },
@@ -366,7 +366,7 @@ test('the journal keeps every run, whole, and a second run appends instead of ov
       '--outcome', 'good — https://github.com/o/r/pull/7']);
     assert.strictEqual(await exited, 0, out.text);
 
-    const jfile = path.join(s.dir, '.bridge-commander', 'pipeline', 'runs.jsonl');
+    const jfile = path.join(s.dir, '.bridge-commander', 'pipeline_runs', 'runs.jsonl');
     const lines = () => fs.readFileSync(jfile, 'utf8').trim().split('\n').map((l) => JSON.parse(l));
     const first = lines();
     assert.ok(first.length >= 8, 'every step is a line:\n' + first.map((r) => r.kind).join(', '));


### PR DESCRIPTION
## Why

`.bridge-commander/pipeline/` and `.bridge-commander/pipelines/` sit next to each other, one letter apart, and hold completely different things:

| | what | size here |
|---|---|---|
| `pipelines/` | three YAMLs, meant to be hand-edited | 21 KB |
| `pipeline/` | 29 folders of machine-written run state — prompts sent, verdicts, cached run output, the journal | 8.6 MB |

The captain read the wrong one within a minute of being shown the folder. That is the argument.

## What changed

The run-state directory becomes `.bridge-commander/pipeline_runs/`. Two source sites (`run.js:299`, `journal.js:26`), the two tests that assert those paths, and the two lines in `pipeline/README.md`.

No migration code. Nothing is in flight, and an orphaned old directory only costs a resume of a run nobody wants resumed.

## Tests

Full suite green: **560 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)