### PR TITLE
Reload lands on the chat that was open

### DIFF
--- a/test/chatmem.test.js
+++ b/test/chatmem.test.js
@@ -1,0 +1,61 @@
+'use strict';
+// ui/js/chatmem.js — the store/restore decision behind "reload lands where you
+// left off": which chat gets written to localStorage, and which chat comes
+// back on load. Pure, so it's imported directly (panekeys.test.js pattern);
+// chat.js owns the localStorage calls and the DOM around them.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let CHAT_KEY, CLOSED, encodeChat, decodeChat;
+test.before(async () => {
+  ({ CHAT_KEY, CLOSED, encodeChat, decodeChat } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'chatmem.js')).href));
+});
+
+test('the key is bc- prefixed like the other remembered board state', () => {
+  assert.strictEqual(CHAT_KEY, 'bc-chat-open');
+});
+
+test('store: what was open, not just an id — both kinds round-trip', () => {
+  assert.strictEqual(encodeChat({ mode: 'lieutenant', id: 'ada' }), 'lieutenant:ada');
+  assert.strictEqual(encodeChat({ mode: 'card', id: 'ship-it' }), 'card:ship-it');
+  // the kind survives, so a card and a lieutenant sharing an id never collide
+  assert.deepStrictEqual(decodeChat('lieutenant:ada'), { mode: 'lieutenant', id: 'ada' });
+  assert.deepStrictEqual(decodeChat('card:ada'), { mode: 'card', id: 'ada' });
+  // ids are not sanitized on the way out — colons in an id survive the split
+  assert.deepStrictEqual(decodeChat(encodeChat({ mode: 'card', id: 'a:b' })), { mode: 'card', id: 'a:b' });
+});
+
+test('nothing open, or junk: null — remove the key rather than store it', () => {
+  assert.strictEqual(encodeChat(null), null);
+  assert.strictEqual(encodeChat(undefined), null);
+  assert.strictEqual(encodeChat({ mode: 'lieutenant' }), null, 'no id');
+  assert.strictEqual(encodeChat({ mode: 'card', id: '' }), null);
+  assert.strictEqual(encodeChat({ mode: 'notakind', id: 'x' }), null);
+});
+
+test('no memory: the board default stands, no error', () => {
+  assert.strictEqual(decodeChat(null), null);
+  assert.strictEqual(decodeChat(undefined), null);
+  assert.strictEqual(decodeChat(''), null);
+  assert.strictEqual(decodeChat('lieutenant:'), null, 'no id is not a chat');
+  assert.strictEqual(decodeChat('{"mode":"card"}'), null, 'an older/other format is not an error');
+});
+
+test('closing the chat is remembered as closed, and reopens nothing', () => {
+  assert.strictEqual(CLOSED, 'none');
+  assert.strictEqual(decodeChat(CLOSED), 'closed');
+  // …which is a different answer from "no memory at all" (first run): one lands
+  // on the board, the other leaves the default alone
+  assert.notStrictEqual(decodeChat(CLOSED), decodeChat(null));
+});
+
+test('a hash in the URL wins over the stored chat', () => {
+  assert.strictEqual(decodeChat('lieutenant:ada', '#card/ship-it'), null);
+  assert.strictEqual(decodeChat(CLOSED, '#card/ship-it'), null, 'a link opens even from closed');
+  // a bare/empty hash is not a link — the memory still applies
+  assert.deepStrictEqual(decodeChat('lieutenant:ada', ''), { mode: 'lieutenant', id: 'ada' });
+  assert.deepStrictEqual(decodeChat('lieutenant:ada', '#'), { mode: 'lieutenant', id: 'ada' });
+});

--- a/ui/js/chat.js
+++ b/ui/js/chat.js
@@ -11,6 +11,7 @@ import { openAttachment } from './detail.js';
 import { avatarHtml } from './avatars.js';
 import { isEchoOf, addPending, pendingFor } from './pending.js';
 import { fileContextBlock } from './filectx.js';
+import { CHAT_KEY, CLOSED, encodeChat, decodeChat } from './chatmem.js';
 
 const feedEl = document.getElementById('chat-feed');
 const titleEl = document.getElementById('chat-title');
@@ -24,9 +25,36 @@ const inputEl = document.getElementById('chat-input');
 let detailOpener = null; // set by main.js to avoid a circular import
 export function onOpenCard(fn) { detailOpener = fn; }
 
