### PR TITLE
Twelve cards, one action: selection mode + bulk actions

### DIFF
--- a/test/selection.test.js
+++ b/test/selection.test.js
@@ -14,11 +14,16 @@ const { pathToFileURL } = require('node:url');
 
 const load = (f) => import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', f)).href);
 
-let sel, bulk;
+let sel, bulk, state;
 test.before(async () => {
   sel = await load('selection.js');
   bulk = await load('bulk.js');
+  state = await load('state.js');
 });
+// The board doc the client actually holds. `workers` is the worker REGISTRY —
+// the ground truth the server itself consults before it kills a session — and
+// it is what "is this card archivable" has to be asked of.
+function board(cards, workers) { state.S.doc = { cards, workers: workers || [], columns: [] }; }
 // module-level state, like the board's own: every test starts from off
 const reset = () => sel.exitSelection();
 
@@ -118,29 +123,43 @@ test('labels ADD and REMOVE against the card\'s own list — they never replace 
   assert.deepStrictEqual(bulk.labelsAfter(undefined, 'first', null), ['first'], 'a card with no labels yet');
 });
 
-test('a card with a live worker refuses to be archived, whatever the worker is doing', () => {
-  const c = (state) => ({ id: 'x', status: { worker: { id: 'w1', state } } });
-  assert.strictEqual(bulk.archiveRefusal(c('working')), 'worker working');
-  assert.strictEqual(bulk.archiveRefusal(c('needs-you')), 'worker needs-you');
-  assert.strictEqual(bulk.archiveRefusal(c('idle')), 'worker idle', 'an idle session is still a bound session');
-  assert.strictEqual(bulk.archiveRefusal(c('absent')), null);
-  assert.strictEqual(bulk.archiveRefusal({ id: 'x' }), null, 'no status at all = nothing to refuse');
+test('a live worker refuses the archive — and "live" is the registry, not the advisory lease', () => {
+  // The shape the real board records for a card being worked on RIGHT NOW: it
+  // sits in Working, it has NO card.status at all (nothing on the workspace
+  // calls status.set), and its liveness lives entirely in board.workers.
+  const working = { id: 'bulk-actions', column: 'working' };
+  board([working], [{ card: 'bulk-actions', done: false, branch: 'bc/bulk-actions' }]);
+  assert.strictEqual(bulk.archiveRefusal(working), 'live worker on bc/bulk-actions',
+    'the guard has to fire on the card as the real board records it');
+
+  // done = the worker finished; the entry stays until the card is archived or released
+  board([working], [{ card: 'bulk-actions', done: true }]);
+  assert.strictEqual(bulk.archiveRefusal(working), null);
+
+  // no registry entry at all
+  board([working], []);
+  assert.strictEqual(bulk.archiveRefusal(working), null);
+
+  // the lease is asked SECOND, never alone: `absent` proves nothing, but a set
+  // lease with no registry entry is still worth refusing
+  board([working], []);
+  assert.strictEqual(bulk.archiveRefusal({ id: 'x', status: { worker: { id: 'w1', state: 'working' } } }), 'worker working');
+  assert.strictEqual(bulk.archiveRefusal({ id: 'x', status: { worker: { id: null, state: 'absent' } } }), null);
 });
 
 test('the archive plan splits the selection before anything happens', () => {
-  const list = [
-    { id: 'a', status: { worker: { state: 'absent' } } },
-    { id: 'b', status: { worker: { state: 'working' } } },
-    { id: 'c' },
-  ];
+  const list = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+  board(list, [{ card: 'b', done: false }, { card: 'c', done: true }]);
   const plan = bulk.archivePlan(list);
   assert.deepStrictEqual(plan.go.map((c) => c.id), ['a', 'c']);
   assert.deepStrictEqual(plan.refused.map((c) => c.id), ['b']);
 });
 
 test('the destructive confirm says what will happen, with the count, before it happens', () => {
-  const live = { id: 'b', title: 'live one', status: { worker: { state: 'working' } } };
-  const c = bulk.archiveConfirmText([{ id: 'a', title: 'one' }, live, { id: 'c', title: 'three' }]);
+  const live = { id: 'b', title: 'live one', column: 'working' };
+  const list = [{ id: 'a', title: 'one' }, live, { id: 'c', title: 'three' }];
+  board(list, [{ card: 'b', done: false }]);
+  const c = bulk.archiveConfirmText(list);
   assert.strictEqual(c.n, 2);
   assert.match(c.text, /Archive 2 cards\?/);
   assert.match(c.text, /restorable/i, 'it does not pretend the cards evaporate');

--- a/test/selection.test.js
+++ b/test/selection.test.js
@@ -1,0 +1,176 @@
+'use strict';
+// ui/js/selection.js — the selection behind bulk actions: what is selected,
+// what a shift-click range means, and what a filter change does to it. Plus the
+// decisions ui/js/bulk.js makes per card (which labels a card ends up with,
+// what refuses to archive, what the one report says).
+//
+// Both modules are DOM-free at import — that is the whole reason they are their
+// own files — so they import straight into node. ESM (they ship to the
+// browser), hence the dynamic import, same shape as panekeys.test.js.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const load = (f) => import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', f)).href);
+
+let sel, bulk;
+test.before(async () => {
+  sel = await load('selection.js');
+  bulk = await load('bulk.js');
+});
+// module-level state, like the board's own: every test starts from off
+const reset = () => sel.exitSelection();
+
+const ORDER = ['a', 'b', 'c', 'd', 'e'];
+
+test('selection mode is off until it is entered, and entering from a card selects it', () => {
+  reset();
+  assert.strictEqual(sel.selectionOn(), false);
+  assert.strictEqual(sel.selCount(), 0);
+  sel.enterSelection('c');
+  assert.strictEqual(sel.selectionOn(), true);
+  assert.deepStrictEqual(sel.selectedIds(), ['c']);
+  sel.exitSelection();
+  assert.strictEqual(sel.selectionOn(), false);
+  assert.strictEqual(sel.selCount(), 0, 'leaving drops the selection — it never outlives the mode');
+});
+
+test('a plain click toggles one card and moves the anchor', () => {
+  reset();
+  sel.enterSelection();
+  sel.pick('b', false, ORDER);
+  sel.pick('d', false, ORDER);
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['b', 'd']);
+  sel.pick('b', false, ORDER);
+  assert.deepStrictEqual(sel.selectedIds(), ['d'], 'clicking a selected card unselects it');
+});
+
+test('shift takes the whole run between anchor and card, in either direction', () => {
+  reset();
+  sel.enterSelection('b');
+  sel.pick('d', true, ORDER);
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['b', 'c', 'd'], 'inclusive at both ends');
+
+  reset();
+  sel.enterSelection('d');
+  sel.pick('b', true, ORDER);
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['b', 'c', 'd'], 'backwards is the same range');
+});
+
+test('a shift-range only ever selects — it never unselects half of what it covers', () => {
+  reset();
+  sel.enterSelection('a');
+  sel.pick('c', false, ORDER); // c selected, anchor c
+  sel.pick('e', true, ORDER);  // range c..e over an already-selected c
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['a', 'c', 'd', 'e']);
+});
+
+test('shift with no anchor, or over ids the view does not show, is a plain toggle', () => {
+  reset();
+  sel.enterSelection();
+  sel.pick('c', true, ORDER); // nothing anchored yet
+  assert.deepStrictEqual(sel.selectedIds(), ['c']);
+  sel.pick('zz', true, ORDER); // not in the rendered order
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['c', 'zz']);
+});
+
+test('the header checkbox takes everything the view shows, or none of it', () => {
+  reset();
+  sel.enterSelection();
+  assert.strictEqual(sel.allSelected(ORDER), false);
+  sel.setAll(ORDER, true);
+  assert.strictEqual(sel.selCount(), 5);
+  assert.strictEqual(sel.allSelected(ORDER), true);
+  sel.setAll(ORDER, false);
+  assert.strictEqual(sel.selCount(), 0);
+  assert.strictEqual(sel.allSelected([]), false, 'an empty view is not "all selected"');
+});
+
+test('a filter change only ever NARROWS the selection', () => {
+  reset();
+  sel.enterSelection();
+  sel.setAll(ORDER, true);
+  // the captain narrows the filter: only b and c are on screen now
+  sel.reconcile(['b', 'c']);
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['b', 'c'], 'what he cannot see is not in the action');
+  // …and clears it again: the twelve cards do not come back
+  sel.reconcile(ORDER);
+  assert.deepStrictEqual(sel.selectedIds().sort(), ['b', 'c'], 'clearing a filter never widens what an action hits');
+});
+
+test('reconcile drops an anchor that left the view, so the next shift-click cannot span it', () => {
+  reset();
+  sel.enterSelection('a');
+  sel.reconcile(['c', 'd', 'e']);
+  assert.deepStrictEqual(sel.selectedIds(), []);
+  sel.pick('e', true, ORDER);
+  assert.deepStrictEqual(sel.selectedIds(), ['e'], 'no anchor, so no range back to the vanished card');
+});
+
+// ---------- what a bulk action decides, per card ----------
+
+test('labels ADD and REMOVE against the card\'s own list — they never replace it', () => {
+  assert.deepStrictEqual(bulk.labelsAfter(['ui', 'bug'], 'urgent', null), ['ui', 'bug', 'urgent']);
+  assert.deepStrictEqual(bulk.labelsAfter(['ui', 'bug'], null, 'ui'), ['bug']);
+  assert.deepStrictEqual(bulk.labelsAfter(['ui', 'bug'], 'ui', null), ['ui', 'bug'], 'already there = unchanged');
+  assert.deepStrictEqual(bulk.labelsAfter(['ui'], null, 'gone'), ['ui'], 'removing what is not there = unchanged');
+  assert.deepStrictEqual(bulk.labelsAfter(undefined, 'first', null), ['first'], 'a card with no labels yet');
+});
+
+test('a card with a live worker refuses to be archived, whatever the worker is doing', () => {
+  const c = (state) => ({ id: 'x', status: { worker: { id: 'w1', state } } });
+  assert.strictEqual(bulk.archiveRefusal(c('working')), 'worker working');
+  assert.strictEqual(bulk.archiveRefusal(c('needs-you')), 'worker needs-you');
+  assert.strictEqual(bulk.archiveRefusal(c('idle')), 'worker idle', 'an idle session is still a bound session');
+  assert.strictEqual(bulk.archiveRefusal(c('absent')), null);
+  assert.strictEqual(bulk.archiveRefusal({ id: 'x' }), null, 'no status at all = nothing to refuse');
+});
+
+test('the archive plan splits the selection before anything happens', () => {
+  const list = [
+    { id: 'a', status: { worker: { state: 'absent' } } },
+    { id: 'b', status: { worker: { state: 'working' } } },
+    { id: 'c' },
+  ];
+  const plan = bulk.archivePlan(list);
+  assert.deepStrictEqual(plan.go.map((c) => c.id), ['a', 'c']);
+  assert.deepStrictEqual(plan.refused.map((c) => c.id), ['b']);
+});
+
+test('the destructive confirm says what will happen, with the count, before it happens', () => {
+  const live = { id: 'b', title: 'live one', status: { worker: { state: 'working' } } };
+  const c = bulk.archiveConfirmText([{ id: 'a', title: 'one' }, live, { id: 'c', title: 'three' }]);
+  assert.strictEqual(c.n, 2);
+  assert.match(c.text, /Archive 2 cards\?/);
+  assert.match(c.text, /restorable/i, 'it does not pretend the cards evaporate');
+  assert.strictEqual(c.refused, '1 refused, live worker: live one');
+
+  const none = bulk.archiveConfirmText([live]);
+  assert.strictEqual(none.n, 0);
+  assert.match(none.text, /Nothing to archive/);
+});
+
+test('one action, many cards, one report — naming everything that did not go plainly', () => {
+  const r = bulk.reportText('Archived', [
+    { title: 'one', ok: true, note: '' },
+    { title: 'two', ok: true, note: '' },
+    { title: 'three', ok: false, note: 'worker working' },
+  ]);
+  assert.strictEqual(r.text, 'Archived 2 of 3 cards');
+  assert.strictEqual(r.sub, 'three — worker working');
+  assert.strictEqual(r.allOk, false);
+  const clean = bulk.reportText('Moved', [{ title: 'one', ok: true, note: '' }]);
+  assert.strictEqual(clean.text, 'Moved 1 of 1 card');
+  assert.strictEqual(clean.sub, '', 'nothing to say when everything went plainly');
+  assert.strictEqual(clean.allOk, true);
+});
+
+test('partial success is the normal case: a card that did something else still counts as done', () => {
+  const r = bulk.reportText('Moved', [
+    { title: 'one', ok: true, note: '' },
+    { title: 'two', ok: true, note: 'start-order sent to scout' },
+  ]);
+  assert.strictEqual(r.text, 'Moved 2 of 2 cards');
+  assert.strictEqual(r.sub, 'two — start-order sent to scout');
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -550,6 +550,35 @@ body.resizing { user-select: none; cursor: col-resize; }
 .ns-row .ns-prev { border: 1px solid var(--line); border-radius: 6px; color: var(--faint); font-size: 11px; padding: 1px 6px; flex: none; }
 .ns-row .ns-prev:hover { color: var(--accent); border-color: var(--accent2); }
 
+/* ---------- selection mode + bulk action bar ----------
+   Every rule here is behind a checkbox or a .selecting/.sel class that only
+   exists while selection mode is on — off, the board is untouched. */
+#board.selecting .tile, .tv.selecting { user-select: none; } /* shift-click selects cards, not text */
+.tile .t-sel, .tv .c-sel input { accent-color: var(--accent); width: 14px; height: 14px; margin: 0; flex: none; cursor: pointer; }
+.tile .t-sel { margin-top: 2px; }
+.tile.sel { border-color: var(--accent); background: var(--panel); }
+.tv .c-sel { width: 1px; padding-right: 0; }
+.tv tbody tr.sel { background: var(--panel); box-shadow: inset 2px 0 0 var(--accent); }
+#bulk-bar {
+  position: fixed; left: 50%; transform: translateX(-50%); bottom: 18px; z-index: 90;
+  display: flex; align-items: center; gap: 8px; padding: 8px 12px; border-radius: 12px;
+  background: var(--bg2); border: 1px solid var(--line2); box-shadow: var(--shadow);
+  max-width: calc(100vw - 20px); flex-wrap: wrap; justify-content: center;
+}
+#bulk-bar .bb-n { font-size: 12px; color: var(--accent); font-weight: 600; white-space: nowrap; }
+#bulk-bar .bb-acts, #bulk-bar .bb-confirm { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: center; }
+#bulk-bar .bb-acts[hidden], #bulk-bar .bb-confirm[hidden] { display: none; }
+#bulk-bar .bb-msg { font-size: 12px; color: var(--text); }
+#bulk-bar .bb-refused { font-size: 11px; color: var(--warn); font-family: var(--mono); max-width: 420px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+#bulk-bar button, #bulk-bar select {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 7px; color: var(--dim);
+  font-size: 12px; padding: 4px 9px; cursor: pointer; outline: none;
+}
+#bulk-bar button:hover:not(:disabled), #bulk-bar select:hover:not(:disabled) { color: var(--accent); border-color: var(--accent2); }
+#bulk-bar .danger:hover:not(:disabled) { color: var(--danger); border-color: var(--danger); }
+#bulk-bar button:disabled, #bulk-bar select:disabled { opacity: .45; cursor: default; }
+@media (max-width: 760px) { #bulk-bar { bottom: 62px; } } /* clear of the mobile tab bar */
+
 /* ---------- notification toasts ---------- */
 #toast-stack {
   position: fixed; top: 52px; right: 10px; z-index: 80; display: flex; flex-direction: column;

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -138,8 +138,15 @@ function wire() {
     el.onclick = (e) => {
       if (pressFired) { pressFired = false; return; } // long-press already handled
       // in selection mode the whole tile is the checkbox — nothing else on it
-      // does its usual thing (a label click here would filter, not select)
-      if (selectionOn()) { pick(el.dataset.id, e.shiftKey, boardOrder()); render(); return; }
+      // does its usual thing: a label click would filter, and a PR chip is an
+      // <a> that would open GitHub, so the anchor's own navigation is cancelled
+      // too (shift-clicking a run of cards must not also open six tabs)
+      if (selectionOn()) {
+        e.preventDefault();
+        pick(el.dataset.id, e.shiftKey, boardOrder());
+        render();
+        return;
+      }
       const t = e.target;
       if (t.closest('a')) return; // PR chip / link: let the anchor navigate, don't open detail
       if (t.closest('.t-peek')) { openCardPane(el.dataset.id); return; }

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -1,7 +1,7 @@
 // board: dense card tiles, drag&drop, long-press move menu, new-card /
 // new-lieutenant modals. (Lieutenant switching lives in the chat header —
 // ltswitcher.js — not on the board.)
-import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, workerFor } from './state.js';
+import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, workerFor, render } from './state.js';
 import { api } from './api.js';
 import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, ctxBarHtml } from './util.js';
 import { labelChipHtml } from './labels.js';
