### PR TITLE
Sound survives the screen going off

### DIFF
--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -1,0 +1,128 @@
+'use strict';
+// ui/js/sound.js — surviving the screen going off.
+//
+// iOS Safari does not suspend an AudioContext when the phone locks, it
+// INTERRUPTS it: a WebKit-only state that every `state === 'suspended'` check
+// reads as fine, so nothing resumes and the board is silent for the rest of the
+// page's life. These tests pin the recovery decision (a pure function, no
+// browser) and the two paths that have to still be armed after the lock.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let play, needsResume;
+
+// The page's listeners, kept by type so a test can fire a gesture by hand.
+const listeners = { window: {}, document: {} };
+const add = (bag) => (ev, fn) => (bag[ev] = bag[ev] || []).push(fn);
+// A real removeEventListener, because "is the gesture path still armed" is
+// exactly what these tests ask — a no-op stub would pass against the bug.
+const remove = (bag) => (ev, fn) => { bag[ev] = (bag[ev] || []).filter((f) => f !== fn); };
+const fire = (bag, ev) => (listeners[bag][ev] || []).slice().forEach((f) => f());
+
+// An AudioContext that can refuse to resume, the way iOS does without a gesture.
+let theCtx = null;
+let resumes = 0;
+class FakeCtx {
+  constructor() {
+    this.state = 'running'; this.currentTime = 0; this.destination = {};
+    this.refuse = false; this.onstatechange = null; theCtx = this;
+  }
+  resume() {
+    resumes++;
+    if (this.refuse) return Promise.reject(new Error('not allowed without a gesture'));
+    this.state = 'running';
+    return Promise.resolve();
+  }
+  createGain() {
+    return { gain: { value: 0, setValueAtTime() {}, linearRampToValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {} };
+  }
+  createDynamicsCompressor() {
+    const p = () => ({ value: 0 });
+    return { threshold: p(), knee: p(), ratio: p(), attack: p(), release: p(), connect() {} };
+  }
+  createOscillator() {
+    const o = { frequency: { setValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {}, start() { played++; }, stop() {} };
+    return o;
+  }
+}
+let played = 0;
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+test.before(async () => {
+  global.window = { AudioContext: FakeCtx, addEventListener: add(listeners.window), removeEventListener: remove(listeners.window) };
+  global.document = { hidden: false, addEventListener: add(listeners.document) };
+  ({ play, needsResume } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'sound.js')).href));
+});
+test.beforeEach(() => { resumes = 0; played = 0; if (theCtx) { theCtx.refuse = false; theCtx.state = 'running'; } });
+
+// ── the decision ──────────────────────────────────────────────────────────
+test('the recovery decision covers every state a context can be in', () => {
+  assert.equal(needsResume('running'), false, 'running: nothing to do');
+  assert.equal(needsResume('suspended'), true, 'suspended: Chrome backgrounding the tab');
+  assert.equal(needsResume('interrupted'), true, "interrupted: iOS locking the screen — the state that made it silent");
+  assert.equal(needsResume('closed'), false, 'closed: dead for good, resume() cannot bring it back');
+  assert.equal(needsResume('whatever-webkit-invents-next'), true, 'anything not running is broken until proven otherwise');
+});
+
+// ── the gesture path ──────────────────────────────────────────────────────
+test('a gesture still unlocks the context long after the first one fired', async () => {
+  fire('window', 'click');              // first gesture ever: makes the context
+  await tick();
+  assert.ok(theCtx, 'the first gesture built the context');
+  assert.equal(theCtx.state, 'running');
+
+  theCtx.state = 'interrupted';          // the phone locks, and is unlocked
+  resumes = 0;
+  fire('window', 'click');               // the captain taps the board again
+  await tick();
+  assert.equal(resumes, 1, 'the gesture listener was still attached');
+  assert.equal(theCtx.state, 'running', 'and it woke the context back up');
+});
+
+test('a refused resume leaves the gesture path armed for the next try', async () => {
+  fire('window', 'click');
+  await tick();
+  theCtx.state = 'interrupted'; theCtx.refuse = true; resumes = 0;
+  fire('window', 'click');               // iOS says no
+  await tick();
+  assert.equal(resumes, 1);
+  assert.equal(theCtx.state, 'interrupted', 'still broken');
+
+  theCtx.refuse = false;
+  fire('window', 'click');               // and the next tap gets it back
+  await tick();
+  assert.equal(resumes, 2, 'not disarmed by the rejection');
+  assert.equal(theCtx.state, 'running');
+});
+
+// ── the other two paths ───────────────────────────────────────────────────
+test('the context recovers on its own statechange, not at the next tone', async () => {
+  fire('window', 'click');
+  await tick();
+  theCtx.state = 'interrupted'; resumes = 0;
+  theCtx.onstatechange();
+  await tick();
+  assert.equal(theCtx.state, 'running', 'iOS said it changed; the module asked to resume');
+});
+
+test('returning to the page resumes an interrupted context', async () => {
+  fire('window', 'click');
+  await tick();
+  theCtx.state = 'interrupted'; resumes = 0;
+  fire('document', 'visibilitychange');
+  await tick();
+  assert.equal(resumes, 1);
+  assert.equal(theCtx.state, 'running');
+});
+
+test('a notification resumes an interrupted context and then sounds', async () => {
+  fire('window', 'click');
+  await tick();
+  theCtx.state = 'interrupted'; played = 0;
+  play('ding');
+  await tick();
+  assert.equal(theCtx.state, 'running', 'resumed before scheduling');
+  assert.ok(played > 0, 'and the tone was actually scheduled');
+});

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -5,12 +5,24 @@
 // speechSynthesis), so a later programmatic play() from an SSE event isn't
 // silently blocked by the browser.
 let ctx = null, master = null, comp = null, volume = 0.85;