+// ---------- the chat that was open last time ----------
+// Restored by assigning S.chatMode directly rather than going through
+// openLieutenantChat/openCardThread: coming back must not focus the composer,
+// flip the mobile tab, scroll the board or mark anything read — it just puts
+// the panel back where it was. A chat that no longer exists is dropped by
+// ensureChatMode() below, which rewrites the key on the next render.
+let chatMemo = null;
+try { chatMemo = localStorage.getItem(CHAT_KEY); } catch (e) {}
+const reopen = decodeChat(chatMemo, window.location.hash);
+if (reopen === 'closed') S.view = 'board'; // mobile: he closed the chat on purpose
+else if (reopen) S.chatMode = reopen;
+// Persist whatever the panel is showing now. Driven from currentTarget() (so
+// it runs after normalization, and after any way the mode can change), and
+// deduped against the last written value so a render loop is not a write loop.
+function rememberChat() {
+  // desktop keeps the chat pane open always — only the mobile tab can close it
+  const closed = window.innerWidth <= 760 && S.view !== 'chat';
+  const v = closed ? CLOSED : encodeChat(S.chatMode);
+  if (v === chatMemo) return;
+  chatMemo = v;
+  try {
+    if (v) localStorage.setItem(CHAT_KEY, v);
+    else localStorage.removeItem(CHAT_KEY);
+  } catch (e) {}
+}
+
 // The chat panel's lieutenant-or-thread mode, normalized: a stale card / dead
 // lieutenant falls back to the first lieutenant; no lieutenants = no target.
 function ensureChatMode() {
+  if (!S.doc) return; // no board yet — nothing to validate a restored chat against
   const lts = lieutenants();
   if (S.chatMode) {
     if (S.chatMode.mode === 'card' && card(S.chatMode.id)) return;
@@ -37,6 +65,7 @@ function ensureChatMode() {
 }
 export function currentTarget() {
   ensureChatMode();
+  rememberChat();
   if (!S.chatMode) return null;
   return S.chatMode.mode === 'card' ? 'card:' + S.chatMode.id : 'lieutenant:' + S.chatMode.id;
 }

--- a/ui/js/chatmem.js
+++ b/ui/js/chatmem.js
@@ -1,0 +1,37 @@
+// chatmem.js — which chat was open, remembered across reloads.
+// Its own module (not part of chat.js) for the same reason panekeys.js is:
+// chat.js grabs DOM nodes at import time, this is pure, and pure is what a
+// unit test can import. The localStorage calls themselves live in chat.js.
+//
+// The stored value says WHAT was open, not just an id:
+//   'lieutenant:<id>' — a lieutenant's main chat
+//   'card:<id>'       — a card's thread
+//   'none'            — the captain closed the chat on purpose (mobile board tab)
+// absent = he never chose, so the board's own default stands.
+
+export const CHAT_KEY = 'bc-chat-open'; // bc- prefixed like bc-board-mode
+export const CLOSED = 'none';
+
+// What to write for the open chat. null = nothing worth remembering, remove
+// the key (an unknown mode or a missing id is junk, not a memory).
+export function encodeChat(open) {
+  if (!open || !open.id) return null;
+  if (open.mode !== 'lieutenant' && open.mode !== 'card') return null;
+  return open.mode + ':' + open.id;
+}
+
+// What to reopen on load, from the raw stored string and location.hash:
+//   {mode, id} — reopen that chat
+//   'closed'   — reopen nothing; he closed it
+//   null       — no usable memory; leave the default alone
+// A hash is a deep link: someone opening a link meant that link, not what was
+// open last time, so it wins over anything stored.
+// Existence is NOT checked here — the board doc has not landed yet at restore
+// time. A chat whose card was archived or whose lieutenant is gone is dropped
+// by ensureChatMode() (chat.js), which then rewrites the key.
+export function decodeChat(raw, hash) {
+  if (hash && hash.length > 1) return null;
+  if (raw === CLOSED) return 'closed';
+  const m = /^(lieutenant|card):(.+)$/.exec(raw || '');
+  return m ? { mode: m[1], id: m[2] } : null;
+}


### PR DESCRIPTION
# Description

Every reload dumped the captain out of the conversation he was in and onto whichever lieutenant happened to sort first, so coming back from a refresh meant re-navigating to the card thread he was reading; the board now remembers which chat was open and reopens it. Restoring is deliberately passive — no focus grab, no tab flip, no read markers — and an explicit close, a deep link, or a chat that no longer exists all beat the memory.

## Type of change

- [x] New feature (non-breaking)

## How has this change been tested?

- New automated tests added — the store/restore decision is a pure module (`ui/js/chatmem.js`), covered without a browser like the rest of `ui/js/`.
- Manually exercised against the dev fixture board in a real browser, desktop and mobile widths: lieutenant chat and card thread both come back at the bottom without stealing focus; the mobile board tab reloads to the board with no chat; an archived card and a removed lieutenant fall back to the board and rewrite the key; a URL hash wins over the stored value.

## Any specific deployment considerations

None — browser-only, `localStorage`.
