### PR TITLE
The room, to spec — arc, comfort, and faces

### DIFF
--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -1,10 +1,15 @@
-// The room's policy — where a window stands, and what standing in front means.
-// Everything else in bridge3d needs a WebGL context and a head, and is checked
-// by wearing it.
+// The room's policy — where a window stands, and what standing in front means —
+// and, at the bottom, what the panels actually PAINT, measured in arc.
 //
 // The rules under test are the captain's, stated by him: the lieutenants are
 // always in front, the board is where he decides what to look at next, the
 // windows are the work, and nothing is ever put behind his head.
+//
+// A room only needs a head for the parts that are a head: the renderer and the
+// session. The painting is a 2D canvas, and a 2D canvas can be faked, which is
+// how the region arithmetic gets checked here rather than by wearing it. A test
+// that only asserts the CONSTANTS say 3° cannot fail when the box drawn from
+// them arrives at 2.58°, and that is exactly what shipped once.
 
 const test = require('node:test');
 const assert = require('node:assert');
@@ -15,7 +20,7 @@ const load = (f) => import(path.join(UI, f));
 
 test('every window stands in front of him — never behind, never inside him', async () => {
   const { placeWindow, EYE } = await load('room.js');
-  for (let count = 1; count <= 9; count++) {
+  for (let count = 1; count <= 12; count++) {
     for (let i = 0; i < count; i++) {
       const p = placeWindow(i, count);
       assert.ok(p.z < -0.6, `window ${i}/${count} is not in front (z=${p.z})`);
@@ -32,13 +37,18 @@ test('every window stands in front of him — never behind, never inside him', a
 
 test('windows do not land on top of each other', async () => {
   const { placeWindow } = await load('room.js');
-  const seen = [];
-  for (let i = 0; i < 6; i++) {
-    const p = placeWindow(i, 6);
-    for (const q of seen) {
-      assert.ok(Math.hypot(p.x - q.x, p.y - q.y, p.z - q.z) > 0.25, 'two windows in the same place');
+  // Past nine they crowd into the last row rather than starting a fourth, so
+  // this walks well beyond the rows to catch the crowding turning into a pile.
+  for (let count = 1; count <= 12; count++) {
+    const seen = [];
+    for (let i = 0; i < count; i++) {
+      const p = placeWindow(i, count);
+      for (const q of seen) {
+        assert.ok(Math.hypot(p.x - q.x, p.y - q.y, p.z - q.z) > 0.25,
+          `two of ${count} windows in the same place`);
+      }
+      seen.push(p);
     }
-    seen.push(p);
   }
 });
 
@@ -110,7 +120,7 @@ async function places() {
     { name: 'board, in front', panel: PANEL.board, at: FRONT, primary: true },
     { name: 'board, pushed back', panel: PANEL.board, at: BACK },
   ];
-  for (let count = 1; count <= 9; count++) {
+  for (let count = 1; count <= 12; count++) {
     for (let i = 0; i < count; i++) {
       const at = placeWindow(i, count);
       out.push({ name: `card window ${i}/${count}`, panel: PANEL.card, at });
@@ -237,4 +247,134 @@ test('arc and metres convert both ways', async () => {
   }
   // The small-angle rule of thumb the skill quotes: 57.3 × size / distance.
   assert.ok(Math.abs(arcDeg(0.04, 1.5) - 57.3 * 0.04 / 1.5) < 0.01);
+});
+
+// ---- what the panels actually paint -----------------------------------------
+//
+// Everything above reasons about the room from its constants. This part builds
+// the real panels, paints them with a real board, and measures the regions they
+// declared — with atan, from the region's own edges, no average and no
+// small-angle shortcut. It is the only kind of check that can tell 3.0° asked
+// for from 2.58° delivered.
+
+// A 2D context with no pixels in it. The paint code only ever asks it to draw
+// and to measure text, and the regions come out of arithmetic, not out of paint.
+function fakeCanvas() {
+  const canvas = { width: 300, height: 150 };
+  const ctx = {
+    canvas, font: '10px x', textAlign: 'left', textBaseline: 'alphabetic',
+    fillStyle: '', strokeStyle: '', lineWidth: 1,
+    measureText(t) {
+      const m = /([\d.]+)px/.exec(ctx.font);
+      return { width: String(t).length * (m ? +m[1] : 10) * 0.52 };
+    },
+  };
+  for (const m of ['fillRect', 'clearRect', 'fillText', 'strokeText', 'beginPath', 'closePath',
+    'moveTo', 'lineTo', 'arc', 'rect', 'fill', 'stroke', 'clip', 'save', 'restore', 'drawImage']) ctx[m] = () => {};
+  canvas.getContext = () => ctx;
+  return canvas;
+}
+
+async function paintKit() {
+  globalThis.document = { createElement: () => fakeCanvas() };
+  globalThis.Image = class { };            // the sheet never lands: faces fall back to dots
+  const P = await load('panels.js');
+  const R = await load('room.js');
+  const lts = [
+    { id: 'monica', name: 'Monica', color: '#7c5cff', avatar: 12, chatOwed: true, chat: [{ author: 'user', text: 'status on the oauth card?', ts: new Date().toISOString() }, { author: 'monica', text: 'worker is mid-flight, PR up as a draft', ts: new Date().toISOString() }] },
+    { id: 'rex', name: 'Rex', color: '#2aa876', avatar: 33, chat: [] },
+    { id: 'ada', name: 'Ada', color: '#d8a03c', avatar: null, chat: [] },
+    { id: 'quill', name: 'Quill', color: '#e05c78', avatar: 21, chat: [] },
+  ];
+  const columns = [{ id: 'backlog', title: '📋 Backlog' }, { id: 'working', title: '🔨 Working' },
+    { id: 'review', title: '👀 Your review' }, { id: 'peer', title: '🤝 Peer review' }];
+  const cards = [];
+  for (let i = 0; i < 18; i++) {
+    cards.push({
+      id: 'c' + i, column: columns[i % 3].id, owner: lts[i % 4].id, type: 'implementation',
+      title: i % 3 ? 'a short one' : 'a card title long enough to wrap onto a second line and then some',
+      body: '# Repro\n1. sign in\n2. wait\n\n- [ ] a plan line', labels: ['infra'],
+      status: i % 2 ? { owed: true } : { worker: { state: 'live' } },
+      thread: [{ author: 'user', text: 'how is it going', ts: new Date().toISOString() }],
+    });
+  }
+  return { P, R, doc: { title: 'Fake Environment', columns, cards, lieutenants: lts } };
+}
+
+// The region's true arc, from its own edges. Deliberately re-derived here rather
+// than asked of the surface: a measurement taken with the code under test is not
+// a measurement.
+function trueArc(s, r) {
+  const D = 180 / Math.PI, d = s.distanceM;
+  const u = (x) => (x / s.canvas.width - 0.5) * s.widthM;
+  const v = (y) => (0.5 - y / s.canvas.height) * s.heightM;
+  return {
+    w: (Math.atan(u(r.x + r.w) / d) - Math.atan(u(r.x) / d)) * D,
+    h: (Math.atan(v(r.y) / d) - Math.atan(v(r.y + r.h) / d)) * D,
+  };
+}
+
+// Every panel the room can put in front of him, painted where it really stands.
+async function paintedPanels() {
+  const { P, R, doc } = await paintKit();
+  const out = [];
+  const bar = new P.LieutenantBar(); bar.paint(doc);
+  out.push({ name: 'lieutenant bar', s: bar });
+  for (const [where, at] of [['front', R.FRONT], ['pushed back', R.BACK]]) {
+    const board = new P.BoardPanel();
+    board.setDistance(R.eyeDistance({ x: 0, y: at.y, z: at.z }));
+    board.paint(doc);
+    out.push({ name: 'board, ' + where, s: board });
+  }
+  for (let count = 1; count <= 12; count++) {
+    for (let i = 0; i < count; i++) {
+      const d = R.eyeDistance(R.placeWindow(i, count));
+      const card = new P.CardWindow('c3');
+      card.setDistance(d); card.paint(doc);
+      out.push({ name: `card window ${i}/${count}`, s: card });
+      const chat = new P.ChatWindow('monica');
+      chat.setDistance(d); chat.paint(doc);
+      out.push({ name: `chat window ${i}/${count}`, s: chat });
+    }
+  }
+  return { out, R };
+}
+
+test('every painted region is a 3° target, measured in true arc where it sits', async () => {
+  const { out, R } = await paintedPanels();
+  let checked = 0;
+  for (const { name, s } of out) {
+    assert.ok(s.hits.length, `${name} painted nothing to point at`);
+    for (const r of s.hits) {
+      const a = trueArc(s, r);
+      checked++;
+      assert.ok(a.w >= R.HIT.min, `${name}: ${r.action.kind} is ${a.w.toFixed(2)}° wide, floor is ${R.HIT.min}°`);
+      assert.ok(a.h >= R.HIT.min, `${name}: ${r.action.kind} is ${a.h.toFixed(2)}° tall, floor is ${R.HIT.min}°`);
+    }
+  }
+  assert.ok(checked > 180, `only ${checked} regions measured — the walk is not covering the room`);
+});
+
+test('and no two of them are closer than 1.6°, nor on top of each other', async () => {
+  const { out, R } = await paintedPanels();
+  for (const { name, s } of out) {
+    const D = 180 / Math.PI, d = s.distanceM;
+    const u = (x) => Math.atan((x / s.canvas.width - 0.5) * s.widthM / d) * D;
+    const v = (y) => Math.atan((0.5 - y / s.canvas.height) * s.heightM / d) * D;
+    const box = (r) => ({ l: u(r.x), r: u(r.x + r.w), t: v(r.y), b: v(r.y + r.h), kind: r.action.kind });
+    const boxes = s.hits.map(box);
+    for (let i = 0; i < boxes.length; i++) {
+      for (let j = i + 1; j < boxes.length; j++) {
+        const a = boxes[i], b = boxes[j];
+        // Clear air between them on each axis; null where they overlap on it.
+        const gapX = a.r <= b.l ? b.l - a.r : (b.r <= a.l ? a.l - b.r : null);
+        const gapY = a.b >= b.t ? a.b - b.t : (b.b >= a.t ? b.b - a.t : null);
+        const apart = Math.max(gapX == null ? -Infinity : gapX, gapY == null ? -Infinity : gapY);
+        assert.ok(gapX != null || gapY != null,
+          `${name}: ${a.kind} and ${b.kind} are on top of each other`);
+        assert.ok(apart >= R.HIT.gap,
+          `${name}: ${a.kind} and ${b.kind} are ${apart.toFixed(2)}° apart, floor is ${R.HIT.gap}°`);
+      }
+    }
+  }
 });

--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -93,15 +93,148 @@ test('the same card twice is one window, brought forward', async () => {
   assert.deepStrictEqual(openWindows(once, 'lt:monica'), ['card:a', 'lt:monica']);
 });
 
-test('a panel at the front is legible: text that big subtends enough of the eye', async () => {
-  const { PPM } = await load('surface.js');
-  const { FRONT } = await load('room.js');
-  assert.ok(PPM > 0, 'surface.js states its canvas pixels per metre');
-  const BODY_PX = 21;                       // what panels.js paints body text at
-  const metres = BODY_PX / PPM;
-  const deg = 2 * Math.atan((metres / 2) / Math.abs(FRONT.z)) * 180 / Math.PI;
-  // A Quest resolves ~20 px per degree. Half a degree of cap height is ~10 px,
-  // which is where reading stops being work — the number the first prototype
-  // was built to produce, now applied to the surfaces that actually matter.
-  assert.ok(deg > 0.5, `front-panel body text is only ${deg.toFixed(2)}° tall`);
+// ---- arc: the floors every size in the room is measured against -------------
+//
+// The room's sizes used to be canvas pixels, and canvas pixels cannot tell 1.55 m
+// from 3.1 m — which is how the board came to paint 0.35° body text nobody could
+// read. Every size is now a number of DEGREES converted at the panel's own
+// distance, so these tests check the degrees and the distances, and the pixels
+// take care of themselves.
+
+// Everywhere a panel actually stands: name -> {size, placement}.
+async function places() {
+  const R = await load('room.js');
+  const { PANEL, BAR, FRONT, BACK, placeWindow, EYE } = R;
+  const out = [
+    { name: 'lieutenant bar', panel: PANEL.bar, at: BAR },
+    { name: 'board, in front', panel: PANEL.board, at: FRONT, primary: true },
+    { name: 'board, pushed back', panel: PANEL.board, at: BACK },
+  ];
+  for (let count = 1; count <= 9; count++) {
+    for (let i = 0; i < count; i++) {
+      const at = placeWindow(i, count);
+      out.push({ name: `card window ${i}/${count}`, panel: PANEL.card, at });
+      out.push({ name: `chat window ${i}/${count}`, panel: PANEL.chat, at });
+    }
+  }
+  return { R, EYE, out };
+}
+
+test('the smallest type in the room still clears the 0.7° cap-height floor', async () => {
+  const { TYPE, CAP } = await load('room.js');
+  for (const [name, em] of Object.entries(TYPE)) {
+    const cap = em * CAP;
+    assert.ok(cap >= 0.7, `${name} type is ${cap.toFixed(2)}° of cap height — under the floor`);
+  }
+  // Body text is not merely legible, it is read without leaning: 1.5° of em box
+  // is the aim and 1.4 is the nearest the dense board will carry.
+  assert.ok(TYPE.body >= 1.4, 'body text should be ~1.5° of em box');
+  assert.ok(TYPE.head > TYPE.body && TYPE.body > TYPE.meta, 'the ladder is head > body > meta');
+});
+
+test('a target is 3° and two of them are 1.6° apart', async () => {
+  const { HIT } = await load('room.js');
+  assert.ok(HIT.min >= 3.0, `hit boxes are ${HIT.min}° — a target you stab at`);
+  assert.ok(HIT.gap >= 1.6, `${HIT.gap}° between two targets is one target`);
+});
+
+test('everything he reads stands inside the comfort band', async () => {
+  const { R, out } = await places();
+  for (const p of out) {
+    const d = R.eyeDistance(p.at);
+    assert.ok(d >= R.NEAR, `${p.name} is ${d.toFixed(2)} m away — too near the face`);
+    assert.ok(d <= R.FAR, `${p.name} is ${d.toFixed(2)} m away — past the comfort band`);
+  }
+});
+
+test('nothing is over the horizon, and the board he reads sits a glance below it', async () => {
+  const { R, EYE, out } = await places();
+  const deg = (opp, adj) => Math.atan2(opp, adj) * 180 / Math.PI;
+  for (const p of out) {
+    const flat = Math.hypot(p.at.x || 0, p.at.z || 0);
+    const top = deg((p.at.y - EYE) + p.panel.heightM / 2, flat);
+    assert.ok(top <= R.RISE, `${p.name} reaches ${top.toFixed(1)}° up — looking up is a sore neck`);
+    if (!p.primary) continue;
+    const centre = -deg(p.at.y - EYE, flat);
+    assert.ok(centre >= R.DROP[0] && centre <= R.DROP[1],
+      `${p.name} is centred ${centre.toFixed(1)}° below the horizon, not ${R.DROP.join('–')}°`);
+  }
+});
+
+test('every panel is cut with enough texels for the arc it covers', async () => {
+  const { R, out } = await places();
+  const MAX = 2048;                              // what surface.js caps a sheet at
+  for (const p of out) {
+    const d = R.eyeDistance(p.at);
+    const scale = Math.min(R.texelsPerMetre(d), MAX / Math.max(p.panel.widthM, p.panel.heightM));
+    const perDeg = p.panel.widthM * scale / R.arcDeg(p.panel.widthM, d);
+    assert.ok(perDeg >= 20, `${p.name} paints ${perDeg.toFixed(0)} texels per degree — soft`);
+    assert.ok(p.panel.widthM * scale <= MAX && p.panel.heightM * scale <= MAX, `${p.name} overflows a texture`);
+  }
+});
+
+test('body text on every panel, in degrees, at the distance it really sits', async () => {
+  const { R, out } = await places();
+  for (const p of out) {
+    const d = R.eyeDistance(p.at);
+    // What panels.js paints: px = deg × (canvas width / panel arc). Rearranged,
+    // the arc of the type is the arc it was asked for, whatever the canvas — so
+    // the figure to check is the one the surface was told to draw.
+    const cap = R.TYPE.body * R.CAP;
+    assert.ok(cap >= 0.7, `body text on ${p.name} at ${d.toFixed(2)} m is ${cap.toFixed(2)}° of cap`);
+    // And the panel has to be able to hold a 3° target with 1.6° beside it.
+    assert.ok(R.arcDeg(p.panel.heightM, d) >= R.HIT.min + R.HIT.gap,
+      `${p.name} is too short to hold a target`);
+  }
+});
+
+// A panel is turned to face the eye, so what it covers is its centre's angle
+// give or take half its own arc — the figure that says whether two of them are
+// on top of each other.
+function span(R, EYE, p) {
+  const flat = Math.hypot(p.at.x || 0, p.at.z || 0);
+  const centre = Math.atan2(p.at.y - EYE, flat) * 180 / Math.PI;
+  const half = R.arcDeg(p.panel.heightM, R.eyeDistance(p.at)) / 2;
+  return { top: centre + half, bottom: centre - half };
+}
+
+test('the bar sits clear underneath: the lieutenants never cover the work', async () => {
+  const { R, EYE, out } = await places();
+  const bar = span(R, EYE, out.find((p) => p.name === 'lieutenant bar'));
+  // The bar is the nearest thing in the room and it never moves, so anything it
+  // overlaps is content he simply cannot see. Front row and board only — a
+  // second row of windows is overflow, and he moves those himself.
+  const front = out.filter((p) => p.name.startsWith('board') || /\b0\/[123]$/.test(p.name));
+  for (const p of front) {
+    const s = span(R, EYE, p);
+    assert.ok(s.bottom >= bar.top,
+      `${p.name} runs down to ${s.bottom.toFixed(1)}° and the bar starts at ${bar.top.toFixed(1)}° — it is covered`);
+  }
+});
+
+test('type clears the floor at the far edge of a panel, not only in the middle', async () => {
+  const { R, out } = await places();
+  const MAX = 2048;
+  for (const p of out) {
+    const d = R.eyeDistance(p.at);
+    const scale = Math.min(R.texelsPerMetre(d), MAX / Math.max(p.panel.widthM, p.panel.heightM));
+    // A flat panel's pixels are not evenly spread across the eye: a degree at
+    // the far edge is worth more pixels than a degree at the centre, so text
+    // sized on the panel's average subtends LESS out there. That corner is
+    // where the floor is closest, and it still has to clear it.
+    const avg = p.panel.widthM * scale / R.arcDeg(p.panel.widthM, d);
+    const x = p.panel.widthM / 2;
+    const edge = scale * ((d * d + x * x) / d) * Math.PI / 180;
+    const cap = R.TYPE.body * R.CAP * (avg / edge);
+    assert.ok(cap >= 0.7, `body text in the corner of ${p.name} is ${cap.toFixed(2)}° of cap height`);
+  }
+});
+
+test('arc and metres convert both ways', async () => {
+  const { arcDeg, sizeForArc } = await load('room.js');
+  for (const [size, dist] of [[0.04, 1.5], [1.9, 1.58], [0.16, 1.15]]) {
+    assert.ok(Math.abs(sizeForArc(arcDeg(size, dist), dist) - size) < 1e-9, 'round trip');
+  }
+  // The small-angle rule of thumb the skill quotes: 57.3 × size / distance.
+  assert.ok(Math.abs(arcDeg(0.04, 1.5) - 57.3 * 0.04 / 1.5) < 0.01);
 });

--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -117,6 +117,9 @@ async function places() {
   const { PANEL, BAR, FRONT, BACK, placeWindow, EYE } = R;
   const out = [
     { name: 'lieutenant bar', panel: PANEL.bar, at: BAR },
+    // The bar grows with the lieutenants; the widest it goes is a panel too.
+    { name: 'lieutenant bar, full', at: BAR,
+      panel: { widthM: R.barWidth(R.BAR_LIMIT, R.eyeDistance(BAR)), heightM: PANEL.bar.heightM } },
     { name: 'board, in front', panel: PANEL.board, at: FRONT, primary: true },
     { name: 'board, pushed back', panel: PANEL.board, at: BACK },
   ];
@@ -257,20 +260,48 @@ test('arc and metres convert both ways', async () => {
 // small-angle shortcut. It is the only kind of check that can tell 3.0° asked
 // for from 2.58° delivered.
 
-// A 2D context with no pixels in it. The paint code only ever asks it to draw
-// and to measure text, and the regions come out of arithmetic, not out of paint.
+// A 2D context with no pixels in it, which WRITES DOWN what it was asked to
+// draw. Regions come out of arithmetic and can be checked on their own; a
+// painted string cannot — the only record of where a glyph landed is the call
+// that put it there. So every mark is kept, clipped the way the real context
+// would clip it, and checked against the box it is supposed to be inside.
 function fakeCanvas() {
-  const canvas = { width: 300, height: 150 };
+  const canvas = { width: 300, height: 150, marks: [] };
+  const clipped = [];
+  let clip = null, pending = null, at = null;
+  const size = () => { const m = /([\d.]+)px/.exec(ctx.font); return m ? +m[1] : 10; };
+  const cut = (a, b) => {
+    if (!b) return a;
+    const x = Math.max(a.x, b.x), y = Math.max(a.y, b.y);
+    const r = Math.min(a.x + a.w, b.x + b.w), t = Math.min(a.y + a.h, b.y + b.h);
+    return r <= x || t <= y ? null : { x, y, w: r - x, h: t - y, line: a.line, what: a.what };
+  };
+  const put = (what, x, y, w, h, line) => {
+    const m = cut({ x: Math.min(x, x + w), y: Math.min(y, y + h), w: Math.abs(w), h: Math.abs(h), line, what }, clip);
+    if (m) canvas.marks.push(m);
+  };
   const ctx = {
     canvas, font: '10px x', textAlign: 'left', textBaseline: 'alphabetic',
     fillStyle: '', strokeStyle: '', lineWidth: 1,
-    measureText(t) {
-      const m = /([\d.]+)px/.exec(ctx.font);
-      return { width: String(t).length * (m ? +m[1] : 10) * 0.52 };
+    measureText(t) { return { width: String(t).length * size() * 0.52 }; },
+    fillText(t, x, y) {
+      const s = size(), w = ctx.measureText(t).width;
+      if (!String(t).length) return;
+      const left = ctx.textAlign === 'center' ? x - w / 2 : (ctx.textAlign === 'right' ? x - w : x);
+      put(String(t), left, y - s * 0.75, w, s);           // baseline to em box
     },
+    fillRect: (x, y, w, h) => put('rect', x, y, w, h),
+    arc: (cx, cy, r) => put('arc', cx - r, cy - r, r * 2, r * 2),
+    drawImage: (img, sx, sy, sw, sh, dx, dy, dw, dh) => put('image', dx, dy, dw, dh),
+    moveTo: (x, y) => { at = [x, y]; },
+    lineTo(x, y) { if (at) put('line', at[0], at[1], x - at[0], y - at[1], true); at = [x, y]; },
+    rect: (x, y, w, h) => { pending = { x, y, w, h }; },
+    beginPath() { pending = null; at = null; },
+    clip() { if (pending) clip = cut(pending, clip); },
+    save() { clipped.push(clip); },
+    restore() { clip = clipped.length ? clipped.pop() : null; },
   };
-  for (const m of ['fillRect', 'clearRect', 'fillText', 'strokeText', 'beginPath', 'closePath',
-    'moveTo', 'lineTo', 'arc', 'rect', 'fill', 'stroke', 'clip', 'save', 'restore', 'drawImage']) ctx[m] = () => {};
+  for (const m of ['clearRect', 'strokeText', 'closePath', 'fill', 'stroke']) ctx[m] = () => {};
   canvas.getContext = () => ctx;
   return canvas;
 }
@@ -318,22 +349,35 @@ function trueArc(s, r) {
 async function paintedPanels() {
   const { P, R, doc } = await paintKit();
   const out = [];
-  const bar = new P.LieutenantBar(); bar.paint(doc);
+  // The bar, at every number of lieutenants it claims to hold. This is where a
+  // fixed-width bar used to keep its 3° plates by eating the air between them.
+  for (let n = 1; n <= R.BAR_LIMIT; n++) {
+    const many = Array.from({ length: n }, (_, i) => ({
+      id: 'lt' + i, color: '#7c5cff', avatar: i % 2 ? i : null, chatOwed: i % 4 === 0,
+      name: i % 3 ? 'Lt' + i : 'a rather long lieutenant name',
+    }));
+    const bar = new P.LieutenantBar();
+    bar.canvas.marks = [];
+    bar.paint({ ...doc, lieutenants: many });
+    out.push({ name: `lieutenant bar, ${n} of them`, s: bar });
+  }
+  const bar = new P.LieutenantBar(); bar.canvas.marks = []; bar.paint(doc);
   out.push({ name: 'lieutenant bar', s: bar });
   for (const [where, at] of [['front', R.FRONT], ['pushed back', R.BACK]]) {
     const board = new P.BoardPanel();
     board.setDistance(R.eyeDistance({ x: 0, y: at.y, z: at.z }));
+    board.canvas.marks = [];
     board.paint(doc);
-    out.push({ name: 'board, ' + where, s: board });
+    out.push({ name: 'board, ' + where, s: board, doc });
   }
   for (let count = 1; count <= 12; count++) {
     for (let i = 0; i < count; i++) {
       const d = R.eyeDistance(R.placeWindow(i, count));
       const card = new P.CardWindow('c3');
-      card.setDistance(d); card.paint(doc);
+      card.setDistance(d); card.canvas.marks = []; card.paint(doc);
       out.push({ name: `card window ${i}/${count}`, s: card });
       const chat = new P.ChatWindow('monica');
-      chat.setDistance(d); chat.paint(doc);
+      chat.setDistance(d); chat.canvas.marks = []; chat.paint(doc);
       out.push({ name: `chat window ${i}/${count}`, s: chat });
     }
   }
@@ -374,6 +418,45 @@ test('and no two of them are closer than 1.6°, nor on top of each other', async
           `${name}: ${a.kind} and ${b.kind} are on top of each other`);
         assert.ok(apart >= R.HIT.gap,
           `${name}: ${a.kind} and ${b.kind} are ${apart.toFixed(2)}° apart, floor is ${R.HIT.gap}°`);
+      }
+    }
+  }
+});
+
+// A mark and a region can relate three ways: the mark is inside the region, the
+// mark contains it (a panel background, the chrome bar), or they are strangers.
+// Anything else is a mark hanging half off the box it belongs to.
+const overlaps = (m, r) => m.x < r.x + r.w && r.x < m.x + m.w && m.y < r.y + r.h && r.y < m.y + m.h;
+const inside = (m, r, e = 0.5) => m.x >= r.x - e && m.y >= r.y - e
+  && m.x + m.w <= r.x + r.w + e && m.y + m.h <= r.y + r.h + e;
+
+test('nothing is painted half on and half off the box it belongs to', async () => {
+  const { out } = await paintedPanels();
+  for (const { name, s } of out) {
+    for (const m of s.canvas.marks) {
+      for (const r of s.hits) {
+        if (!overlaps(m, r) || inside(m, r) || inside(r, m)) continue;
+        assert.fail(`${name}: "${m.what}" at x ${m.x.toFixed(1)}–${(m.x + m.w).toFixed(1)} hangs off `
+          + `the ${r.action.kind} box at ${r.x.toFixed(1)}–${(r.x + r.w).toFixed(1)}`);
+      }
+    }
+  }
+});
+
+test('what a card paints lands on that card, not in the gutter beside it', async () => {
+  const { out, R } = await paintedPanels();
+  for (const { name, s } of out) {
+    const half = s.px(R.HIT.gap) / 2;
+    for (const r of s.hits) {
+      for (const m of s.canvas.marks) {
+        if (m.line || inside(r, m)) continue;          // lines and backgrounds are not content
+        const my = m.y + m.h / 2;
+        if (my < r.y || my > r.y + r.h) continue;      // not on this row at all
+        const near = m.x + m.w > r.x - half && m.x < r.x + r.w + half;
+        if (!near) continue;                           // somebody else's business
+        assert.ok(inside(m, r),
+          `${name}: "${m.what}" at x ${m.x.toFixed(1)}–${(m.x + m.w).toFixed(1)} is not on its own `
+          + `${r.action.kind} box at ${r.x.toFixed(1)}–${(r.x + r.w).toFixed(1)}`);
       }
     }
   }

--- a/ui/js/bridge3d/faces.js
+++ b/ui/js/bridge3d/faces.js
@@ -1,0 +1,55 @@
+// faces.js — the lieutenants' heads, inside the session.
+//
+// The 2D board draws these with a CSS sprite (ui/js/avatars.js), which is no use
+// in here: an immersive session has no DOM to hang a background-position on.
+// Same sheet, same indices, painted onto the panel canvas with drawImage.
+//
+// One Image for the whole room. It is fetched once and shared, and a panel
+// painted before it decodes is repainted when it lands — otherwise the first
+// second in the room is a bar of faceless dots that never come back.
+
+const COLS = 8;
+const COUNT = COLS * COLS;
+// 1254 / 8 = 156.75. The sheet does not divide into whole pixels, so the source
+// rect is rounded and pulled in by one on each side: a face that reaches its
+// cell's edge otherwise brings a slice of its neighbour along with it.
+const CELL = 1254 / COLS;
+
+const img = new Image();
+let ready = false;
+const waiting = [];
+
+img.onload = () => { ready = true; waiting.splice(0).forEach((fn) => fn()); };
+img.src = new URL('../../img/avatars.png', import.meta.url).href;
+
+// whenFaces(cb) — called once the sheet is usable (immediately, if it already
+// is). The room hands it its repaint.
+export function whenFaces(cb) { if (ready) cb(); else waiting.push(cb); }
+
+// face(g, idx, cx, cy, r, colour) — a head in a circle of the lieutenant's own
+// colour, the same mark ltswitcher.js draws on the flat board. No avatar, or a
+// sheet that has not landed yet, falls back to the coloured dot — which is the
+// fallback and not a bug.
+export function face(g, idx, cx, cy, r, colour) {
+  const has = ready && Number.isInteger(idx) && idx >= 0 && idx < COUNT;
+  g.save();
+  g.beginPath();
+  g.arc(cx, cy, r, 0, Math.PI * 2);
+  if (has) {
+    g.clip();
+    const s = Math.round(CELL) - 2;
+    g.drawImage(img, Math.round((idx % COLS) * CELL) + 1, Math.round(Math.floor(idx / COLS) * CELL) + 1, s, s,
+      cx - r, cy - r, r * 2, r * 2);
+  } else {
+    g.fillStyle = colour || '#66788a';
+    g.fill();
+  }
+  g.restore();
+  if (has) {
+    g.beginPath();
+    g.arc(cx, cy, r, 0, Math.PI * 2);
+    g.strokeStyle = colour || '#66788a';
+    g.lineWidth = Math.max(2, r * 0.12);
+    g.stroke();
+  }
+}

--- a/ui/js/bridge3d/main.js
+++ b/ui/js/bridge3d/main.js
@@ -22,7 +22,8 @@
 
 import * as THREE from '../../vendor/three/three.module.min.js';
 import { BoardPanel, LieutenantBar, CardWindow, ChatWindow } from './panels.js';
-import { EYE, FRONT, BACK, BAR, placeWindow, nextFront, openWindows } from './room.js';
+import { EYE, FRONT, BACK, BAR, TYPE, placeWindow, nextFront, openWindows, eyeDistance } from './room.js';
+import { whenFaces } from './faces.js';
 import { keyForEvent } from '../panekeys.js';
 
 const say = (m) => { const el = document.getElementById('status'); if (el) el.textContent = m; };
@@ -38,11 +39,18 @@ renderer.setPixelRatio(window.devicePixelRatio);
 renderer.setSize(window.innerWidth, window.innerHeight);
 renderer.xr.enabled = true;
 renderer.xr.setReferenceSpaceType('local-floor');
+// three.js ships foveation at 1.0 — MAXIMUM — which renders the edges of the
+// view at reduced resolution. This room parks its secondary panels off-centre on
+// purpose, for a head turn to find, so the default blurs exactly the things it
+// was told to keep readable. A room of text pays the GPU instead.
+renderer.xr.setFoveation(0);
 document.body.appendChild(renderer.domElement);
 
 const scene = new THREE.Scene();
 scene.background = new THREE.Color('#05070b');
-const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.05, 100);
+// Near at 0.3 m: closer than that a panel is intersecting his face, and nothing
+// he reads is ever meant to be inside 0.5 m anyway.
+const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.3, 100);
 camera.position.set(0, EYE, 0);
 scene.add(camera);
 
@@ -74,6 +82,10 @@ const state = { open: [], front: 'board' };
 rig.add(bar.group, board.group);
 bar.group.position.set(BAR.x, BAR.y, BAR.z);
 bar.group.lookAt(0, EYE, 0);
+
+// The sheet of faces arrives after the first paint, and a bar of dots that never
+// became faces is worse than one that took a moment to.
+whenFaces(() => repaint());
 
 function surfaceFor(id) {
   if (id === 'board') return board;
@@ -113,11 +125,15 @@ function layout() {
     const p = placeWindow(i, ids.length);
     s.group.position.set(p.x, p.y, p.z);
     s.group.lookAt(0, EYE, 0);
+    s.setDistance(eyeDistance(p));
   });
   const boardBack = state.front !== 'board';
   const at = boardBack ? BACK : FRONT;
   board.group.position.set(0, at.y, at.z);
   board.group.lookAt(0, EYE, 0);
+  // Pushing the board back moves it 36 cm further off, and its type is re-cut
+  // for the new distance — that is what "readable wherever it sits" costs.
+  board.setDistance(eyeDistance({ x: 0, y: at.y, z: at.z }));
   board.setFront(!boardBack);
   for (const [id, s] of windows) s.setFront(id === state.front);
   repaint();
@@ -225,6 +241,9 @@ for (let i = 0; i < 2; i++) {
     if (!h) return;
     rig.attach(h.surface.group);
     held.delete(c);
+    // He put it down somewhere else, so it is a different number of degrees
+    // wide than it was when he picked it up: re-cut the type at where it now is.
+    if (h.surface.setDistance(eyeDistance(h.surface.group.position))) h.surface.paint(doc);
   });
 }
 
@@ -287,11 +306,12 @@ function draftPaint() {
   s.paint(doc);
   const g = s.ctx;
   const h = s.canvas.height, w = s.canvas.width;
+  const strip = s.line(TYPE.body) + s.px(0.4);
   g.fillStyle = '#111a24';
-  g.fillRect(0, h - 44, w, 44);
+  g.fillRect(0, h - strip, w, strip);
   g.fillStyle = '#4cc2ff';
-  g.font = '22px system-ui, sans-serif';
-  g.fillText('› ' + composing.text, 18, h - 15);
+  g.font = s.font(TYPE.body);
+  g.fillText('› ' + composing.text, s.px(0.7), h - s.px(0.5));
   s.texture.needsUpdate = true;
 }
 

--- a/ui/js/bridge3d/panels.js
+++ b/ui/js/bridge3d/panels.js
@@ -22,7 +22,7 @@
 
 import { Surface, wrap, COL } from './surface.js';
 import { face } from './faces.js';
-import { PANEL, TYPE, BUILD, BAR, FRONT, eyeDistance, placeWindow } from './room.js';
+import { PANEL, TYPE, BUILD, BAR, FRONT, barWidth, eyeDistance, placeWindow } from './room.js';
 
 const WINDOW_D = eyeDistance(placeWindow(0, 1));   // where a window first lands
 
@@ -45,25 +45,29 @@ export class LieutenantBar extends Surface {
   }
 
   paint(doc) {
+    const lts = doc.lieutenants || [];
+    // The bar is as wide as the lieutenants need. A fixed width would keep the
+    // plates at 3° by taking it out of the air between them, which is the same
+    // mis-hit by another route — so the bar grows and the floors both hold.
+    const want = barWidth(lts.length, this.distanceM);
+    if (Math.abs(want - this.widthM) > 0.005) this.resize(want, this.heightM);
+
     const g = this.begin();
     const w = this.canvas.width, h = this.canvas.height;
-    const lts = doc.lieutenants || [];
-    const cell = w / Math.max(1, lts.length);
-    // ponytail: past ~11 lieutenants a cell is under the 3° + 1.6° a hand can
-    // land on. Page the bar when that is a real number of lieutenants.
-    const r = Math.min(this.px(1.7), h * 0.28);
+    // Cells are equal in DEGREES, not in pixels: an equal slice of canvas out at
+    // the end of the bar is a smaller slice of him, and every lieutenant is
+    // owed the same target.
+    const step = this.degX(0, w) / Math.max(1, lts.length);
     lts.forEach((l, i) => {
-      const x = i * cell;
       const owed = !!l.chatOwed;
-      // The plate's edges are walked in true arc from the cell's, so the air
-      // between two lieutenants is 1.6° at the end of the bar as well as in the
-      // middle of it — a cell out at the edge is worth fewer degrees per pixel.
-      const left = this.atDegX(x, BUILD.gap / 2);
-      const plate = this.atDegX(x + cell, -BUILD.gap / 2) - left;
+      const left = this.atDegX(0, i * step + BUILD.gap / 2);
+      const plate = this.atDegX(0, (i + 1) * step - BUILD.gap / 2) - left;
+      const mid = left + plate / 2;
+      const r = Math.min(this.px(1.7), h * 0.28, plate * 0.4);
       g.save();
       g.beginPath();
-      g.rect(x, 0, cell, h);
-      g.clip();                       // a long name stays in its own cell
+      g.rect(left, 0, plate, h);
+      g.clip();                       // a long name stays on its own plate
       g.fillStyle = owed ? '#1d2836' : '#111823';
       g.fillRect(left, this.px(0.2), plate, h - this.px(0.4));
       // A lieutenant waiting on the captain is the only thing in this room that
@@ -72,11 +76,11 @@ export class LieutenantBar extends Surface {
         g.fillStyle = COL.accent;
         g.fillRect(left, this.px(0.2), this.px(0.22), h - this.px(0.4));
       }
-      face(g, l.avatar, x + cell / 2, h * 0.38, r, l.color || COL.accent);
+      face(g, l.avatar, mid, h * 0.38, r, l.color || COL.accent);
       g.fillStyle = owed ? COL.text : COL.dim;
       g.font = this.font(TYPE.meta, 600);
       g.textAlign = 'center';
-      g.fillText(l.name || l.id, x + cell / 2, h - this.px(0.5));
+      g.fillText(l.name || l.id, mid, h - this.px(0.5));
       g.textAlign = 'left';
       g.restore();
       // The plate is what he aims at, and the 1.6° between two plates is what
@@ -108,13 +112,17 @@ export class BoardPanel extends Surface {
       const x = ci * cw;
       // A card in this column and the card beside it in the next one are two
       // targets, so the column edges owe each other 1.6° the same way two
-      // lieutenants do — half of it from each side.
+      // lieutenants do — half of it from each side. EVERYTHING a card paints is
+      // laid out from boxL/boxW below, never from the raw column: the plate is
+      // narrower than the column, so a title placed at the column's edge starts
+      // outside its own card and the owner's stripe runs through the first
+      // letter of it.
       const boxL = this.atDegX(x, BUILD.gap / 2);
       const boxW = this.atDegX(x + cw, -BUILD.gap / 2) - boxL;
       const mine = (doc.cards || []).filter((c) => c.column === col.id);
       g.fillStyle = COL.faint;
       g.font = this.font(TYPE.meta, 600);
-      g.fillText((col.title || col.id) + '  ' + mine.length, x + pad, top + this.px(1.6));
+      g.fillText((col.title || col.id) + '  ' + mine.length, boxL + pad, top + this.px(1.6));
       g.strokeStyle = COL.edge;
       g.lineWidth = Math.max(1, this.px(0.06));
       if (ci) { g.beginPath(); g.moveTo(x, top); g.lineTo(x, h); g.stroke(); }
@@ -124,7 +132,7 @@ export class BoardPanel extends Surface {
         const owed = c.status && (c.status.owed || c.status.unread);
         const working = c.status && c.status.worker && c.status.worker.state === 'live';
         g.font = this.font(TYPE.body);
-        const lines = wrap(g, c.title || c.id, cw - pad * 2 - this.px(0.8)).slice(0, 2);
+        const lines = wrap(g, c.title || c.id, boxW - pad * 2 - this.px(0.8)).slice(0, 2);
         // A card is a target before it is a label: never shorter than 3°, even
         // when its title is one line — and 3° low down the board is more pixels
         // than 3° at the top, so the floor is taken from where this box sits.
@@ -132,7 +140,7 @@ export class BoardPanel extends Surface {
         if (y + boxH > h - this.px(BUILD.gap)) {
           g.fillStyle = COL.faint;
           g.font = this.font(TYPE.meta);
-          g.fillText('+' + (mine.length - mine.indexOf(c)) + ' more', x + pad, y + this.px(1.2));
+          g.fillText('+' + (mine.length - mine.indexOf(c)) + ' more', boxL + pad, y + this.px(1.2));
           break;
         }
         g.fillStyle = owed ? '#18222e' : '#101720';
@@ -140,10 +148,11 @@ export class BoardPanel extends Surface {
         g.fillStyle = ltColour.get(c.owner) || COL.dim;
         g.fillRect(boxL, y, this.px(0.18), boxH);
         const dot = this.px(0.22);
-        if (working) { g.fillStyle = COL.good; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
-        if (owed) { g.fillStyle = COL.accent; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
+        const dotX = boxL + boxW - pad;
+        if (working) { g.fillStyle = COL.good; g.beginPath(); g.arc(dotX, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
+        if (owed) { g.fillStyle = COL.accent; g.beginPath(); g.arc(dotX, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
         g.fillStyle = owed ? COL.text : COL.dim;
-        lines.forEach((ln, i) => g.fillText(ln, x + pad, y + this.px(0.3) + lh * (i + 0.78)));
+        lines.forEach((ln, i) => g.fillText(ln, boxL + pad, y + this.px(0.3) + lh * (i + 0.78)));
         this.region(boxL, y, boxW, boxH, { kind: 'card', id: c.id });
         y = this.atDegY(y + boxH, BUILD.gap);      // 1.6° of air, measured there
       }

--- a/ui/js/bridge3d/panels.js
+++ b/ui/js/bridge3d/panels.js
@@ -22,7 +22,7 @@
 
 import { Surface, wrap, COL } from './surface.js';
 import { face } from './faces.js';
-import { PANEL, TYPE, HIT, BAR, FRONT, eyeDistance, placeWindow } from './room.js';
+import { PANEL, TYPE, BUILD, BAR, FRONT, eyeDistance, placeWindow } from './room.js';
 
 const WINDOW_D = eyeDistance(placeWindow(0, 1));   // where a window first lands
 
@@ -51,22 +51,26 @@ export class LieutenantBar extends Surface {
     const cell = w / Math.max(1, lts.length);
     // ponytail: past ~11 lieutenants a cell is under the 3° + 1.6° a hand can
     // land on. Page the bar when that is a real number of lieutenants.
-    const gap = this.px(HIT.gap);
     const r = Math.min(this.px(1.7), h * 0.28);
     lts.forEach((l, i) => {
       const x = i * cell;
       const owed = !!l.chatOwed;
+      // The plate's edges are walked in true arc from the cell's, so the air
+      // between two lieutenants is 1.6° at the end of the bar as well as in the
+      // middle of it — a cell out at the edge is worth fewer degrees per pixel.
+      const left = this.atDegX(x, BUILD.gap / 2);
+      const plate = this.atDegX(x + cell, -BUILD.gap / 2) - left;
       g.save();
       g.beginPath();
       g.rect(x, 0, cell, h);
       g.clip();                       // a long name stays in its own cell
       g.fillStyle = owed ? '#1d2836' : '#111823';
-      g.fillRect(x + gap / 2, this.px(0.2), cell - gap, h - this.px(0.4));
+      g.fillRect(left, this.px(0.2), plate, h - this.px(0.4));
       // A lieutenant waiting on the captain is the only thing in this room that
       // is allowed to shout, because it is the only thing that is his move.
       if (owed) {
         g.fillStyle = COL.accent;
-        g.fillRect(x + gap / 2, this.px(0.2), this.px(0.22), h - this.px(0.4));
+        g.fillRect(left, this.px(0.2), this.px(0.22), h - this.px(0.4));
       }
       face(g, l.avatar, x + cell / 2, h * 0.38, r, l.color || COL.accent);
       g.fillStyle = owed ? COL.text : COL.dim;
@@ -77,7 +81,7 @@ export class LieutenantBar extends Surface {
       g.restore();
       // The plate is what he aims at, and the 1.6° between two plates is what
       // keeps the wrong lieutenant from answering.
-      this.region(x + gap / 2, 0, cell - gap, h, { kind: 'lieutenant', id: l.id });
+      this.region(left, 0, plate, h, { kind: 'lieutenant', id: l.id });
     });
     this.end();
   }
@@ -94,7 +98,7 @@ export class BoardPanel extends Surface {
     const g = this.begin();
     const top = this.chrome(g, doc.title || '');
     const w = this.canvas.width, h = this.canvas.height;
-    const pad = this.px(0.8), gap = this.px(HIT.gap), floor = this.px(HIT.min);
+    const pad = this.px(0.8);
     const lh = this.line(TYPE.body);
     const cols = (doc.columns || []).filter((c) => c.id !== 'peer');
     const cw = w / Math.max(1, cols.length);
@@ -102,6 +106,11 @@ export class BoardPanel extends Surface {
 
     cols.forEach((col, ci) => {
       const x = ci * cw;
+      // A card in this column and the card beside it in the next one are two
+      // targets, so the column edges owe each other 1.6° the same way two
+      // lieutenants do — half of it from each side.
+      const boxL = this.atDegX(x, BUILD.gap / 2);
+      const boxW = this.atDegX(x + cw, -BUILD.gap / 2) - boxL;
       const mine = (doc.cards || []).filter((c) => c.column === col.id);
       g.fillStyle = COL.faint;
       g.font = this.font(TYPE.meta, 600);
@@ -117,25 +126,26 @@ export class BoardPanel extends Surface {
         g.font = this.font(TYPE.body);
         const lines = wrap(g, c.title || c.id, cw - pad * 2 - this.px(0.8)).slice(0, 2);
         // A card is a target before it is a label: never shorter than 3°, even
-        // when its title is one line.
-        const boxH = Math.max(floor, lines.length * lh + this.px(0.6));
-        if (y + boxH > h - gap) {
+        // when its title is one line — and 3° low down the board is more pixels
+        // than 3° at the top, so the floor is taken from where this box sits.
+        const boxH = Math.max(this.atDegY(y, BUILD.min) - y, lines.length * lh + this.px(0.6));
+        if (y + boxH > h - this.px(BUILD.gap)) {
           g.fillStyle = COL.faint;
           g.font = this.font(TYPE.meta);
           g.fillText('+' + (mine.length - mine.indexOf(c)) + ' more', x + pad, y + this.px(1.2));
           break;
         }
         g.fillStyle = owed ? '#18222e' : '#101720';
-        g.fillRect(x + pad * 0.5, y, cw - pad, boxH);
+        g.fillRect(boxL, y, boxW, boxH);
         g.fillStyle = ltColour.get(c.owner) || COL.dim;
-        g.fillRect(x + pad * 0.5, y, this.px(0.18), boxH);
+        g.fillRect(boxL, y, this.px(0.18), boxH);
         const dot = this.px(0.22);
         if (working) { g.fillStyle = COL.good; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
         if (owed) { g.fillStyle = COL.accent; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
         g.fillStyle = owed ? COL.text : COL.dim;
         lines.forEach((ln, i) => g.fillText(ln, x + pad, y + this.px(0.3) + lh * (i + 0.78)));
-        this.region(x + pad * 0.5, y, cw - pad, boxH, { kind: 'card', id: c.id });
-        y += boxH + gap;
+        this.region(boxL, y, boxW, boxH, { kind: 'card', id: c.id });
+        y = this.atDegY(y + boxH, BUILD.gap);      // 1.6° of air, measured there
       }
     });
     this.end();

--- a/ui/js/bridge3d/panels.js
+++ b/ui/js/bridge3d/panels.js
@@ -13,10 +13,18 @@
 // A terminal is not on this list on purpose. It is a glance — open the eye, see
 // that something really is happening, close it — and it comes back later at
 // that size.
+//
+// Not one size below is in pixels. Everything asks its own surface for degrees
+// of the captain's field — `this.px(deg)` — and the surface knows how far away
+// it is standing. Sizes authored in canvas pixels are what made the first room
+// unreadable: 21 px is comfortable at 1.55 m and gone at 3.1 m, and the pixels
+// could not tell the difference.
 
-import { Surface, wrap, COL, FONT, UI } from './surface.js';
+import { Surface, wrap, COL } from './surface.js';
+import { face } from './faces.js';
+import { PANEL, TYPE, HIT, BAR, FRONT, eyeDistance, placeWindow } from './room.js';
 
-const PAD = 22;
+const WINDOW_D = eyeDistance(placeWindow(0, 1));   // where a window first lands
 
 function ago(ts) {
   const ms = Date.now() - new Date(ts).getTime();
@@ -33,7 +41,7 @@ function ago(ts) {
 
 export class LieutenantBar extends Surface {
   constructor() {
-    super({ widthM: 1.5, heightM: 0.16, title: '', closable: false });
+    super({ ...PANEL.bar, distanceM: eyeDistance(BAR), title: '', closable: false });
   }
 
   paint(doc) {
@@ -41,27 +49,35 @@ export class LieutenantBar extends Surface {
     const w = this.canvas.width, h = this.canvas.height;
     const lts = doc.lieutenants || [];
     const cell = w / Math.max(1, lts.length);
+    // ponytail: past ~11 lieutenants a cell is under the 3° + 1.6° a hand can
+    // land on. Page the bar when that is a real number of lieutenants.
+    const gap = this.px(HIT.gap);
+    const r = Math.min(this.px(1.7), h * 0.28);
     lts.forEach((l, i) => {
       const x = i * cell;
       const owed = !!l.chatOwed;
+      g.save();
+      g.beginPath();
+      g.rect(x, 0, cell, h);
+      g.clip();                       // a long name stays in its own cell
       g.fillStyle = owed ? '#1d2836' : '#111823';
-      g.fillRect(x + 3, 6, cell - 6, h - 12);
+      g.fillRect(x + gap / 2, this.px(0.2), cell - gap, h - this.px(0.4));
       // A lieutenant waiting on the captain is the only thing in this room that
       // is allowed to shout, because it is the only thing that is his move.
       if (owed) {
         g.fillStyle = COL.accent;
-        g.fillRect(x + 3, 6, 5, h - 12);
+        g.fillRect(x + gap / 2, this.px(0.2), this.px(0.22), h - this.px(0.4));
       }
-      g.fillStyle = l.color || COL.accent;
-      g.beginPath();
-      g.arc(x + cell / 2, h * 0.36, 13, 0, Math.PI * 2);
-      g.fill();
+      face(g, l.avatar, x + cell / 2, h * 0.38, r, l.color || COL.accent);
       g.fillStyle = owed ? COL.text : COL.dim;
-      g.font = '600 24px ' + UI;
+      g.font = this.font(TYPE.meta, 600);
       g.textAlign = 'center';
-      g.fillText(l.name || l.id, x + cell / 2, h * 0.78);
+      g.fillText(l.name || l.id, x + cell / 2, h - this.px(0.5));
       g.textAlign = 'left';
-      this.region(x, 0, cell, h, { kind: 'lieutenant', id: l.id });
+      g.restore();
+      // The plate is what he aims at, and the 1.6° between two plates is what
+      // keeps the wrong lieutenant from answering.
+      this.region(x + gap / 2, 0, cell - gap, h, { kind: 'lieutenant', id: l.id });
     });
     this.end();
   }
@@ -71,13 +87,15 @@ export class LieutenantBar extends Surface {
 
 export class BoardPanel extends Surface {
   constructor() {
-    super({ widthM: 1.9, heightM: 1.05, title: 'board', closable: false });
+    super({ ...PANEL.board, distanceM: eyeDistance(FRONT), title: 'board', closable: false });
   }
 
   paint(doc) {
     const g = this.begin();
     const top = this.chrome(g, doc.title || '');
     const w = this.canvas.width, h = this.canvas.height;
+    const pad = this.px(0.8), gap = this.px(HIT.gap), floor = this.px(HIT.min);
+    const lh = this.line(TYPE.body);
     const cols = (doc.columns || []).filter((c) => c.id !== 'peer');
     const cw = w / Math.max(1, cols.length);
     const ltColour = new Map((doc.lieutenants || []).map((l) => [l.id, l.color || COL.dim]));
@@ -86,35 +104,38 @@ export class BoardPanel extends Surface {
       const x = ci * cw;
       const mine = (doc.cards || []).filter((c) => c.column === col.id);
       g.fillStyle = COL.faint;
-      g.font = '600 22px ' + UI;
-      g.fillText((col.title || col.id) + '  ' + mine.length, x + PAD, top + 34);
+      g.font = this.font(TYPE.meta, 600);
+      g.fillText((col.title || col.id) + '  ' + mine.length, x + pad, top + this.px(1.6));
       g.strokeStyle = COL.edge;
-      g.lineWidth = 2;
+      g.lineWidth = Math.max(1, this.px(0.06));
       if (ci) { g.beginPath(); g.moveTo(x, top); g.lineTo(x, h); g.stroke(); }
 
-      let y = top + 60;
+      let y = top + this.px(2.6);
       for (const c of mine) {
-        if (y > h - 44) {
-          g.fillStyle = COL.faint;
-          g.font = '20px ' + UI;
-          g.fillText('+' + (mine.length - (mine.indexOf(c))) + ' more', x + PAD, y + 20);
-          break;
-        }
         const owed = c.status && (c.status.owed || c.status.unread);
         const working = c.status && c.status.worker && c.status.worker.state === 'live';
-        g.font = '21px ' + UI;
-        const lines = wrap(g, c.title || c.id, cw - PAD * 2 - 18).slice(0, 2);
-        const boxH = 14 + lines.length * 26;
+        g.font = this.font(TYPE.body);
+        const lines = wrap(g, c.title || c.id, cw - pad * 2 - this.px(0.8)).slice(0, 2);
+        // A card is a target before it is a label: never shorter than 3°, even
+        // when its title is one line.
+        const boxH = Math.max(floor, lines.length * lh + this.px(0.6));
+        if (y + boxH > h - gap) {
+          g.fillStyle = COL.faint;
+          g.font = this.font(TYPE.meta);
+          g.fillText('+' + (mine.length - mine.indexOf(c)) + ' more', x + pad, y + this.px(1.2));
+          break;
+        }
         g.fillStyle = owed ? '#18222e' : '#101720';
-        g.fillRect(x + PAD - 8, y - 4, cw - PAD * 2 + 16, boxH);
+        g.fillRect(x + pad * 0.5, y, cw - pad, boxH);
         g.fillStyle = ltColour.get(c.owner) || COL.dim;
-        g.fillRect(x + PAD - 8, y - 4, 4, boxH);
-        if (working) { g.fillStyle = COL.good; g.beginPath(); g.arc(x + cw - PAD - 4, y + 8, 5, 0, Math.PI * 2); g.fill(); }
-        if (owed) { g.fillStyle = COL.accent; g.beginPath(); g.arc(x + cw - PAD - 4, y + 8, 5, 0, Math.PI * 2); g.fill(); }
+        g.fillRect(x + pad * 0.5, y, this.px(0.18), boxH);
+        const dot = this.px(0.22);
+        if (working) { g.fillStyle = COL.good; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
+        if (owed) { g.fillStyle = COL.accent; g.beginPath(); g.arc(x + cw - pad, y + this.px(0.7), dot, 0, Math.PI * 2); g.fill(); }
         g.fillStyle = owed ? COL.text : COL.dim;
-        lines.forEach((ln, i) => g.fillText(ln, x + PAD + 4, y + 20 + i * 26));
-        this.region(x, y - 4, cw, boxH, { kind: 'card', id: c.id });
-        y += boxH + 10;
+        lines.forEach((ln, i) => g.fillText(ln, x + pad, y + this.px(0.3) + lh * (i + 0.78)));
+        this.region(x + pad * 0.5, y, cw - pad, boxH, { kind: 'card', id: c.id });
+        y += boxH + gap;
       }
     });
     this.end();
@@ -125,51 +146,53 @@ export class BoardPanel extends Surface {
 
 export class CardWindow extends Surface {
   constructor(cardId) {
-    super({ widthM: 1.5, heightM: 0.95, title: '', closable: true });
+    super({ ...PANEL.card, distanceM: WINDOW_D, title: '', closable: true });
     this.cardId = cardId;
   }
 
   paint(doc) {
     const card = (doc.cards || []).find((c) => c.id === this.cardId);
     const g = this.begin();
+    const pad = this.px(0.8);
     if (!card) {
       this.title = this.cardId;
       const top = this.chrome(g, 'gone from the board');
       g.fillStyle = COL.faint;
-      g.font = '24px ' + UI;
-      g.fillText('this card is no longer on the board', PAD, top + 60);
+      g.font = this.font(TYPE.body);
+      g.fillText('this card is no longer on the board', pad, top + this.px(2.4));
       return this.end();
     }
     const lt = (doc.lieutenants || []).find((l) => l.id === card.owner);
-    this.title = (card.title || card.id).slice(0, 46);
+    this.title = card.title || card.id;
     const top = this.chrome(g, (lt && lt.name) || card.owner || '');
 
     const w = this.canvas.width, h = this.canvas.height;
+    const lh = this.line(TYPE.body);
     // The chat is not a panel you go and find — it is the right-hand half of the
     // card, always, because reading the work and answering it are one act.
     const split = Math.round(w * 0.52);
     g.strokeStyle = COL.edge;
-    g.lineWidth = 2;
+    g.lineWidth = Math.max(1, this.px(0.06));
     g.beginPath(); g.moveTo(split, top); g.lineTo(split, h); g.stroke();
 
     // left: what the card says
-    let y = top + 34;
+    let y = top + this.px(1.6);
     g.fillStyle = COL.faint;
-    g.font = '20px ' + UI;
-    g.fillText(card.type + ' · ' + card.column + (card.labels && card.labels.length ? ' · ' + card.labels.join(' ') : ''), PAD, y);
-    y += 30;
-    g.font = '21px ' + UI;
-    for (const line of wrap(g, card.body || 'no body yet', split - PAD * 2)) {
-      if (y > h - 60) { g.fillStyle = COL.faint; g.fillText('…', PAD, y); break; }
+    g.font = this.font(TYPE.meta);
+    g.fillText(card.type + ' · ' + card.column + (card.labels && card.labels.length ? ' · ' + card.labels.join(' ') : ''), pad, y);
+    y += lh;
+    g.font = this.font(TYPE.body);
+    for (const line of wrap(g, card.body || 'no body yet', split - pad * 2)) {
+      if (y > h - lh) { g.fillStyle = COL.faint; g.fillText('…', pad, y); break; }
       const head = /^#{1,3}\s/.test(line);
       g.fillStyle = head ? COL.text : COL.dim;
-      g.font = (head ? '600 22px ' : '21px ') + UI;
-      g.fillText(line.replace(/^#{1,3}\s*/, ''), PAD, y);
-      y += 27;
+      g.font = this.font(head ? TYPE.head : TYPE.body, head ? 600 : '');
+      g.fillText(line.replace(/^#{1,3}\s*/, ''), pad, y);
+      y += head ? this.line(TYPE.head) : lh;
     }
 
     // right: the last of the conversation, newest at the bottom
-    this._chat(g, card.thread || [], split + PAD, top, w - split - PAD * 2, h, lt && lt.color);
+    this._chat(g, card.thread || [], split + pad, top, w - split - pad * 2, h, lt && lt.color);
     this.end();
   }
 
@@ -178,37 +201,39 @@ export class CardWindow extends Surface {
   // a bug you notice every single time.
   //
   // Who is speaking is NOT written on every message. This is a conversation with
-  // exactly one other party, and the title bar already names them — a per-message
-  // name is the same word repeated down the whole column, and it is the copy that
-  // scrolls away while the title bar stays. What the board's own chat does is the
-  // same: the bubble's side carries the identity, the footer carries the time.
+  // exactly one other party, and the title bar already names them and now wears
+  // their face — a per-message name is the same word repeated down the whole
+  // column, and it is the copy that scrolls away while the title bar stays. What
+  // the board's own chat does is the same: the bubble's side carries the
+  // identity, the footer carries the time.
   _chat(g, msgs, x, top, width, h, colour) {
-    let y = h - PAD;
-    for (let i = msgs.length - 1; i >= 0 && y > top + 30; i--) {
+    const pad = this.px(0.8), lh = this.line(TYPE.body);
+    let y = h - pad;
+    for (let i = msgs.length - 1; i >= 0 && y > top + lh; i--) {
       const m = msgs[i];
       const mine = m.author === 'user';
-      g.font = '21px ' + UI;
-      const lines = wrap(g, m.text || '', width - 16).slice(0, 8);
-      const blockH = lines.length * 26 + 26;
+      g.font = this.font(TYPE.body);
+      const lines = wrap(g, m.text || '', width - pad).slice(0, 8);
+      const blockH = lines.length * lh + this.line(TYPE.meta);
       y -= blockH;
       // The oldest visible message runs off the TOP, and it has to stop at the
       // title bar rather than being painted over it.
-      if (y < top + 6) break;
+      if (y < top + this.px(0.2)) break;
       g.fillStyle = mine ? '#16202c' : '#0f1620';
-      g.fillRect(x - 8, y - 4, width + 16, blockH);
+      g.fillRect(x - pad * 0.4, y - this.px(0.15), width + pad * 0.8, blockH);
       // The side bar is who: the captain's own accent against the lieutenant's
       // own colour, the same mark the board puts on a card for its owner.
       g.fillStyle = mine ? COL.accent : (colour || COL.dim);
-      g.fillRect(x - 8, y - 4, 4, blockH);
+      g.fillRect(x - pad * 0.4, y - this.px(0.15), this.px(0.18), blockH);
       g.fillStyle = COL.dim;
-      g.font = '21px ' + UI;
-      lines.forEach((ln, k) => g.fillText(ln, x + 4, y + 18 + k * 26));
+      g.font = this.font(TYPE.body);
+      lines.forEach((ln, k) => g.fillText(ln, x + pad * 0.2, y + lh * (k + 0.78)));
       g.fillStyle = COL.faint;
-      g.font = '18px ' + UI;
+      g.font = this.font(TYPE.meta);
       g.textAlign = 'right';
-      g.fillText(ago(m.ts), x + width, y + blockH - 6);
+      g.fillText(ago(m.ts), x + width, y + blockH - this.px(0.25));
       g.textAlign = 'left';
-      y -= 10;
+      y -= this.px(0.4);
     }
   }
 }
@@ -217,7 +242,7 @@ export class CardWindow extends Surface {
 
 export class ChatWindow extends Surface {
   constructor(ltId) {
-    super({ widthM: 0.9, heightM: 0.95, title: '', closable: true });
+    super({ ...PANEL.chat, distanceM: WINDOW_D, title: '', closable: true });
     this.ltId = ltId;
   }
 
@@ -225,9 +250,14 @@ export class ChatWindow extends Surface {
     const lt = (doc.lieutenants || []).find((l) => l.id === this.ltId);
     const g = this.begin();
     this.title = (lt && lt.name) || this.ltId;
-    const top = this.chrome(g, lt && lt.chatOwed ? '· waiting on you' : '');
+    // The face goes in the title bar, where the flat board puts it: this window
+    // is one conversation with one lieutenant, and the bar is the one place that
+    // says so and stays put while the messages scroll away underneath.
+    const top = this.chrome(g, lt && lt.chatOwed ? '· waiting on you' : '',
+      { avatar: lt && lt.avatar, colour: (lt && lt.color) || COL.accent });
     const w = this.canvas.width, h = this.canvas.height;
-    CardWindow.prototype._chat.call(this, g, (lt && lt.chat) || [], PAD, top, w - PAD * 2, h, lt && lt.color);
+    const pad = this.px(0.8);
+    CardWindow.prototype._chat.call(this, g, (lt && lt.chat) || [], pad, top, w - pad * 2, h, lt && lt.color);
     this.end();
   }
 }

--- a/ui/js/bridge3d/room.js
+++ b/ui/js/bridge3d/room.js
@@ -34,8 +34,15 @@ export const CAP = 0.72;            // cap height as a fraction of the em box
 export const TYPE = { head: 2.0, body: 1.4, meta: 1.15 };
 
 // A target under 3° is a target you stab at; two of them closer than 1.6° apart
-// are one target that sometimes does the other thing.
+// are one target that sometimes does the other thing. These are the FLOORS —
+// what a measurement is held against.
 export const HIT = { min: 3.0, gap: 1.6 };
+
+// And this is what the room BUILDS to. A box constructed to land exactly on
+// 3.000° lands a rounding error under it about half the time, and
+// fractionally-below is not met — so every target is cut a hair over its floor
+// and the floor stays the floor.
+export const BUILD = { min: HIT.min + 0.06, gap: HIT.gap + 0.06 };
 
 // Nothing readable comes nearer than NEAR — discomfort rises exponentially as
 // content approaches the face — and past FAR the eyes are working at a depth
@@ -98,11 +105,16 @@ export const BAR = { x: 0, y: EYE - 0.62, z: -1.00 };
 //
 // Rows step back and down together, and by little: the far row still has to land
 // inside FAR, or the windows he is not working on become the unreadable ones.
+// Which is also why there is a LAST row — a fourth would have landed at 2.20 m
+// with its bottom edge under the floor. Past it the windows crowd into the row
+// he already has rather than going further away, which is what "they stack"
+// meant all along.
 export function placeWindow(index, count) {
-  const perRow = 3;
-  const row = Math.floor(index / perRow);
-  const col = index % perRow;
-  const inRow = Math.min(perRow, count - row * perRow);
+  const perRow = 3, rows = 3;
+  const row = Math.min(rows - 1, Math.floor(index / perRow));
+  const col = index - row * perRow;
+  const left = count - row * perRow;
+  const inRow = Math.max(1, row === rows - 1 ? left : Math.min(perRow, left));
   const spread = 60;                                    // degrees across a row
   const step = inRow > 1 ? spread / (inRow - 1) : 0;
   const a = ((inRow > 1 ? -spread / 2 + col * step : 0)) * Math.PI / 180;

--- a/ui/js/bridge3d/room.js
+++ b/ui/js/bridge3d/room.js
@@ -18,29 +18,98 @@
 
 export const EYE = 1.45;
 
-export const FRONT = { z: -1.55, y: EYE - 0.02, dim: 1 };
-export const BACK = { z: -3.1, y: EYE + 0.32, dim: 0.55 };
+// ---- arc, the only unit a person actually perceives -------------------------
+//
+// A size in canvas pixels means nothing on its own, and neither does a size in
+// metres: half a metre is a wall at arm's length and a postage stamp across the
+// room. Everything the captain reads or points at is authored in DEGREES here
+// and converted at the distance its own panel sits — which is why a Surface is
+// told where it stands, and sizes its own type from that.
+
+export const PPD = 25;              // what a Quest 3 effectively resolves, px/°
+export const CAP = 0.72;            // cap height as a fraction of the em box
+
+// Em-box degrees. The floor is 0.7° of CAP height, and `meta` is the smallest
+// thing painted anywhere in the room: 1.15 × 0.72 = 0.83°, clear of it.
+export const TYPE = { head: 2.0, body: 1.4, meta: 1.15 };
+
+// A target under 3° is a target you stab at; two of them closer than 1.6° apart
+// are one target that sometimes does the other thing.
+export const HIT = { min: 3.0, gap: 1.6 };
+
+// Nothing readable comes nearer than NEAR — discomfort rises exponentially as
+// content approaches the face — and past FAR the eyes are working at a depth
+// the headset's fixed focal plane cannot meet.
+export const NEAR = 0.5;
+export const FAR = 2.0;
+
+// Looking up is the fastest route to a sore neck: nothing's top edge goes above
+// RISE, and a panel he reads sits with its centre a comfortable glance DOWN.
+export const RISE = 10;
+export const DROP = [10, 20];
+
+export function arcDeg(sizeM, distM) { return 2 * Math.atan(sizeM / (2 * distM)) * 180 / Math.PI; }
+export function sizeForArc(deg, distM) { return 2 * distM * Math.tan(deg * Math.PI / 360); }
+
+// Canvas texels a panel wants per world metre, so one degree of its arc gets PPD
+// of them. Under-resolving here is the usual reason canvas text looks soft.
+export function texelsPerMetre(distM) { return PPD / sizeForArc(1, distM); }
+
+// How far a thing placed at p is from the eye — the number every arc above is
+// measured against, so it is computed and never assumed from z alone.
+export function eyeDistance(p) {
+  return Math.hypot(p.x || 0, (p.y === undefined ? EYE : p.y) - EYE, p.z || 0);
+}
+
+// What each surface is, in metres. Here rather than in panels.js because these
+// are half of every arc figure in the room, and the tests check them.
+//
+// How tall a panel may be is not a taste: the room has about 45° of usable
+// vertical field — from +10°, past which looking up is a sore neck, down to the
+// bottom of a comfortable glance — and the bar takes the bottom 9° of it. What
+// is left is ~35°, which is 0.90 m at the distance the board stands. A panel's
+// METRES do not decide how much it shows; its DEGREES do, and they are all the
+// room has to spend.
+export const PANEL = {
+  bar: { widthM: 1.2, heightM: 0.15 },
+  board: { widthM: 1.9, heightM: 0.90 },
+  card: { widthM: 1.5, heightM: 0.86 },
+  chat: { widthM: 0.9, heightM: 0.86 },
+};
+
+// The board reads at 1.58 m in front and 1.93 m pushed back — both inside the
+// comfort band, where the old back position (3.1 m) put its body text at 0.35°
+// and made the remembering surface a thing he had to lean towards. Centred 11°
+// below the horizon, which is where the eyes rest.
+export const FRONT = { z: -1.55, y: EYE - 0.30, dim: 1 };
+export const BACK = { z: -1.90, y: EYE - 0.36, dim: 0.55 };
 
 // The bar sits low and close, under the conversation rather than in it — near
-// enough to hit without aiming, far enough down not to cover a face.
-export const BAR = { x: 0, y: EYE - 0.44, z: -0.92 };
+// enough to hit without aiming, far enough down not to cover a face. Its top
+// edge clears the bottom of everything in the front row: the lieutenants are
+// the one thing always visible, so they are also the one thing that must never
+// be sitting on top of the work.
+export const BAR = { x: 0, y: EYE - 0.62, z: -1.00 };
 
 // placeWindow(index, count) — where the n-th open window goes: an arc in front,
 // widening as more open, never wrapping past the shoulders. Beyond that the
 // captain is out of attention, which is his limit to set, not ours — so they
 // stack rather than spiral out of reach.
+//
+// Rows step back and down together, and by little: the far row still has to land
+// inside FAR, or the windows he is not working on become the unreadable ones.
 export function placeWindow(index, count) {
   const perRow = 3;
   const row = Math.floor(index / perRow);
   const col = index % perRow;
   const inRow = Math.min(perRow, count - row * perRow);
-  const spread = 46;                                    // degrees across a row
+  const spread = 60;                                    // degrees across a row
   const step = inRow > 1 ? spread / (inRow - 1) : 0;
   const a = ((inRow > 1 ? -spread / 2 + col * step : 0)) * Math.PI / 180;
-  const radius = 1.35 + row * 0.28;
+  const radius = 1.35 + row * 0.15;
   return {
     x: Math.sin(a) * radius,
-    y: EYE + 0.06 - row * 0.42,
+    y: EYE - 0.24 - row * 0.34,
     z: -Math.cos(a) * radius,
   };
 }

--- a/ui/js/bridge3d/room.js
+++ b/ui/js/bridge3d/room.js
@@ -98,6 +98,25 @@ export const BACK = { z: -1.90, y: EYE - 0.36, dim: 0.55 };
 // be sitting on top of the work.
 export const BAR = { x: 0, y: EYE - 0.62, z: -1.00 };
 
+// How wide the bar has to be to give every lieutenant a plate he can hit with
+// air beside it. A fixed-width bar keeps its 3° plates as the count climbs by
+// eating the gap instead — at twelve lieutenants the air between two of them
+// collapses to 1.06° and the wrong one answers — so the bar GROWS instead, out
+// to BAR_ARC. Past the count that fits in that, the shoulders are the limit
+// rather than the arithmetic.
+//
+// ponytail: BAR_LIMIT is the last count the bar holds to both floors with room
+// to spare. Past it the bar is full and the air between plates starts to go —
+// 1.32° at sixteen, 0.83° at eighteen. Page it when that is a real number of
+// lieutenants; today the captain has four.
+export const BAR_ARC = 70;                                   // degrees, edges at ±35
+export const BAR_LIMIT = Math.floor(BAR_ARC / (BUILD.min + BUILD.gap));
+
+export function barWidth(count, distM) {
+  const want = Math.min(BAR_ARC, Math.max(1, count) * (BUILD.min + BUILD.gap));
+  return Math.max(PANEL.bar.widthM, sizeForArc(want, distM));
+}
+
 // placeWindow(index, count) — where the n-th open window goes: an arc in front,
 // widening as more open, never wrapping past the shoulders. Beyond that the
 // captain is out of attention, which is his limit to set, not ours — so they

--- a/ui/js/bridge3d/surface.js
+++ b/ui/js/bridge3d/surface.js
@@ -11,14 +11,18 @@
 // business of whoever made it.
 
 import * as THREE from '../../vendor/three/three.module.min.js';
+import { arcDeg, texelsPerMetre, TYPE, HIT } from './room.js';
+import { face } from './faces.js';
 
 export const FONT = 'ui-monospace, "DejaVu Sans Mono", "Courier New", monospace';
 export const UI = 'system-ui, -apple-system, "Segoe UI", sans-serif';
 
-// Canvas pixels per world metre. Everything else is expressed in metres and
-// multiplied by this, so a surface is authored once and stays sharp when the
-// captain grows it — the canvas is re-cut, not stretched.
-export const PPM = 1100;
+// A canvas has pixels and the eye has degrees, and the conversion between them
+// runs through the distance the panel stands at — so a Surface is told that
+// distance and everything painted on it is asked for in degrees. `px(deg)` is
+// the only way sizes get onto this canvas; a number of pixels chosen directly
+// is a number nobody has checked against an eye.
+const MAX_TEXELS = 2048;
 
 export const COL = {
   bg: '#0d1117',
@@ -50,10 +54,12 @@ export function wrap(ctx, text, maxWidth) {
 }
 
 export class Surface {
-  // widthM / heightM are world metres; the canvas follows at PPM.
-  constructor({ widthM = 1.0, heightM = 0.7, title = '', closable = true } = {}) {
+  // widthM / heightM are world metres; distanceM is how far from the eye it
+  // stands, and it is what turns every degree below into canvas pixels.
+  constructor({ widthM = 1.0, heightM = 0.7, distanceM = 1.5, title = '', closable = true } = {}) {
     this.widthM = widthM;
     this.heightM = heightM;
+    this.distanceM = distanceM;
     this.title = title;
     this.closable = closable;
     this.front = false;
@@ -79,6 +85,9 @@ export class Surface {
       new THREE.EdgesGeometry(new THREE.PlaneGeometry(1, 1)),
       new THREE.LineBasicMaterial({ color: new THREE.Color(COL.edge) }),
     );
+    // A millimetre off the plate: two coplanar surfaces shimmer against each
+    // other, and a shimmering border is felt as eyestrain rather than seen.
+    this.frame.position.z = 0.001;
 
     this.group = new THREE.Group();
     this.group.add(this.mesh, this.frame);
@@ -86,23 +95,35 @@ export class Surface {
     this._applySize();
   }
 
+  // The canvas is cut to the panel's own arc: enough texels for PPD of them per
+  // degree at the distance it stands, capped at what a texture can hold. When it
+  // is capped the arc of everything on it is unchanged — the sheet just gets
+  // softer, which is the failure you want of the two.
   _cut() {
-    this.canvas.width = Math.max(64, Math.round(this.widthM * PPM));
-    this.canvas.height = Math.max(64, Math.round(this.heightM * PPM));
+    const scale = Math.min(
+      texelsPerMetre(this.distanceM),
+      MAX_TEXELS / Math.max(this.widthM, this.heightM),
+    );
+    this.canvas.width = Math.max(64, Math.round(this.widthM * scale));
+    this.canvas.height = Math.max(64, Math.round(this.heightM * scale));
+    this.pxPerDeg = this.canvas.width / arcDeg(this.widthM, this.distanceM);
   }
+
+  // px(deg) — degrees of the captain's visual field, in canvas pixels.
+  px(deg) { return deg * this.pxPerDeg; }
+
+  // font(deg) — a font whose EM BOX is deg wide. Cap height is ~0.72 of that,
+  // which is the number the 0.7° floor is about. Regular and bold only: lighter
+  // strokes vibrate at this size and read as blur.
+  font(deg, weight) { return (weight ? weight + ' ' : '') + Math.round(this.px(deg)) + 'px ' + UI; }
+  line(deg) { return Math.round(this.px(deg) * 1.3); }
 
   _applySize() {
     this.mesh.scale.set(this.widthM, this.heightM, 1);
     this.frame.scale.set(this.widthM, this.heightM, 1);
   }
 
-  // resize(w, h) — re-cut the canvas rather than stretching the plane, so text
-  // is the same sharpness at every size the captain drags it to.
-  resize(widthM, heightM) {
-    this.widthM = Math.max(0.25, Math.min(4, widthM));
-    this.heightM = Math.max(0.2, Math.min(3, heightM));
-    this._cut();
-    this._applySize();
+  _retexture() {
     this.texture.dispose();
     this.texture = new THREE.CanvasTexture(this.canvas);
     this.texture.colorSpace = THREE.SRGBColorSpace;
@@ -113,6 +134,29 @@ export class Surface {
     this.mesh.material.needsUpdate = true;
     this.dirty = true;
   }
+
+  // resize(w, h) — re-cut the canvas rather than stretching the plane, so text
+  // is the same sharpness at every size the captain drags it to. The type keeps
+  // its arc: a bigger panel shows MORE, it does not show the same thing bigger.
+  resize(widthM, heightM) {
+    this.widthM = Math.max(0.25, Math.min(4, widthM));
+    this.heightM = Math.max(0.2, Math.min(3, heightM));
+    this._cut();
+    this._applySize();
+    this._retexture();
+  }
+
+  // setDistance(m) — he carried it nearer or further, so the type is re-derived
+  // at where it now stands. A panel that knows its own distance sizes its own
+  // text; that is the whole reason the distance is stored on it.
+  setDistance(distanceM) {
+    if (!(distanceM > 0) || Math.abs(distanceM - this.distanceM) < 0.02) return false;
+    this.distanceM = distanceM;
+    this._cut();
+    this._retexture();
+    return true;
+  }
+
 
   // Depth is the only thing that says which panel is being worked and which is
   // merely available: the front one is brighter and nearer, the rest fall back
@@ -142,7 +186,17 @@ export class Surface {
   // A rectangle on the canvas that means something when it is pointed at. The
   // panel declares these AS it paints, so what is clickable is whatever is
   // actually drawn — the two cannot drift apart.
-  region(x, y, w, h, action) { this.hits.push({ x, y, w, h, action }); }
+  //
+  // Pad the hit box, not the drawing: the mark may be smaller than 3° of his
+  // field, the thing that answers a ray may not be. Every region in the room
+  // grows about its own centre to that floor here, once, rather than each
+  // caller being trusted to remember it.
+  region(x, y, w, h, action) {
+    const min = this.px(HIT.min);
+    if (w < min) { x -= (min - w) / 2; w = min; }
+    if (h < min) { y -= (min - h) / 2; h = min; }
+    this.hits.push({ x, y, w, h, action });
+  }
 
   // uv comes off the raycast with its origin at the bottom left, which is why y
   // is flipped exactly here and nowhere else in the room.
@@ -160,36 +214,61 @@ export class Surface {
 
   // A titled panel's chrome: the bar across the top, and the close mark the
   // controller ray can hit. Returns the y the content starts at.
-  chrome(g, subtitle) {
+  //
+  // The bar is as tall as the close button has to be — 3° — because the close
+  // button IS the bar's height, and at 62 × 54 canvas pixels it used to be 2.07°
+  // of him: a target you aim at twice.
+  chrome(g, subtitle, who) {
     const w = this.canvas.width;
-    const barH = 54;
+    const pad = this.px(0.7);
+    const box = this.px(HIT.min);                 // the close target, 3° square
+    const barH = Math.max(box, this.px(TYPE.head) * 1.7);
     g.fillStyle = this.front ? '#1b2531' : '#131a23';
     g.fillRect(0, 0, w, barH);
+
+    // The title and its subtitle stop short of the close mark rather than
+    // running under it — the 1.6° between them has to stay empty to be a gap.
+    g.save();
+    g.beginPath();
+    g.rect(0, 0, w - box - this.px(HIT.gap), barH);
+    g.clip();
+    let x = pad;
+    // Who this conversation is with, where the 2D board puts it: the face first,
+    // then the name. A lieutenant without one keeps the coloured dot.
+    if (who) {
+      const r = barH * 0.34;
+      face(g, who.avatar, x + r, barH / 2, r, who.colour);
+      x += r * 2 + pad;
+    }
+    const mid = barH / 2 + this.px(TYPE.head) * 0.36;
     g.fillStyle = this.front ? COL.accent : COL.dim;
-    g.font = '600 26px ' + UI;
-    g.fillText(this.title, 20, 36);
+    g.font = this.font(TYPE.head, 600);
+    g.fillText(this.title, x, mid);
     // Measure the title in the TITLE's font, before switching to the smaller
     // one — measuring it in the subtitle's font puts the subtitle on top of it.
-    const after = 20 + g.measureText(this.title).width + 16;
+    const after = x + g.measureText(this.title).width + pad;
     if (subtitle) {
       g.fillStyle = COL.faint;
-      g.font = '22px ' + UI;
-      g.fillText(subtitle, after, 36);
+      g.font = this.font(TYPE.meta);
+      g.fillText(subtitle, after, mid);
     }
+    g.restore();
+
     if (this.closable) {
       g.strokeStyle = COL.faint;
-      g.lineWidth = 3;
-      const cx = w - 30, cy = barH / 2, r = 9;
+      g.lineWidth = Math.max(2, this.px(0.09));
+      const cx = w - box / 2, cy = barH / 2, r = this.px(0.5);
       g.beginPath();
       g.moveTo(cx - r, cy - r); g.lineTo(cx + r, cy + r);
       g.moveTo(cx + r, cy - r); g.lineTo(cx - r, cy + r);
       g.stroke();
-      this.region(w - 62, 0, 62, barH, { kind: 'close' });
+      this.region(w - box, 0, box, barH, { kind: 'close' });
     }
     // The bar itself is the handle: point anywhere along it and squeeze to move
     // the window, which is the one gesture every window manager already taught
-    // everybody.
-    this.region(0, 0, w - 64, barH, { kind: 'grab' });
+    // everybody. It ends a clear 1.6° before the close mark, so the gesture that
+    // moves the window is never the gesture that throws it away.
+    this.region(0, 0, w - box - this.px(HIT.gap), barH, { kind: 'grab' });
     return barH;
   }
 

--- a/ui/js/bridge3d/surface.js
+++ b/ui/js/bridge3d/surface.js
@@ -240,16 +240,21 @@ export class Surface {
   // it sits, so a region near an edge grows by more pixels than one in the
   // middle to reach the same 3°.
   region(x, y, w, h, action) {
-    if (this.degX(x, x + w) < BUILD.min) {
+    const E = 1e-9;                    // already exactly at the floor is not under it
+    if (this.degX(x, x + w) < BUILD.min - E) {
       const mid = x + w / 2;
       x = this.atDegX(mid, -BUILD.min / 2);
       w = this.atDegX(mid, BUILD.min / 2) - x;
     }
-    if (this.degY(y, y + h) < BUILD.min) {
+    if (this.degY(y, y + h) < BUILD.min - E) {
       const mid = y + h / 2;
       y = this.atDegY(mid, -BUILD.min / 2);
       h = this.atDegY(mid, BUILD.min / 2) - y;
     }
+    // A region that grew off the edge of the canvas is a region whose last
+    // degree cannot be hit — the ray's uv stops at the panel. Slide it back on.
+    x = Math.max(0, Math.min(x, this.canvas.width - w));
+    y = Math.max(0, Math.min(y, this.canvas.height - h));
     this.hits.push({ x, y, w, h, action });
   }
 

--- a/ui/js/bridge3d/surface.js
+++ b/ui/js/bridge3d/surface.js
@@ -11,7 +11,7 @@
 // business of whoever made it.
 
 import * as THREE from '../../vendor/three/three.module.min.js';
-import { arcDeg, texelsPerMetre, TYPE, HIT } from './room.js';
+import { arcDeg, texelsPerMetre, TYPE, BUILD } from './room.js';
 import { face } from './faces.js';
 
 export const FONT = 'ui-monospace, "DejaVu Sans Mono", "Courier New", monospace';
@@ -109,8 +109,54 @@ export class Surface {
     this.pxPerDeg = this.canvas.width / arcDeg(this.widthM, this.distanceM);
   }
 
-  // px(deg) — degrees of the captain's visual field, in canvas pixels.
+  // px(deg) — degrees of the captain's visual field, in canvas pixels, using the
+  // panel's AVERAGE density. Good enough for type, which is never at the floor:
+  // body text comes out 1.10° of cap in the middle and 0.85° in the far corner,
+  // both clear of 0.7°. Not good enough for a target, which is measured against
+  // the floor exactly — those use the pair below.
   px(deg) { return deg * this.pxPerDeg; }
+
+  // ---- degrees where the thing actually sits -------------------------------
+  //
+  // A flat panel does not spread its pixels evenly across the eye. At a lateral
+  // offset u from its centre, a metre of canvas is worth d/(d² + u²) radians
+  // instead of 1/d, so a degree in the corner costs MORE pixels than a degree in
+  // the middle — and a fixed pixel count out there subtends less arc than it was
+  // asked for. That is not a rounding error at the edge of a wide panel: on a
+  // 1.5 m window at 1.37 m the corner runs 0.84 of the average, which is how a
+  // close button drawn at "3°" arrived at 2.58° of him.
+  //
+  // The close button is at the far edge BY CONSTRUCTION — chrome() pins it to the
+  // right-hand corner of every window there will ever be — so hit geometry is
+  // converted with atan at the position it occupies, in both axes, and no
+  // small-angle average is involved anywhere in it.
+
+  _u(x) { return (x / this.canvas.width - 0.5) * this.widthM; }      // m right of centre
+  _v(y) { return (0.5 - y / this.canvas.height) * this.heightM; }    // m above centre
+
+  // The true arc between two canvas coordinates.
+  degX(x1, x2) {
+    const d = this.distanceM;
+    return (Math.atan(this._u(x2) / d) - Math.atan(this._u(x1) / d)) * 180 / Math.PI;
+  }
+  degY(y1, y2) {
+    const d = this.distanceM;
+    return (Math.atan(this._v(y1) / d) - Math.atan(this._v(y2) / d)) * 180 / Math.PI;
+  }
+
+  // The canvas coordinate exactly deg away from another — right/down for a
+  // positive deg, left/up for a negative one. This is how a 3° box gets built
+  // from the corner it is pinned to rather than from an average of the panel.
+  atDegX(x, deg) {
+    const d = this.distanceM;
+    const u = d * Math.tan(Math.atan(this._u(x) / d) + deg * Math.PI / 180);
+    return (u / this.widthM + 0.5) * this.canvas.width;
+  }
+  atDegY(y, deg) {
+    const d = this.distanceM;
+    const v = d * Math.tan(Math.atan(this._v(y) / d) - deg * Math.PI / 180);
+    return (0.5 - v / this.heightM) * this.canvas.height;
+  }
 
   // font(deg) — a font whose EM BOX is deg wide. Cap height is ~0.72 of that,
   // which is the number the 0.7° floor is about. Regular and bold only: lighter
@@ -190,11 +236,20 @@ export class Surface {
   // Pad the hit box, not the drawing: the mark may be smaller than 3° of his
   // field, the thing that answers a ray may not be. Every region in the room
   // grows about its own centre to that floor here, once, rather than each
-  // caller being trusted to remember it.
+  // caller being trusted to remember it — and it is measured in true arc where
+  // it sits, so a region near an edge grows by more pixels than one in the
+  // middle to reach the same 3°.
   region(x, y, w, h, action) {
-    const min = this.px(HIT.min);
-    if (w < min) { x -= (min - w) / 2; w = min; }
-    if (h < min) { y -= (min - h) / 2; h = min; }
+    if (this.degX(x, x + w) < BUILD.min) {
+      const mid = x + w / 2;
+      x = this.atDegX(mid, -BUILD.min / 2);
+      w = this.atDegX(mid, BUILD.min / 2) - x;
+    }
+    if (this.degY(y, y + h) < BUILD.min) {
+      const mid = y + h / 2;
+      y = this.atDegY(mid, -BUILD.min / 2);
+      h = this.atDegY(mid, BUILD.min / 2) - y;
+    }
     this.hits.push({ x, y, w, h, action });
   }
 
@@ -221,8 +276,12 @@ export class Surface {
   chrome(g, subtitle, who) {
     const w = this.canvas.width;
     const pad = this.px(0.7);
-    const box = this.px(HIT.min);                 // the close target, 3° square
-    const barH = Math.max(box, this.px(TYPE.head) * 1.7);
+    // Both of these are built by walking BACK from the right-hand edge in true
+    // arc, because that corner is where they live and where a degree is dearest.
+    const boxL = this.atDegX(w, -BUILD.min);      // left edge of the 3° close box
+    const grabR = this.atDegX(boxL, -BUILD.gap);  // and 1.6° of clear air before it
+    const box = w - boxL;
+    const barH = Math.max(this.atDegY(0, BUILD.min), this.px(TYPE.head) * 1.7);
     g.fillStyle = this.front ? '#1b2531' : '#131a23';
     g.fillRect(0, 0, w, barH);
 
@@ -230,7 +289,7 @@ export class Surface {
     // running under it — the 1.6° between them has to stay empty to be a gap.
     g.save();
     g.beginPath();
-    g.rect(0, 0, w - box - this.px(HIT.gap), barH);
+    g.rect(0, 0, grabR, barH);
     g.clip();
     let x = pad;
     // Who this conversation is with, where the 2D board puts it: the face first,
@@ -262,13 +321,13 @@ export class Surface {
       g.moveTo(cx - r, cy - r); g.lineTo(cx + r, cy + r);
       g.moveTo(cx + r, cy - r); g.lineTo(cx - r, cy + r);
       g.stroke();
-      this.region(w - box, 0, box, barH, { kind: 'close' });
+      this.region(boxL, 0, box, barH, { kind: 'close' });
     }
     // The bar itself is the handle: point anywhere along it and squeeze to move
     // the window, which is the one gesture every window manager already taught
     // everybody. It ends a clear 1.6° before the close mark, so the gesture that
     // moves the window is never the gesture that throws it away.
-    this.region(0, 0, w - box - this.px(HIT.gap), barH, { kind: 'grab' });
+    this.region(0, 0, grabR, barH, { kind: 'grab' });
     return barH;
   }
 


### PR DESCRIPTION
# Description

The captain wore the room and came out with "tá ruim, mas é promissor" — and the "ruim" turns out to be arithmetic, not taste. Every size in `ui/js/bridge3d/` was authored in canvas pixels and never converted to the arc it subtends at the distance its panel actually sits, so the board's body text landed at 0.35° (unreadable starts at 0.4°), the close button at 2.07° (a 3° target), and the board itself at 3.1 m with the comfort band ending at 2 m. This makes arc the unit: a panel is told where it stands and sizes its own type and hit boxes from that, so the numbers hold wherever a panel is carried. The lieutenants also get their faces — the avatar sheet the flat board draws with a CSS sprite, painted onto the panel canvas, because there is no DOM inside an immersive session.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added: the panels are built with a real board, painted onto a recording 2D context, and the regions and glyph boxes they declare are measured back in true arc — an independent derivation, not the code under test asking itself.
- Opened on a desktop browser (non-XR path) against the dev playground: room renders, faces land, cards and chats open, no console errors.

## Any specific deployment considerations

None — static UI files.