+
+// Ask whether it is RUNNING, not which way it is broken: Chrome parks a
+// backgrounded context in 'suspended', iOS Safari moves it to 'interrupted'
+// when the screen locks, and WebKit is free to invent a third. 'closed' is the
+// one dead end — resume() can never bring it back.
+export const needsResume = (state) => state !== 'running' && state !== 'closed';
+// resume() rejects on iOS when there is no gesture behind it. Stay silent and
+// leave every recovery path armed for the next try.
+const wake = (c) => { if (c && needsResume(c.state)) c.resume().catch(() => {}); };
+
 function ensureCtx() {
   if (ctx) return ctx;
   const AC = window.AudioContext || window.webkitAudioContext;
   if (!AC) return null;
   try {
     ctx = new AC();
+    // Recover the moment iOS allows it, instead of finding out at the next tone.
+    ctx.onstatechange = () => wake(ctx);
     master = ctx.createGain(); master.gain.value = volume;
     comp = ctx.createDynamicsCompressor();
     comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
@@ -74,7 +86,7 @@ export function play(name) {
   const c = ensureCtx();
   if (!c) return;
   const run = () => { try { fn(c.currentTime + 0.02); } catch (e) {} };
-  if (c.state === 'suspended') { c.resume().then(run).catch(() => {}); }
+  if (needsResume(c.state)) { c.resume().then(run).catch(() => {}); }
   else run();
 }
 
@@ -84,15 +96,12 @@ export function play(name) {
 // capture phase (runs before target handlers) across several gesture types,
 // because the board's first click is often a control like the gear icon that
 // calls stopPropagation() — a bubble-phase window listener would miss it.
-function primeOnGesture() {
-  const c = ensureCtx();
-  if (c && c.state === 'suspended') c.resume().catch(() => {});
-  for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.removeEventListener(ev, primeOnGesture, true);
-}
+// It stays attached for the life of the page: the context can die again long
+// after the first gesture (screen lock), and a gesture must always be able to
+// unlock it. A no-op when the context is already running.
+function primeOnGesture() { wake(ensureCtx()); }
 for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEventListener(ev, primeOnGesture, { capture: true, passive: true });
 
 // Re-resume proactively on refocus so the next notification after a
-// backgrounded tab isn't the one that eats the resume latency.
-document.addEventListener('visibilitychange', () => {
-  if (!document.hidden && ctx && ctx.state === 'suspended') ctx.resume().catch(() => {});
-});
+// backgrounded tab (or a locked phone) isn't the one that eats the latency.
+document.addEventListener('visibilitychange', () => { if (!document.hidden) wake(ctx); });

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -223,7 +223,9 @@ export async function speak({url, voice, input, params, title, artist, onFirstSo
   announce(title, artist);
   transport(true, title);
   const s = live = {ac: new AbortController(), srcs: [], pending: 0, over: false};
-  if (ctx.state === 'suspended') await ctx.resume().catch(() => {});
+  // Anything but 'running' needs the resume: iOS parks it in 'interrupted'
+  // (not 'suspended') when the screen locks, and that is silence too.
+  if (ctx.state !== 'running') await ctx.resume().catch(() => {});
 
   const t0 = performance.now();
   const chunks = [];


### PR DESCRIPTION
# Description

Lock an iPhone with the board open and it goes silent for the rest of the page's life — no TTS, no notification tones — because iOS Safari does not *suspend* an AudioContext when the screen locks, it moves it to `interrupted`, a WebKit-only state that every `state === 'suspended'` check in the audio path read as healthy. Nothing ever resumed, and tapping around afterwards did not rescue it either, since the gesture primer unregistered itself after the first gesture of the session.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added: the recovery decision as a pure function over every state a context can be in, and the two recovery paths that have to survive the lock.
- Needs the captain's own verdict on a real iPhone: lock, unlock, and a notification still sounds.

## Any specific deployment considerations

- None — browser-side only, no server change.
