### PR TITLE
The ray lands where it points, and the chat says a name once

### DIFF
--- a/ui/js/bridge3d/main.js
+++ b/ui/js/bridge3d/main.js
@@ -141,6 +141,8 @@ async function refresh() {
 
 const raycaster = new THREE.Raycaster();
 const tmpMat = new THREE.Matrix4();
+const tmpOrigin = new THREE.Vector3();
+const tmpDir = new THREE.Vector3();
 
 function pick(origin, direction) {
   raycaster.ray.origin.copy(origin);
@@ -171,6 +173,7 @@ function activate(hit) {
 
 // ---------- controllers: point, squeeze to carry, stick to size ----------
 
+const REACH = 2.5;                  // how far the ray goes when it hits nothing
 const controllers = [];
 const held = new Map();             // controller -> { surface, w, h }
 for (let i = 0; i < 2; i++) {
@@ -179,16 +182,32 @@ for (let i = 0; i < 2; i++) {
     new THREE.BufferGeometry().setFromPoints([new THREE.Vector3(0, 0, 0), new THREE.Vector3(0, 0, -1)]),
     new THREE.LineBasicMaterial({ color: 0x4cc2ff }),
   );
-  ray.scale.z = 2.5;
-  c.add(ray);
+  ray.scale.z = REACH;
+  // The dot rides on the controller, not on the ray: the ray is scaled in z to
+  // the hit distance, and a child of it would be stretched by the same amount.
+  const dot = new THREE.Mesh(
+    new THREE.SphereGeometry(0.012, 10, 8),
+    new THREE.MeshBasicMaterial({ color: 0x4cc2ff }),
+  );
+  dot.visible = false;
+  c.add(ray, dot);
   scene.add(c);
   controllers.push(c);
 
   const aim = () => {
     tmpMat.identity().extractRotation(c.matrixWorld);
-    const o = new THREE.Vector3().setFromMatrixPosition(c.matrixWorld);
-    const d = new THREE.Vector3(0, 0, -1).applyMatrix4(tmpMat).normalize();
-    return pick(o, d);
+    tmpOrigin.setFromMatrixPosition(c.matrixWorld);
+    tmpDir.set(0, 0, -1).applyMatrix4(tmpMat).normalize();
+    return pick(tmpOrigin, tmpDir);
+  };
+  // A ray that goes through what it is pointing at reads as "nothing here", so
+  // every frame it is cut to the surface it lands on and the dot marks the spot.
+  c.userData.aim = () => {
+    const hit = aim();
+    const len = hit ? hit.distance : REACH;
+    ray.scale.z = len;
+    dot.position.z = -len;
+    dot.visible = !!hit;
   };
 
   c.addEventListener('selectstart', () => activate(aim()));
@@ -356,10 +375,11 @@ renderer.setAnimationLoop((t) => {
   const dt = last ? Math.min(0.1, (t - last) / 1000) : 0.016;
   last = t;
   readGamepads(dt);
+  if (renderer.xr.isPresenting) for (const c of controllers) c.userData.aim();
   renderer.render(scene, camera);
 });
 
-window.__bridge = { state, windows, board, bar, open, close, layout, get doc() { return doc; } };
+window.__bridge = { state, windows, board, bar, controllers, open, close, layout, get doc() { return doc; } };
 
 refresh().then(() => { layout(); document.getElementById('gate').classList.add('ready'); });
 setInterval(refresh, 5000);

--- a/ui/js/bridge3d/panels.js
+++ b/ui/js/bridge3d/panels.js
@@ -176,6 +176,12 @@ export class CardWindow extends Surface {
   // Painted from the bottom up: the newest line is the one he wants, and a chat
   // that scrolls off the top is normal where one that scrolls off the bottom is
   // a bug you notice every single time.
+  //
+  // Who is speaking is NOT written on every message. This is a conversation with
+  // exactly one other party, and the title bar already names them — a per-message
+  // name is the same word repeated down the whole column, and it is the copy that
+  // scrolls away while the title bar stays. What the board's own chat does is the
+  // same: the bubble's side carries the identity, the footer carries the time.
   _chat(g, msgs, x, top, width, h, colour) {
     let y = h - PAD;
     for (let i = msgs.length - 1; i >= 0 && y > top + 30; i--) {
@@ -190,12 +196,18 @@ export class CardWindow extends Surface {
       if (y < top + 6) break;
       g.fillStyle = mine ? '#16202c' : '#0f1620';
       g.fillRect(x - 8, y - 4, width + 16, blockH);
+      // The side bar is who: the captain's own accent against the lieutenant's
+      // own colour, the same mark the board puts on a card for its owner.
       g.fillStyle = mine ? COL.accent : (colour || COL.dim);
-      g.font = '600 19px ' + UI;
-      g.fillText((mine ? 'you' : m.author) + '  ' + ago(m.ts), x, y + 16);
+      g.fillRect(x - 8, y - 4, 4, blockH);
       g.fillStyle = COL.dim;
       g.font = '21px ' + UI;
-      lines.forEach((ln, k) => g.fillText(ln, x, y + 42 + k * 26));
+      lines.forEach((ln, k) => g.fillText(ln, x + 4, y + 18 + k * 26));
+      g.fillStyle = COL.faint;
+      g.font = '18px ' + UI;
+      g.textAlign = 'right';
+      g.fillText(ago(m.ts), x + width, y + blockH - 6);
+      g.textAlign = 'left';
       y -= 10;
     }
   }


### PR DESCRIPTION
# Description

Two things the captain hit on his first real session in the room: the aiming ray ran straight through whatever it was pointing at, so a card you were aimed at read as "nothing here", and the chat column repeated the speaker's name on every single message while the title bar already said who this was. The ray now stops at the surface it hits with a dot on the spot, and the per-message name is gone — identity moved to a coloured stripe on the bubble, the same mark the board already puts on a card for its owner, which is the copy that survives a long conversation instead of scrolling away.

## Type of change

- [x] Bug fix / polish (non-breaking)

## How has this change been tested?

- Existing suite green (568 tests); the room has no automated coverage and this PR does not add any.
- Ray driven live on `ui/bridge3d.html` against the fixture board, one controller at a time: aimed at the nearest window it reports `scale.z = 1.462` with the dot at `z = -1.462` and the board correctly ignored behind it at 3.118; aimed away it goes back to 2.500 with the dot hidden. The two controllers were confirmed independent by swapping which hand was pointing.
- Both chat surfaces painted to a plain canvas and looked at (renders attached to the card).

## Any specific deployment considerations

- None — static UI only. The desk (non-XR) path has no ray and is untouched; the per-frame pick is behind `renderer.xr.isPresenting`.