@@ -9,6 +9,7 @@ import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
 import { openCardPane } from './pane.js';
 import { avatarGridHtml, wireAvatarGrid } from './avatars.js';
+import { selectionOn, isSelected, enterSelection, pick } from './selection.js';
 
 const boardEl = document.getElementById('board');
 
@@ -63,9 +64,16 @@ function tileHtml(c) {
     : '';
   // owner color stripe on the LEFT edge: every card belongs to exactly one lieutenant
   const stripe = '<span class="t-stripe" style="background:' + esc(lieutenantColor(c.owner)) + '"></span>';
-  return '<div class="tile' + (c.id === S.openCardId ? ' open' : '') + workerCls + '" draggable="true" data-id="' + esc(c.id) + '"' + workerTitle + '>' +
+  // selection mode only: the checkbox and the selected state. Off = the tile is
+  // exactly what it always was, and dragging still belongs to drag&drop.
+  const sel = selectionOn();
+  const box = sel
+    ? '<input class="t-sel" type="checkbox" tabindex="-1" aria-label="select card"' + (isSelected(c.id) ? ' checked' : '') + '>'
+    : '';
+  return '<div class="tile' + (c.id === S.openCardId ? ' open' : '') + (sel && isSelected(c.id) ? ' sel' : '') + workerCls +
+    '" draggable="' + (sel ? 'false' : 'true') + '" data-id="' + esc(c.id) + '"' + workerTitle + '>' +
     stripe +
-    '<div class="t-row1"><span class="t-emoji">' + esc(cardEmoji(c)) + '</span>' +
+    '<div class="t-row1">' + box + '<span class="t-emoji">' + esc(cardEmoji(c)) + '</span>' +
     '<span class="t-title">' + esc(c.title || c.id) + '</span>' +
     cornerInd + '</div>' +
     (labels || prs || order ? '<div class="t-chips">' + order + labels + prs + '</div>' : '') +
@@ -85,8 +93,16 @@ function tileHtml(c) {
     '</div></div>';
 }
 
+// the visible cards in the order the board draws them — what a shift-click
+// range runs over
+function boardOrder() {
+  return columns().flatMap((col) =>
+    cards().filter((c) => c.column === col.id && cardVisible(c)).sort(byRecency).map((c) => c.id));
+}
+
 export function renderBoard() {
   const cols = columns();
+  boardEl.classList.toggle('selecting', selectionOn()); // outside the html cache
   const html = !cols.length
     ? '<div class="empty">waiting for board…</div>'
     : cols.map((col) => {
@@ -121,6 +137,9 @@ function wire() {
   boardEl.querySelectorAll('.tile').forEach((el) => {
     el.onclick = (e) => {
       if (pressFired) { pressFired = false; return; } // long-press already handled
+      // in selection mode the whole tile is the checkbox — nothing else on it
+      // does its usual thing (a label click here would filter, not select)
+      if (selectionOn()) { pick(el.dataset.id, e.shiftKey, boardOrder()); render(); return; }
       const t = e.target;
       if (t.closest('a')) return; // PR chip / link: let the anchor navigate, don't open detail
       if (t.closest('.t-peek')) { openCardPane(el.dataset.id); return; }
@@ -202,6 +221,12 @@ export function openMoveMenu(cardId, x, y) {
   const sep = document.createElement('div');
   sep.className = 'mm-sep';
   menuEl.appendChild(sep);
+  // The way INTO selection mode, on both the board and the table — nothing has
+  // to sit on screen the rest of the time for this to be reachable.
+  const many = document.createElement('button');
+  many.textContent = '☑ select cards';
+  many.onclick = () => { closeMoveMenu(); enterSelection(cardId); render(); };
+  menuEl.appendChild(many);
   const kill = document.createElement('button');
   kill.className = 'danger';
   kill.textContent = '✕ archive';

--- a/ui/js/bulk.js
+++ b/ui/js/bulk.js
@@ -1,0 +1,192 @@
+// bulk.js — one action, many cards, ONE report. The action bar that appears
+// with a selection (selection.js holds the selection itself) and the per-card
+// work behind its buttons.
+//
+// DOM-free at import on purpose — the bar is built lazily the first time
+// selection mode turns on, the way toast.js builds its stack — so nothing new
+// is on screen while selection mode is off, and so the decisions below (what
+// labels a card ends up with, what refuses to archive, what the report says)
+// are plain functions a unit test can import.
+import { cards, columns, cardStatus, cardVisible, card, render } from './state.js';
+import { api } from './api.js';
+import { push as toast } from './toast.js';
+import { selectionOn, selectedIds, selCount, exitSelection, reconcile } from './selection.js';
+
+// ---------- the decisions (pure) ----------
+
+// Labels ADD and REMOVE — they never replace. The API takes the whole list
+// (PATCH /api/cards/:id with `labels` in full), so the merge happens here, per
+// card, against that card's own labels. Deliberately not a new server verb: the
+// client already knows every card's labels, and a card the merge is computed
+// from is the card the PATCH is sent for.
+export function labelsAfter(labels, add, remove) {
+  const out = (labels || []).filter((n) => n !== remove);
+  if (add && !out.includes(add)) out.push(add);
+  return out;
+}
+
+// A card with a live worker is not archivable: the session and its worktree are
+// still in use, and archiving kills them. null = go ahead.
+export function archiveRefusal(c) {
+  const w = cardStatus(c).worker;
+  return w && w.state && w.state !== 'absent' ? 'worker ' + w.state : null;
+}
+// what "archive the selection" will actually do, before it happens
+export function archivePlan(list) {
+  const go = [], refused = [];
+  for (const c of list) (archiveRefusal(c) ? refused : go).push(c);
+  return { go, refused };
+}
+
+// results: [{title, ok, note}] → the one report. Every card that did anything
+// other than the plain thing — refused, ordered, already there — is named in
+// the sub-line, once. A toast per card is a punishment.
+export function reportText(verb, results) {
+  const done = results.filter((r) => r.ok).length;
+  return {
+    text: verb + ' ' + done + ' of ' + results.length + ' card' + (results.length === 1 ? '' : 's'),
+    sub: results.filter((r) => r.note).map((r) => r.title + ' — ' + r.note).join(' · '),
+    allOk: done === results.length,
+  };
+}
+
+// ---------- running one action over the selection ----------
+// Sequential, not all-at-once: every write broadcasts the whole board, and
+// twelve of those in flight together is a stampede for no gain at this size.
+// `act` returns a note (or nothing) for a card it handled, and throws to refuse.
+async function run(verb, act) {
+  const list = selectedIds().map(card).filter(Boolean);
+  if (!list.length) return;
+  const results = [];
+  for (const c of list) {
+    const title = c.title || c.id;
+    try { results.push({ title, ok: true, note: (await act(c)) || '' }); }
+    catch (e) { results.push({ title, ok: false, note: e.message }); }
+  }
+  const r = reportText(verb, results);
+  // a report with refusals stays until it is dismissed — it is the only place
+  // the captain learns what did NOT happen
+  toast({ emoji: r.allOk ? '✅' : '⚠️', text: r.text, sub: r.sub, sticky: !r.allOk });
+  render();
+}
+
+async function bulkMove(to) {
+  const label = (columns().find((k) => k.id === to) || {}).title || to;
+  await run('Moved ' + selCount() + ' → ' + label + ':', async (c) => {
+    if (c.column === to) return 'already in ' + label;
+    // a captain move into Working (or review → backlog) is an ORDER: the
+    // lieutenant moves the card, not the board
+    const r = await api.moveCard(c.id, to);
+    return r.ordered ? r.ordered + ' sent to ' + c.owner : '';
+  });
+}
+
+async function bulkArchive() {
+  await run('Archived', async (c) => {
+    const why = archiveRefusal(c);
+    if (why) throw new Error(why);
+    await api.archiveCard(c.id);
+  });
+}
+
+// The confirm the destructive action carries. It is the bar itself in a second
+// state, not a dialog: the selection stays on screen behind it, and it says the
+// count and the refusals BEFORE anything happens. There is no undo window —
+// archived cards come back one at a time from 🧊 archived — so this line is
+// where the weight sits.
+export function archiveConfirmText(list) {
+  const { go, refused } = archivePlan(list);
+  return {
+    n: go.length,
+    text: go.length
+      ? 'Archive ' + go.length + ' card' + (go.length === 1 ? '' : 's') + '? They leave the board (restorable one at a time from 🧊).'
+      : 'Nothing to archive — every selected card has a live worker.',
+    refused: refused.length
+      ? refused.length + ' refused, live worker: ' + refused.map((c) => c.title || c.id).join(', ')
+      : '',
+  };
+}
+
+async function bulkLabel(add) {
+  const name = (prompt((add ? 'Add label to ' : 'Remove label from ') + selCount() + ' cards:', '') || '').trim();
+  if (!name) return;
+  await run((add ? 'Labelled ' : 'Unlabelled ') + name + ':', async (c) => {
+    const next = labelsAfter(c.labels, add ? name : null, add ? null : name);
+    if (next.length === (c.labels || []).length) return add ? 'already had it' : 'did not have it';
+    await api.patchCard(c.id, { labels: next });
+  });
+}
+
+// ---------- the bar ----------
+let bar = null;
+let confirming = 0; // >0 = the archive confirm is up, over this many selected cards
+function ensureBar() {
+  if (bar) return bar;
+  bar = document.createElement('div');
+  bar.id = 'bulk-bar';
+  bar.innerHTML = '<span class="bb-n"></span>'
+    + '<span class="bb-acts">'
+    + '<select class="bb-move" title="move the selection"><option value="">move to…</option></select>'
+    + '<button class="bb-lab" type="button">＋ label</button>'
+    + '<button class="bb-unlab" type="button">－ label</button>'
+    + '<button class="bb-arch danger" type="button">✕ archive</button>'
+    + '<button class="bb-x" type="button" title="leave selection mode">done</button>'
+    + '</span>'
+    + '<span class="bb-confirm" hidden><span class="bb-msg"></span><span class="bb-refused"></span>'
+    + '<button class="bb-no" type="button">cancel</button>'
+    + '<button class="bb-yes danger" type="button">archive</button></span>';
+  const mv = bar.querySelector('.bb-move');
+  mv.onchange = () => { const to = mv.value; mv.value = ''; if (to) bulkMove(to); };
+  bar.querySelector('.bb-lab').onclick = () => bulkLabel(true);
+  bar.querySelector('.bb-unlab').onclick = () => bulkLabel(false);
+  bar.querySelector('.bb-arch').onclick = () => { confirming = selCount(); render(); };
+  bar.querySelector('.bb-no').onclick = () => { confirming = 0; render(); };
+  bar.querySelector('.bb-yes').onclick = () => { confirming = 0; bulkArchive(); };
+  bar.querySelector('.bb-x').onclick = () => { exitSelection(); render(); };
+  document.body.appendChild(bar);
+  return bar;
+}
+// what the confirm row says right now, and whether "archive" can be pressed
+function paintConfirm(b) {
+  const plan = archiveConfirmText(selectedIds().map(card).filter(Boolean));
+  b.querySelector('.bb-msg').textContent = plan.text;
+  b.querySelector('.bb-refused').textContent = plan.refused;
+  const yes = b.querySelector('.bb-yes');
+  yes.textContent = plan.n ? 'archive ' + plan.n : 'archive';
+  yes.disabled = !plan.n;
+}
+
+// Called once per render pass, BEFORE the board/table repaint, so the selection
+// the views draw is the one the actions will hit.
+export function renderBulkBar() {
+  reconcile(cards().filter(cardVisible).map((c) => c.id));
+  if (!selectionOn()) {
+    if (bar) { bar.remove(); bar = null; }
+    confirming = 0;
+    return;
+  }
+  const b = ensureBar();
+  const n = selCount();
+  if (confirming && confirming !== n) confirming = 0; // the selection moved under it
+  b.querySelector('.bb-n').textContent = n ? n + ' selected' : 'none selected';
+  b.querySelector('.bb-acts').hidden = !!confirming;
+  b.querySelector('.bb-confirm').hidden = !confirming;
+  if (confirming) { paintConfirm(b); return; }
+  const mv = b.querySelector('.bb-move');
+  const cols = columns().map((c) => c.id).join(',');
+  if (mv.dataset.cols !== cols) { // columns rarely change; don't rebuild under a click
+    mv.dataset.cols = cols;
+    mv.textContent = '';
+    const head = document.createElement('option');
+    head.value = ''; head.textContent = 'move to…';
+    mv.appendChild(head);
+    for (const col of columns()) {
+      const o = document.createElement('option');
+      o.value = col.id; o.textContent = col.title || col.id;
+      mv.appendChild(o);
+    }
+  }
+  for (const el of b.querySelectorAll('select, button')) {
+    if (!el.classList.contains('bb-x')) el.disabled = !n; // the way out is never disabled
+  }
+}

--- a/ui/js/bulk.js
+++ b/ui/js/bulk.js
@@ -7,7 +7,7 @@
 // is on screen while selection mode is off, and so the decisions below (what
 // labels a card ends up with, what refuses to archive, what the report says)
 // are plain functions a unit test can import.
-import { cards, columns, cardStatus, cardVisible, card, render } from './state.js';
+import { cards, columns, cardStatus, cardVisible, card, workerFor, render } from './state.js';
 import { api } from './api.js';
 import { push as toast } from './toast.js';
 import { selectionOn, selectedIds, selCount, exitSelection, reconcile } from './selection.js';
@@ -25,11 +25,18 @@ export function labelsAfter(labels, add, remove) {
   return out;
 }
 
-// A card with a live worker is not archivable: the session and its worktree are
-// still in use, and archiving kills them. null = go ahead.
+// A card with a live worker is not archivable: archiving kills that session and
+// drops its worktree binding. The question is asked of the WORKER REGISTRY
+// (board.workers, via workerFor) — the same record the server consults before it
+// kills anything, and an entry with done !== true is live work. card.status is
+// only an advisory lease that nothing but POST /api/cards/:id/status writes, so
+// its `absent` is evidence of nothing; it is asked second, never alone.
+// null = go ahead.
 export function archiveRefusal(c) {
-  const w = cardStatus(c).worker;
-  return w && w.state && w.state !== 'absent' ? 'worker ' + w.state : null;
+  const w = workerFor(c.id);
+  if (w && w.done !== true) return 'live worker' + (w.branch ? ' on ' + w.branch : '');
+  const lease = cardStatus(c).worker;
+  return lease && lease.state && lease.state !== 'absent' ? 'worker ' + lease.state : null;
 }
 // what "archive the selection" will actually do, before it happens
 export function archivePlan(list) {

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -7,6 +7,8 @@ import { trackEvents, renderNotifSettings } from './notifysettings.js';
 import { onOpenCard as toastOnOpenCard, onOpenLieutenant as toastOnOpenLieutenant } from './toast.js';
 import { renderBoard, newCardOpen, closeNewCard, newLieutenantOpen, closeNewLieutenant, closeMoveMenu } from './board.js';
 import { renderTable } from './table.js';
+import { renderBulkBar } from './bulk.js';
+import { selectionOn, exitSelection } from './selection.js';
 import { renderArchive } from './archtable.js';
 import { renderFilterUI, filterPanelOpen, closeFilterPanel } from './filterpop.js';
 import { renderChat, onOpenCard as chatOnOpenCard, openCardConversation, openLieutenantChat, onQuoteSource } from './chat.js';
@@ -191,6 +193,7 @@ document.addEventListener('keydown', (e) => {
     else if (ltSwitcherOpen()) closeLtSwitcher();
     else if (ownerMenuOpen()) closeOwnerMenu(); // just the menu — keep the detail open
     else if (S.notifOpen) { S.notifOpen = false; render(); }
+    else if (selectionOn()) { exitSelection(); render(); } // leave selection mode
     else if (!spEl.hidden) { spEl.hidden = true; gearBtn.classList.remove('on'); }
     else if (detailOpen()) closeDetail();
     else if (searchModeOn()) topbarEl.classList.remove('searching'); // collapse first, filters survive
@@ -214,6 +217,9 @@ onRender(() => {
   syncFilterInputs();
   renderFilterUI();
   renderStatusDot();
+  // the selection is trimmed to what the filters still show BEFORE the views
+  // paint it, so the checkboxes and the action bar's count never disagree
+  renderBulkBar();
   // The file screen owns its own DOM and is never repainted from here: a render
   // under the captain's cursor would eat what he is typing.
   if (S.boardMode === 'file') { /* nothing to repaint */ }

--- a/ui/js/selection.js
+++ b/ui/js/selection.js
@@ -1,0 +1,66 @@
+// selection.js — the board's selection mode: what is selected, what a
+// shift-click range means, and what a filter change does to a selection.
+// Its own module (not part of board.js/table.js) for the same reason
+// panekeys.js and chatmem.js are: those files grab DOM nodes at import time,
+// this is pure, and pure is what a unit test can import.
+//
+// Nothing here is persisted, on purpose: a selection survives a re-render (the
+// board redraws constantly from SSE — a selection that evaporated on every
+// worker event would be unusable) and dies with the page.
+
+export const SEL = { on: false, ids: new Set(), anchor: null };
+
+export function selectionOn() { return SEL.on; }
+export function selectedIds() { return [...SEL.ids]; }
+export function selCount() { return SEL.ids.size; }
+export function isSelected(id) { return SEL.ids.has(id); }
+
+// Entered deliberately and left deliberately. Entering FROM a card selects it —
+// the captain right-clicked that card because he meant it.
+export function enterSelection(id) {
+  SEL.on = true;
+  SEL.ids.clear();
+  SEL.anchor = null;
+  if (id) { SEL.ids.add(id); SEL.anchor = id; }
+}
+export function exitSelection() {
+  SEL.on = false;
+  SEL.ids.clear();
+  SEL.anchor = null;
+}
+
+// A click on a card while selection mode is on. `order` is the ids in the order
+// the view shows them (column by column on the board, row by row in the table).
+// Shift with a live anchor SELECTS the whole run between anchor and card — never
+// toggles it: a range that unselects half of what it covers is a coin flip.
+export function pick(id, shift, order) {
+  const list = order || [];
+  if (shift && SEL.anchor && SEL.anchor !== id && list.includes(id) && list.includes(SEL.anchor)) {
+    const a = list.indexOf(SEL.anchor), b = list.indexOf(id);
+    for (const x of list.slice(Math.min(a, b), Math.max(a, b) + 1)) SEL.ids.add(x);
+    SEL.anchor = id;
+    return;
+  }
+  if (SEL.ids.has(id)) SEL.ids.delete(id); else SEL.ids.add(id);
+  SEL.anchor = id;
+}
+
+// the table's header checkbox: everything the view currently shows, or none of it
+export function setAll(order, on) {
+  for (const id of order || []) { if (on) SEL.ids.add(id); else SEL.ids.delete(id); }
+  SEL.anchor = null;
+}
+export function allSelected(order) {
+  return !!(order && order.length) && order.every((id) => SEL.ids.has(id));
+}
+
+// Run on every render, against the ids the filters currently show. A selected
+// card that is no longer visible (the filter narrowed, or the card was archived
+// by someone else) LEAVES the selection: what the captain can see is what the
+// next action hits. It only ever removes — so clearing a filter afterwards can
+// never silently widen the selection back out.
+export function reconcile(visibleIds) {
+  const vis = new Set(visibleIds || []);
+  for (const id of SEL.ids) if (!vis.has(id)) SEL.ids.delete(id);
+  if (SEL.anchor && !vis.has(SEL.anchor)) SEL.anchor = null;
+}

--- a/ui/js/table.js
+++ b/ui/js/table.js
@@ -136,8 +136,9 @@ function wire(order) {
     // right-click is the way into selection mode here, same menu as a tile's
     tr.oncontextmenu = (e) => { e.preventDefault(); openMoveMenu(tr.dataset.id, e.clientX, e.clientY); };
     tr.onclick = (e) => {
-      // in selection mode the whole row is the checkbox — shift takes the range
-      if (selectionOn()) { pick(tr.dataset.id, e.shiftKey, order); render(); return; }
+      // in selection mode the whole row is the checkbox — shift takes the range,
+      // and a PR chip's <a> does not navigate out from under it
+      if (selectionOn()) { e.preventDefault(); pick(tr.dataset.id, e.shiftKey, order); render(); return; }
       if (e.target.closest('a')) return; // PR chip: let the link navigate
       // label / owner clicks feed the shared filter (a chip in the popup)
       const lab = e.target.closest('.label');

--- a/ui/js/table.js
+++ b/ui/js/table.js
@@ -7,6 +7,8 @@ import { S, cards, columns, lieutenant, lieutenantColor, cardVisible, cardStatus
 import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, ctxBarHtml, setHtmlIfChanged } from './util.js';
 import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
+import { openMoveMenu } from './board.js';
+import { selectionOn, isSelected, pick, setAll, allSelected } from './selection.js';
 
 const tableEl = document.getElementById('table');
 
@@ -51,8 +53,22 @@ function cmp(a, b) {
 }
 
 // ---------- html ----------
-function headHtml() {
-  return '<tr>' + COLS.map((col) => {
+// selection mode only: a leading checkbox column. The header box takes
+// EVERYTHING currently filtered in — the table is where selecting twelve
+// things is natural.
+function selHeadHtml(list) {
+  return selectionOn()
+    ? '<th class="c-sel"><input type="checkbox" class="tv-all" title="select every card the filter shows"' +
+      (allSelected(list.map((r) => r.c.id)) ? ' checked' : '') + '></th>'
+    : '';
+}
+function selCellHtml(c) {
+  return selectionOn()
+    ? '<td class="c-sel"><input type="checkbox" tabindex="-1" aria-label="select card"' + (isSelected(c.id) ? ' checked' : '') + '></td>'
+    : '';
+}
+function headHtml(list) {
+  return '<tr>' + selHeadHtml(list) + COLS.map((col) => {
     const on = T.sort.key === col.key;
     const arrow = on ? (T.sort.dir > 0 ? ' ▲' : ' ▼') : '';
     return '<th' + (col.sortable ? ' class="sort' + (on ? ' on' : '') + (col.hideM ? ' hide-m' : '') + '" data-sort="' + col.key + '"' : (col.hideM ? ' class="hide-m"' : '')) + '>' +
@@ -79,7 +95,8 @@ function rowHtml(row) {
   const c = row.c;
   const l = lieutenant(c.owner);
   const wst = c.column === 'working' ? ctxBarHtml((workerFor(c.id) || {}).agentStatus) : '';
-  return '<tr data-id="' + esc(c.id) + '">' +
+  return '<tr data-id="' + esc(c.id) + '"' + (selectionOn() && isSelected(c.id) ? ' class="sel"' : '') + '>' +
+    selCellHtml(c) +
     '<td class="c-title">' + titleCellHtml(row) + '</td>' +
     '<td class="c-status">' + statusCellHtml(row) + '</td>' +
     '<td class="c-type hide-m">' + esc(c.type || '') + '</td>' +
@@ -97,13 +114,16 @@ function rowHtml(row) {
 export function renderTable() {
   if (S.boardMode !== 'table') return;
   const list = rows();
-  const html = '<div class="tv-scroll"><table class="tv"><thead>' + headHtml() + '</thead><tbody>' +
-    (list.length ? list.map(rowHtml).join('') : '<tr><td colspan="9" class="tv-empty">no cards match</td></tr>') +
+  const span = COLS.length + (selectionOn() ? 1 : 0);
+  const html = '<div class="tv-scroll"><table class="tv' + (selectionOn() ? ' selecting' : '') + '"><thead>' + headHtml(list) + '</thead><tbody>' +
+    (list.length ? list.map(rowHtml).join('') : '<tr><td colspan="' + span + '" class="tv-empty">no cards match</td></tr>') +
     '</tbody></table></div>';
   if (!setHtmlIfChanged(tableEl, html)) return;
-  wire();
+  wire(list.map((r) => r.c.id));
 }
-function wire() {
+function wire(order) {
+  const all = tableEl.querySelector('.tv-all');
+  if (all) all.onclick = (e) => { e.stopPropagation(); setAll(order, all.checked); render(); };
   for (const th of tableEl.querySelectorAll('th.sort')) {
     th.onclick = () => {
       const key = th.dataset.sort;
@@ -113,7 +133,11 @@ function wire() {
     };
   }
   for (const tr of tableEl.querySelectorAll('tbody tr[data-id]')) {
+    // right-click is the way into selection mode here, same menu as a tile's
+    tr.oncontextmenu = (e) => { e.preventDefault(); openMoveMenu(tr.dataset.id, e.clientX, e.clientY); };
     tr.onclick = (e) => {
+      // in selection mode the whole row is the checkbox — shift takes the range
+      if (selectionOn()) { pick(tr.dataset.id, e.shiftKey, order); render(); return; }
       if (e.target.closest('a')) return; // PR chip: let the link navigate
       // label / owner clicks feed the shared filter (a chip in the popup)
       const lab = e.target.closest('.label');

--- a/ui/js/toast.js
+++ b/ui/js/toast.js
@@ -18,7 +18,10 @@ function ensureRoot() {
   return root;
 }
 
-// e: { emoji, text, cardTitle, actor, card, lieutenant }
+// e: { emoji, text, cardTitle, actor, card, lieutenant, sub, sticky }
+// `sub` overrides the derived "cardTitle · actor" line; `sticky` keeps the
+// toast up until it is dismissed (a bulk report that names what it refused has
+// to be readable at leisure — it is the only place that news appears).
 export function push(e) {
   const stack = ensureRoot();
   const el = document.createElement('div');
@@ -35,7 +38,7 @@ export function push(e) {
   tx.textContent = e.text || '';
   const sub = document.createElement('div');
   sub.className = 'sub';
-  sub.textContent = [e.cardTitle, e.actor].filter(Boolean).join(' · ');
+  sub.textContent = e.sub || [e.cardTitle, e.actor].filter(Boolean).join(' · ');
   bd.append(tx, sub);
 
   const x = document.createElement('button');
@@ -48,7 +51,7 @@ export function push(e) {
 
   let timer = null;
   const dismiss = () => { clearTimeout(timer); el.remove(); };
-  const arm = () => { timer = setTimeout(dismiss, DISMISS_MS); };
+  const arm = () => { if (!e.sticky) timer = setTimeout(dismiss, DISMISS_MS); };
   el.onmouseenter = () => clearTimeout(timer);
   el.onmouseleave = arm;
   x.onclick = (ev) => { ev.stopPropagation(); dismiss(); };


### PR DESCRIPTION
# Description

Housekeeping on a 59-card board is one card at a time: re-labelling a batch or clearing out a dozen stale Backlog cards means a dozen right-clicks, and archiving is the one that hurts because a card with a live worker looks exactly like one without. This adds a selection mode — entered from the move menu that already exists, so nothing new sits on screen the rest of the time — with an action bar that moves, archives, and adds/removes labels across the selection and answers in one report.

Two decisions worth a reviewer's attention, both visible in the diff but easy to read past:

- **Liveness is read from `board.workers`, not `card.status`.** `card.status.worker` is an advisory lease only `POST /api/cards/:id/status` writes, and nothing on this workspace calls it — it reads `absent` for all 59 cards including the one with a running agent. The archive guard asks the same registry the server consults before `kill()`.
- **Labels merge client-side.** `PATCH /api/cards/:id` replaces the whole `labels` list, so add/remove is computed per card against that card's own labels. No new server verb.

There is no undo window: the confirm names the count, names what it refuses and why, and says archived cards come back one at a time from 🧊.

Deliberately out of scope: bulk owner change, bulk start.

## Type of change

- [x] New feature (non-breaking)

## How has this change been tested?

- New automated tests added — `test/selection.test.js` covers the pure modules: what a shift-range means, that a filter change only ever narrows, that labels add/remove rather than replace, and that the archive guard fires on a card shaped the way the real board records one.
- Driven in a browser against a sandbox copy of this workspace's real `board.json` (59 cards, 22 worker records): bulk move, label add/remove (including the merge preserving existing labels), header select-all under a filter, and an archive of 4 that refused the 2 with live workers and reported both. Screenshots are attached to the card.

## Any specific deployment considerations

- None — frontend only, no server or API change.
