### PR TITLE
The audio context comes back dead, so replace it

### DIFF
--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -11,7 +11,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let play, needsResume;
+let play, needsResume, needsRebuild, setVolume;
 
 // The page's listeners, kept by type so a test can fire a gesture by hand.
 const listeners = { window: {}, document: {} };
@@ -22,12 +22,14 @@ const remove = (bag) => (ev, fn) => { bag[ev] = (bag[ev] || []).filter((f) => f 
 const fire = (bag, ev) => (listeners[bag][ev] || []).slice().forEach((f) => f());
 
 // An AudioContext that can refuse to resume, the way iOS does without a gesture.
+// It also records the graph hung off it, because a rebuilt context that is bare
+// is silent just as surely as a corpse.
 let theCtx = null;
-let resumes = 0;
+let resumes = 0, built = 0;
 class FakeCtx {
   constructor() {
     this.state = 'running'; this.currentTime = 0; this.destination = {};
-    this.refuse = false; this.onstatechange = null; theCtx = this;
+    this.refuse = false; this.onstatechange = null; theCtx = this; built++;
   }
   resume() {
     resumes++;
@@ -35,12 +37,17 @@ class FakeCtx {
     this.state = 'running';
     return Promise.resolve();
   }
+  close() { this.state = 'closed'; return Promise.resolve(); }
   createGain() {
-    return { gain: { value: 0, setValueAtTime() {}, linearRampToValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {} };
+    const g = { gain: { value: 0, setValueAtTime() {}, linearRampToValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect(to) { g.to = to; } };
+    this.master = this.master || g;      // the first gain is master; the rest are envelopes
+    return g;
   }
   createDynamicsCompressor() {
     const p = () => ({ value: 0 });
-    return { threshold: p(), knee: p(), ratio: p(), attack: p(), release: p(), connect() {} };
+    const c = { threshold: p(), knee: p(), ratio: p(), attack: p(), release: p(), connect(to) { c.to = to; } };
+    this.comp = c;
+    return c;
   }
   createOscillator() {
     const o = { frequency: { setValueAtTime() {}, exponentialRampToValueAtTime() {} }, connect() {}, start() { played++; }, stop() {} };
@@ -49,11 +56,14 @@ class FakeCtx {
 }
 let played = 0;
 const tick = () => new Promise((r) => setTimeout(r, 0));
+// Real time has to actually pass: the corpse test is "did the clock move while
+// the world did", and there is no faking the world half of that from here.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 test.before(async () => {
   global.window = { AudioContext: FakeCtx, addEventListener: add(listeners.window), removeEventListener: remove(listeners.window) };
   global.document = { hidden: false, addEventListener: add(listeners.document) };
-  ({ play, needsResume } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'sound.js')).href));
+  ({ play, needsResume, needsRebuild, setVolume } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'sound.js')).href));
 });
 test.beforeEach(() => { resumes = 0; played = 0; if (theCtx) { theCtx.refuse = false; theCtx.state = 'running'; } });
 
@@ -64,6 +74,19 @@ test('the recovery decision covers every state a context can be in', () => {
   assert.equal(needsResume('interrupted'), true, "interrupted: iOS locking the screen — the state that made it silent");
   assert.equal(needsResume('closed'), false, 'closed: dead for good, resume() cannot bring it back');
   assert.equal(needsResume('whatever-webkit-invents-next'), true, 'anything not running is broken until proven otherwise');
+});
+
+// The state field is not enough: after an iOS audio-session interruption (the
+// microphone taken by a Siri Shortcut) the context can come back reading
+// 'running' and never make a sound again. resume() cannot revive that one — only
+// a new context can — and the honest signal for it is the clock, not the state.
+test('the corpse test asks the clock, not the state field', () => {
+  assert.equal(needsRebuild('running', 0.4, 500), false, 'the clock moved: alive');
+  assert.equal(needsRebuild('running', 0, 500), true, 'running and frozen: the corpse the interruption leaves');
+  assert.equal(needsRebuild('running', 0, 50), false, 'too soon to tell — a healthy clock needs real time to move');
+  assert.equal(needsRebuild('suspended', 0, 500), false, 'suspended is SUPPOSED to be frozen; resume() is its cure');
+  assert.equal(needsRebuild('interrupted', 0, 500), false, 'same for interrupted — the corpse is the one that claims to be running');
+  assert.equal(needsRebuild('closed', 0, 500), false, 'closed: already let go of');
 });
 
 // ── the gesture path ──────────────────────────────────────────────────────
@@ -125,4 +148,49 @@ test('a notification resumes an interrupted context and then sounds', async () =
   await tick();
   assert.equal(theCtx.state, 'running', 'resumed before scheduling');
   assert.ok(played > 0, 'and the tone was actually scheduled');
+});
+
+// ── the corpse, end to end ────────────────────────────────────────────────
+// These two spend real milliseconds on purpose (see sleep above) and so they
+// come last: they leave gaps in the clock that earlier tests do not expect.
+test('a healthy context is never replaced, however many gestures land on it', async () => {
+  fire('window', 'click');
+  await tick();
+  const c = theCtx;
+  built = 0;
+  for (let i = 0; i < 2; i++) {
+    await sleep(220);
+    c.currentTime += 0.22;               // a clock that runs is a clock that moves
+    fire('window', 'click');
+    await tick();
+  }
+  assert.equal(built, 0, 'a rebuild on every gesture is its own bug');
+  assert.equal(theCtx, c, 'same context throughout');
+});
+
+test('a dead context is replaced by one with the whole graph and the volume on it', async () => {
+  fire('window', 'click');
+  await tick();
+  setVolume(0.42);
+  const corpse = theCtx;
+  built = 0;
+  // The interruption: real time passes, the clock does not move, and the state
+  // field goes on insisting everything is fine.
+  await sleep(220);
+  corpse.state = 'running';
+  fire('window', 'click');               // the captain taps ▶ in settings
+  await tick();
+
+  assert.equal(built, 1, 'exactly one replacement');
+  assert.notEqual(theCtx, corpse, 'the tap got a new context');
+  assert.equal(corpse.state, 'closed', 'and the old one was let go of');
+  assert.equal(theCtx.master.gain.value, 0.42, 'the volume came across');
+  assert.equal(theCtx.master.to, theCtx.comp, 'master → compressor');
+  assert.equal(theCtx.comp.to, theCtx.destination, 'compressor → the speakers');
+  assert.equal(theCtx.comp.threshold.value, -14, 'a rebuilt graph, not a bare context');
+
+  played = 0;
+  play('ding');
+  await tick();
+  assert.ok(played > 0, 'and the ▶ makes a sound');
 });

--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -62,6 +62,14 @@ class FakeCtx {
   }
 }
 let played = 0;
+// Every interval the module has running, because "is it looking" is a claim
+// about a timer and there is no way to ask it from the outside. A real one is
+// handed back, so the beats still happen; only the bookkeeping is ours.
+const intervals = new Set();
+const realSetInterval = global.setInterval, realClearInterval = global.clearInterval;
+global.setInterval = (fn, ms) => { const t = realSetInterval(fn, ms); intervals.add(t); return t; };
+global.clearInterval = (t) => { intervals.delete(t); return realClearInterval(t); };
+
 const tick = () => new Promise((r) => setTimeout(r, 0));
 // Real time has to actually pass: the corpse test is "did the clock move while
 // the world did", and there is no faking the world half of that from here.
@@ -229,4 +237,69 @@ test('the tap after a dictation: the context RAN, then died', async () => {
   assert.equal(built, 1, 'the tap should have replaced the corpse');
   assert.notEqual(theCtx, corpse, 'and played into the new context');
   assert.ok(played > 0, 'so the ▶ was heard, on the FIRST tap');
+});
+
+// The captain's loop with the page in it: the Shortcut takes the screen as well
+// as the microphone, so the death happens while the board is not being looked
+// at. Coming back is the moment to ask, and the answer has to be there before
+// the thumb arrives — the ▶ is a tap or two later, not a beat later.
+test('the dictation as it happens: the page goes away, and coming back is what asks', async () => {
+  fire('window', 'click');
+  await tick();
+  const corpse = theCtx;
+
+  await sleep(300);                      // the board is used normally
+  document.hidden = true;
+  fire('document', 'visibilitychange');  // the Shortcut takes the screen…
+  corpse.freeze();                       // …and the microphone with it
+  await sleep(1000);                     // the dictation
+
+  built = 0; played = 0;
+  document.hidden = false;
+  fire('document', 'visibilitychange');  // he is back on the board
+  await tick();
+  assert.equal(built, 1, 'the return alone replaced the corpse — no tap needed');
+  assert.notEqual(theCtx, corpse);
+
+  fire('window', 'click');               // and the ▶ he taps next
+  play('ding');
+  await tick();
+  assert.ok(played > 0, 'sounds');
+});
+
+// ── the watch ─────────────────────────────────────────────────────────────
+// The looking cannot be helped — a dead context fires no event, which is what
+// makes it dead — but the looking FOREVER can. Nothing takes the audio session
+// from a page that is sitting still, so a page sitting still runs no timer.
+test('the watch winds down once it has seen the clock keeping up', async () => {
+  fire('window', 'click');
+  await tick();
+  assert.equal(intervals.size, 1, 'the gesture armed it');
+  await sleep(1200);                     // two beats of a healthy clock
+  assert.equal(intervals.size, 0, 'and it let go: an idle page is not worth watching');
+  await sleep(700);
+  assert.equal(intervals.size, 0, 'and stays let go — nothing re-arms itself');
+});
+
+test('and re-arms for every moment something could have taken the session', async () => {
+  await sleep(1200);
+  assert.equal(intervals.size, 0, 'wound down');
+
+  fire('window', 'click');               // a tap
+  assert.equal(intervals.size, 1, 'looking again');
+  await sleep(1200);
+  assert.equal(intervals.size, 0);
+
+  theCtx.onstatechange();                // the session moving under the page
+  assert.equal(intervals.size, 1, 'looking again');
+  await sleep(1200);
+  assert.equal(intervals.size, 0);
+
+  document.hidden = true;                // the page going away…
+  fire('document', 'visibilitychange');
+  assert.equal(intervals.size, 0, 'nothing to watch while it is away');
+  await sleep(300);
+  document.hidden = false;               // …and coming back
+  fire('document', 'visibilitychange');
+  assert.equal(intervals.size, 1, 'the return is exactly when to look');
 });

--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -28,9 +28,16 @@ let theCtx = null;
 let resumes = 0, built = 0;
 class FakeCtx {
   constructor() {
-    this.state = 'running'; this.currentTime = 0; this.destination = {};
+    this.state = 'running'; this.destination = {};
+    this.t0 = performance.now(); this.stopped = null;
     this.refuse = false; this.onstatechange = null; theCtx = this; built++;
   }
+  // A real context's clock moves with the world, and a detector that cannot tell
+  // "the clock never moved" from "the clock moved and then stopped" is not a
+  // detector. freeze() is the corpse an interruption leaves: the clock stops
+  // where it was and the state field goes on saying 'running'.
+  get currentTime() { return (this.stopped === null ? performance.now() - this.t0 : this.stopped) / 1000; }
+  freeze() { this.stopped = performance.now() - this.t0; }
   resume() {
     resumes++;
     if (this.refuse) return Promise.reject(new Error('not allowed without a gesture'));
@@ -158,9 +165,8 @@ test('a healthy context is never replaced, however many gestures land on it', as
   await tick();
   const c = theCtx;
   built = 0;
-  for (let i = 0; i < 2; i++) {
-    await sleep(220);
-    c.currentTime += 0.22;               // a clock that runs is a clock that moves
+  for (let i = 0; i < 3; i++) {          // several heartbeats' worth of an idle page
+    await sleep(250);
     fire('window', 'click');
     await tick();
   }
@@ -173,11 +179,10 @@ test('a dead context is replaced by one with the whole graph and the volume on i
   await tick();
   setVolume(0.42);
   const corpse = theCtx;
+  await sleep(300);                      // the page is used; the clock runs
+  corpse.freeze();                       // the Shortcut takes the microphone
+  await sleep(1200);                     // long enough for the beat to see it stop
   built = 0;
-  // The interruption: real time passes, the clock does not move, and the state
-  // field goes on insisting everything is fine.
-  await sleep(220);
-  corpse.state = 'running';
   fire('window', 'click');               // the captain taps ▶ in settings
   await tick();
 
@@ -193,4 +198,35 @@ test('a dead context is replaced by one with the whole graph and the volume on i
   play('ding');
   await tick();
   assert.ok(played > 0, 'and the ▶ makes a sound');
+});
+
+// The captain's actual morning, and the one a stale baseline gets wrong: the
+// context is healthy and sampled, runs on for a moment, and only THEN dies. A
+// detector comparing against the last time anyone looked sees a clock that moved
+// and calls it alive. One tap is four events inside a tenth of a second, so
+// there is no second chance inside the tap either — the ▶ is simply silent.
+test('the tap after a dictation: the context RAN, then died', async () => {
+  fire('window', 'click');               // first gesture: the context is made
+  await tick();
+  const corpse = theCtx;
+
+  await sleep(300);                      // the board is used normally for a while
+  fire('window', 'click');
+  await tick();
+
+  corpse.freeze();                       // the Siri Shortcut takes the microphone
+  await sleep(1500);                     // the dictation
+
+  built = 0; played = 0;
+  // One tap: pointerdown, touchstart, click, and then the button's own play().
+  fire('window', 'pointerdown');
+  fire('window', 'touchstart');
+  await sleep(80);
+  fire('window', 'click');
+  play('ding');
+  await tick();
+
+  assert.equal(built, 1, 'the tap should have replaced the corpse');
+  assert.notEqual(theCtx, corpse, 'and played into the new context');
+  assert.ok(played > 0, 'so the ▶ was heard, on the FIRST tap');
 });

--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -62,14 +62,6 @@ class FakeCtx {
   }
 }
 let played = 0;
-// Every interval the module has running, because "is it looking" is a claim
-// about a timer and there is no way to ask it from the outside. A real one is
-// handed back, so the beats still happen; only the bookkeeping is ours.
-const intervals = new Set();
-const realSetInterval = global.setInterval, realClearInterval = global.clearInterval;
-global.setInterval = (fn, ms) => { const t = realSetInterval(fn, ms); intervals.add(t); return t; };
-global.clearInterval = (t) => { intervals.delete(t); return realClearInterval(t); };
-
 const tick = () => new Promise((r) => setTimeout(r, 0));
 // Real time has to actually pass: the corpse test is "did the clock move while
 // the world did", and there is no faking the world half of that from here.
@@ -237,69 +229,4 @@ test('the tap after a dictation: the context RAN, then died', async () => {
   assert.equal(built, 1, 'the tap should have replaced the corpse');
   assert.notEqual(theCtx, corpse, 'and played into the new context');
   assert.ok(played > 0, 'so the ▶ was heard, on the FIRST tap');
-});
-
-// The captain's loop with the page in it: the Shortcut takes the screen as well
-// as the microphone, so the death happens while the board is not being looked
-// at. Coming back is the moment to ask, and the answer has to be there before
-// the thumb arrives — the ▶ is a tap or two later, not a beat later.
-test('the dictation as it happens: the page goes away, and coming back is what asks', async () => {
-  fire('window', 'click');
-  await tick();
-  const corpse = theCtx;
-
-  await sleep(300);                      // the board is used normally
-  document.hidden = true;
-  fire('document', 'visibilitychange');  // the Shortcut takes the screen…
-  corpse.freeze();                       // …and the microphone with it
-  await sleep(1000);                     // the dictation
-
-  built = 0; played = 0;
-  document.hidden = false;
-  fire('document', 'visibilitychange');  // he is back on the board
-  await tick();
-  assert.equal(built, 1, 'the return alone replaced the corpse — no tap needed');
-  assert.notEqual(theCtx, corpse);
-
-  fire('window', 'click');               // and the ▶ he taps next
-  play('ding');
-  await tick();
-  assert.ok(played > 0, 'sounds');
-});
-
-// ── the watch ─────────────────────────────────────────────────────────────
-// The looking cannot be helped — a dead context fires no event, which is what
-// makes it dead — but the looking FOREVER can. Nothing takes the audio session
-// from a page that is sitting still, so a page sitting still runs no timer.
-test('the watch winds down once it has seen the clock keeping up', async () => {
-  fire('window', 'click');
-  await tick();
-  assert.equal(intervals.size, 1, 'the gesture armed it');
-  await sleep(1200);                     // two beats of a healthy clock
-  assert.equal(intervals.size, 0, 'and it let go: an idle page is not worth watching');
-  await sleep(700);
-  assert.equal(intervals.size, 0, 'and stays let go — nothing re-arms itself');
-});
-
-test('and re-arms for every moment something could have taken the session', async () => {
-  await sleep(1200);
-  assert.equal(intervals.size, 0, 'wound down');
-
-  fire('window', 'click');               // a tap
-  assert.equal(intervals.size, 1, 'looking again');
-  await sleep(1200);
-  assert.equal(intervals.size, 0);
-
-  theCtx.onstatechange();                // the session moving under the page
-  assert.equal(intervals.size, 1, 'looking again');
-  await sleep(1200);
-  assert.equal(intervals.size, 0);
-
-  document.hidden = true;                // the page going away…
-  fire('document', 'visibilitychange');
-  assert.equal(intervals.size, 0, 'nothing to watch while it is away');
-  await sleep(300);
-  document.hidden = false;               // …and coming back
-  fire('document', 'visibilitychange');
-  assert.equal(intervals.size, 1, 'the return is exactly when to look');
 });

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -38,21 +38,6 @@ const bar = {
   querySelector() { return this.what; },
 };
 const styles = [];
-// The page's own listeners, kept by type so a test can be the captain: tap the
-// board, leave it for a dictation, come back. The module listens for those and
-// nothing else, so a page without them cannot be interrupted at all — which is
-// the one thing these tests have to be able to do to it.
-const listeners = { window: {}, document: {} };
-const add = (bag) => (ev, fn) => (bag[ev] = bag[ev] || []).push(fn);
-const fire = (bag, ev) => (listeners[bag][ev] || []).slice().forEach((f) => f());
-// Every interval the module has running: "is it still looking" is a claim about
-// a timer, and there is no way to ask it from the outside. The real one is handed
-// back, so the beats still happen — only the bookkeeping is ours.
-const intervals = new Set();
-const realSetInterval = global.setInterval, realClearInterval = global.clearInterval;
-global.setInterval = (fn, ms) => { const t = realSetInterval(fn, ms); intervals.add(t); return t; };
-global.clearInterval = (t) => { intervals.delete(t); return realClearInterval(t); };
-
 let session;
 function fakePage() {
   // Only what a new test needs fresh. The element itself is the module's, made
@@ -63,8 +48,6 @@ function fakePage() {
   bar.hidden = true;
   bar.what.textContent = '';
   global.document = {
-    hidden: false,
-    addEventListener: add(listeners.document),
     createElement(tag) {
       if (tag === 'audio') return sinkEl;
       if (tag === 'div') return bar;
@@ -96,10 +79,7 @@ class FakeCtx {
   // stopped" have to be two different fakes: only the second is the corpse an
   // interruption leaves, and a detector that cannot tell them apart is not one.
   // It stays put during a message so the seam assertions stay about the seams.
-  // run() is the third thing it has to be able to be: a clock keeping up with
-  // the world, which is what tells the watch there is nothing left to watch.
-  get currentTime() { return this.at === undefined ? this.clock : this.clock + (performance.now() - this.at) / 1000; }
-  run() { this.at = performance.now(); }
+  get currentTime() { return this.clock; }
   resume() { this.state = 'running'; return Promise.resolve(); }
   close() { this.state = 'closed'; return Promise.resolve(); }
   suspend() { this.state = 'suspended'; return Promise.resolve(); }
@@ -173,8 +153,7 @@ test.before(async () => {
   // `MediaMetadata` is guarded on window and then called bare, the way a browser
   // sees it — it is the same global in both places.
   global.MediaMetadata = function (m) { Object.assign(this, m); };
-  global.window = { AudioContext: FakeCtx, MediaMetadata: global.MediaMetadata,
-    addEventListener: add(listeners.window) };
+  global.window = { AudioContext: FakeCtx, MediaMetadata: global.MediaMetadata };
   fakePage();
   ({ speak, stop, pause, resume } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'speech.js')).href));
@@ -422,24 +401,15 @@ test('a new message aborts the one it supersedes', async () => {
 // only ever looked at it inside speak(), so the baseline was "the previous
 // message" and a death in the gap between two messages read as "it moved, it is
 // alive". The first message after a dictation was deterministically silent.
-//
-// The dictation is played out as the captain does it, because that is what says
-// WHEN to look: the Shortcut takes the screen along with the microphone, so the
-// board is put away, dictated over, and come back to. Nothing is watched while
-// it is away — the return is what closes the window on it.
 test('a message after a dictation replaces the context, sink and element with it', async () => {
   fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
   await speak({ ...ASK, input: 'first', title: 'Ana' });
   const corpse = theCtx, oldSink = nodes.msd;
   corpse.clock = 5;                // it went on running healthily for a while…
-  document.hidden = true;
-  fire('document', 'visibilitychange');
   await tick(1300);                // …and the Shortcut froze it here, still 'running'
   built = 0;
   scheduled.length = 0;
   Object.assign(sinkEl, { plays: 0, fed: 0 });
-  document.hidden = false;
-  fire('document', 'visibilitychange');   // back on the board
   await speak({ ...ASK, input: 'second', title: 'Ana' });
 
   assert.equal(built, 1, 'one replacement — not a fresh context per message');
@@ -450,39 +420,6 @@ test('a message after a dictation replaces the context, sink and element with it
   assert.ok(sinkEl.plays >= 1, 'and played again — the interruption paused it too');
   assert.ok(scheduled.length, 'the second message was heard');
   for (const s of scheduled) assert.equal(s.to, nodes.msd, 'through the new sink');
-});
-
-// ── the watch ─────────────────────────────────────────────────────────────
-// Looking is the only way to find a corpse — a dead context fires no event, that
-// is what makes it dead — but nothing takes the audio session from a page that is
-// sitting still. So the watch is armed by the moments that could have taken it
-// and lets go the moment it has seen the clock keeping up with the world.
-test('the watch winds down on a healthy clock, and re-arms for every interruption', async () => {
-  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
-  await speak({ ...ASK, input: 'olá', title: 'Ana' });
-  await tick(10);
-  const c = theCtx;
-  assert.equal(intervals.size, 1, 'a context nobody has seen run yet is watched');
-
-  c.run();                           // it is a healthy context, and the beat sees it
-  await tick(700);
-  assert.equal(intervals.size, 0, 'the watch let go');
-  await tick(700);
-  assert.equal(intervals.size, 0, 'and stays let go — an idle page runs no timer at all');
-
-  fire('window', 'click');           // a tap: the session could have moved under it
-  assert.equal(intervals.size, 1, 'looking again');
-  await tick(700);
-  assert.equal(intervals.size, 0, 'and satisfied again');
-
-  document.hidden = true;            // the board is put away…
-  fire('document', 'visibilitychange');
-  assert.equal(intervals.size, 0, 'nothing to watch while the page is away');
-  await tick(300);
-  document.hidden = false;           // …and picked back up
-  fire('document', 'visibilitychange');
-  assert.equal(intervals.size, 1, 'the return is exactly when to look');
-  assert.equal(theCtx, c, 'and a healthy context is never replaced by any of it');
 });
 
 // LAST, deliberately: a refusal is remembered for the life of the page, so every

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -72,11 +72,12 @@ function fakePage() {
 // `scheduled` is emptied between tests rather than the context being rebuilt.
 const scheduled = [];
 const nodes = {};
-let theCtx = null;
+let theCtx = null, built = 0;
 class FakeCtx {
-  constructor() { this.state = 'running'; nodes.destination = this.destination = {}; theCtx = this; }
+  constructor() { this.state = 'running'; nodes.destination = this.destination = {}; theCtx = this; built++; }
   get currentTime() { return 0; }
   resume() { this.state = 'running'; return Promise.resolve(); }
+  close() { this.state = 'closed'; return Promise.resolve(); }
   suspend() { this.state = 'suspended'; return Promise.resolve(); }
   createMediaStreamDestination() { return (nodes.msd = { stream: { id: 'live' } }); }
   createBuffer(ch, len, rate) {
@@ -384,6 +385,31 @@ test('a new message aborts the one it supersedes', async () => {
   assert.equal(posts[1].signal.aborted, false);
   assert.ok(scheduled.length > before, 'and the new one actually played');
   assert.deepEqual(session.titles, ['Ana', 'Bea']);
+});
+
+// ── the interruption that kills the context ───────────────────────────────
+// A Siri Shortcut takes the microphone; coming back, the AudioContext can read
+// 'running' with a clock that never moves again. No resume() revives that one,
+// and everything hanging off it — the sink, the stream the element holds — is
+// dead with it. The next message has to build all of it again.
+test('a context killed by an interruption is replaced, sink and element with it', async () => {
+  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
+  await speak({ ...ASK, input: 'first', title: 'Ana' });
+  const corpse = theCtx, oldSink = nodes.msd;
+  built = 0;
+  await tick(220);                 // real time passes; the fake's clock never moves
+  scheduled.length = 0;
+  Object.assign(sinkEl, { plays: 0, fed: 0 });
+  await speak({ ...ASK, input: 'second', title: 'Ana' });
+
+  assert.equal(built, 1, 'one replacement — not a fresh context per message');
+  assert.notEqual(theCtx, corpse, 'the dead one is gone');
+  assert.equal(corpse.state, 'closed', 'and was let go of');
+  assert.notEqual(nodes.msd, oldSink, 'the sink belonged to the corpse; a new one took over');
+  assert.equal(sinkEl.srcObject, nodes.msd.stream, 'the element was handed the new stream');
+  assert.ok(sinkEl.plays >= 1, 'and played again — the interruption paused it too');
+  assert.ok(scheduled.length, 'the second message was heard');
+  for (const s of scheduled) assert.equal(s.to, nodes.msd, 'through the new sink');
 });
 
 // LAST, deliberately: a refusal is remembered for the life of the page, so every

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -38,6 +38,21 @@ const bar = {
   querySelector() { return this.what; },
 };
 const styles = [];
+// The page's own listeners, kept by type so a test can be the captain: tap the
+// board, leave it for a dictation, come back. The module listens for those and
+// nothing else, so a page without them cannot be interrupted at all — which is
+// the one thing these tests have to be able to do to it.
+const listeners = { window: {}, document: {} };
+const add = (bag) => (ev, fn) => (bag[ev] = bag[ev] || []).push(fn);
+const fire = (bag, ev) => (listeners[bag][ev] || []).slice().forEach((f) => f());
+// Every interval the module has running: "is it still looking" is a claim about
+// a timer, and there is no way to ask it from the outside. The real one is handed
+// back, so the beats still happen — only the bookkeeping is ours.
+const intervals = new Set();
+const realSetInterval = global.setInterval, realClearInterval = global.clearInterval;
+global.setInterval = (fn, ms) => { const t = realSetInterval(fn, ms); intervals.add(t); return t; };
+global.clearInterval = (t) => { intervals.delete(t); return realClearInterval(t); };
+
 let session;
 function fakePage() {
   // Only what a new test needs fresh. The element itself is the module's, made
@@ -48,6 +63,8 @@ function fakePage() {
   bar.hidden = true;
   bar.what.textContent = '';
   global.document = {
+    hidden: false,
+    addEventListener: add(listeners.document),
     createElement(tag) {
       if (tag === 'audio') return sinkEl;
       if (tag === 'div') return bar;
@@ -79,7 +96,10 @@ class FakeCtx {
   // stopped" have to be two different fakes: only the second is the corpse an
   // interruption leaves, and a detector that cannot tell them apart is not one.
   // It stays put during a message so the seam assertions stay about the seams.
-  get currentTime() { return this.clock; }
+  // run() is the third thing it has to be able to be: a clock keeping up with
+  // the world, which is what tells the watch there is nothing left to watch.
+  get currentTime() { return this.at === undefined ? this.clock : this.clock + (performance.now() - this.at) / 1000; }
+  run() { this.at = performance.now(); }
   resume() { this.state = 'running'; return Promise.resolve(); }
   close() { this.state = 'closed'; return Promise.resolve(); }
   suspend() { this.state = 'suspended'; return Promise.resolve(); }
@@ -153,7 +173,8 @@ test.before(async () => {
   // `MediaMetadata` is guarded on window and then called bare, the way a browser
   // sees it — it is the same global in both places.
   global.MediaMetadata = function (m) { Object.assign(this, m); };
-  global.window = { AudioContext: FakeCtx, MediaMetadata: global.MediaMetadata };
+  global.window = { AudioContext: FakeCtx, MediaMetadata: global.MediaMetadata,
+    addEventListener: add(listeners.window) };
   fakePage();
   ({ speak, stop, pause, resume } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'speech.js')).href));
@@ -401,15 +422,24 @@ test('a new message aborts the one it supersedes', async () => {
 // only ever looked at it inside speak(), so the baseline was "the previous
 // message" and a death in the gap between two messages read as "it moved, it is
 // alive". The first message after a dictation was deterministically silent.
+//
+// The dictation is played out as the captain does it, because that is what says
+// WHEN to look: the Shortcut takes the screen along with the microphone, so the
+// board is put away, dictated over, and come back to. Nothing is watched while
+// it is away — the return is what closes the window on it.
 test('a message after a dictation replaces the context, sink and element with it', async () => {
   fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
   await speak({ ...ASK, input: 'first', title: 'Ana' });
   const corpse = theCtx, oldSink = nodes.msd;
   corpse.clock = 5;                // it went on running healthily for a while…
+  document.hidden = true;
+  fire('document', 'visibilitychange');
   await tick(1300);                // …and the Shortcut froze it here, still 'running'
   built = 0;
   scheduled.length = 0;
   Object.assign(sinkEl, { plays: 0, fed: 0 });
+  document.hidden = false;
+  fire('document', 'visibilitychange');   // back on the board
   await speak({ ...ASK, input: 'second', title: 'Ana' });
 
   assert.equal(built, 1, 'one replacement — not a fresh context per message');
@@ -420,6 +450,39 @@ test('a message after a dictation replaces the context, sink and element with it
   assert.ok(sinkEl.plays >= 1, 'and played again — the interruption paused it too');
   assert.ok(scheduled.length, 'the second message was heard');
   for (const s of scheduled) assert.equal(s.to, nodes.msd, 'through the new sink');
+});
+
+// ── the watch ─────────────────────────────────────────────────────────────
+// Looking is the only way to find a corpse — a dead context fires no event, that
+// is what makes it dead — but nothing takes the audio session from a page that is
+// sitting still. So the watch is armed by the moments that could have taken it
+// and lets go the moment it has seen the clock keeping up with the world.
+test('the watch winds down on a healthy clock, and re-arms for every interruption', async () => {
+  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
+  await speak({ ...ASK, input: 'olá', title: 'Ana' });
+  await tick(10);
+  const c = theCtx;
+  assert.equal(intervals.size, 1, 'a context nobody has seen run yet is watched');
+
+  c.run();                           // it is a healthy context, and the beat sees it
+  await tick(700);
+  assert.equal(intervals.size, 0, 'the watch let go');
+  await tick(700);
+  assert.equal(intervals.size, 0, 'and stays let go — an idle page runs no timer at all');
+
+  fire('window', 'click');           // a tap: the session could have moved under it
+  assert.equal(intervals.size, 1, 'looking again');
+  await tick(700);
+  assert.equal(intervals.size, 0, 'and satisfied again');
+
+  document.hidden = true;            // the board is put away…
+  fire('document', 'visibilitychange');
+  assert.equal(intervals.size, 0, 'nothing to watch while the page is away');
+  await tick(300);
+  document.hidden = false;           // …and picked back up
+  fire('document', 'visibilitychange');
+  assert.equal(intervals.size, 1, 'the return is exactly when to look');
+  assert.equal(theCtx, c, 'and a healthy context is never replaced by any of it');
 });
 
 // LAST, deliberately: a refusal is remembered for the life of the page, so every

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -74,8 +74,12 @@ const scheduled = [];
 const nodes = {};
 let theCtx = null, built = 0;
 class FakeCtx {
-  constructor() { this.state = 'running'; nodes.destination = this.destination = {}; theCtx = this; built++; }
-  get currentTime() { return 0; }
+  constructor() { this.state = 'running'; this.clock = 0; nodes.destination = this.destination = {}; theCtx = this; built++; }
+  // Settable, because "the clock never moved" and "the clock moved and then
+  // stopped" have to be two different fakes: only the second is the corpse an
+  // interruption leaves, and a detector that cannot tell them apart is not one.
+  // It stays put during a message so the seam assertions stay about the seams.
+  get currentTime() { return this.clock; }
   resume() { this.state = 'running'; return Promise.resolve(); }
   close() { this.state = 'closed'; return Promise.resolve(); }
   suspend() { this.state = 'suspended'; return Promise.resolve(); }
@@ -392,12 +396,18 @@ test('a new message aborts the one it supersedes', async () => {
 // 'running' with a clock that never moves again. No resume() revives that one,
 // and everything hanging off it — the sink, the stream the element holds — is
 // dead with it. The next message has to build all of it again.
-test('a context killed by an interruption is replaced, sink and element with it', async () => {
+//
+// The clock RUNS before it stops, which is the whole difficulty: this module
+// only ever looked at it inside speak(), so the baseline was "the previous
+// message" and a death in the gap between two messages read as "it moved, it is
+// alive". The first message after a dictation was deterministically silent.
+test('a message after a dictation replaces the context, sink and element with it', async () => {
   fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
   await speak({ ...ASK, input: 'first', title: 'Ana' });
   const corpse = theCtx, oldSink = nodes.msd;
+  corpse.clock = 5;                // it went on running healthily for a while…
+  await tick(1300);                // …and the Shortcut froze it here, still 'running'
   built = 0;
-  await tick(220);                 // real time passes; the fake's clock never moves
   scheduled.length = 0;
   Object.assign(sinkEl, { plays: 0, fed: 0 });
   await speak({ ...ASK, input: 'second', title: 'Ana' });

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -19,78 +19,29 @@ const wake = (c) => { if (c && needsResume(c.state)) c.resume().catch(() => {});
 // Siri Shortcut taking the microphone, a call) can leave the context PERMANENTLY
 // dead: resume() resolves, state reads 'running', and not one sample ever comes
 // out of it again. So do not ask the state field, it lies — ask the clock. A
-// running context whose currentTime did not keep up with real time is a corpse,
+// running context whose currentTime did not move across real time is a corpse,
 // and the only cure is the one a page reload performs: build a new one.
-//
-// KEPT UP, not merely moved. currentTime IS real time for a running context —
-// that is what it means — so a clock holding less than half of the window it was
-// measured across stopped somewhere inside that window, and the shortfall says so
-// however long the window is. "Did it move at all" only answers for a window
-// short enough that moving and keeping up are the same question, and that is a
-// window somebody has to be awake to take. Measuring the shortfall is what lets
-// the watch sleep: the first look after a long quiet page is still a real answer.
 export const needsRebuild = (state, ctxAdvance, realMs) =>
-  state === 'running' && realMs >= 200 && ctxAdvance * 1000 <= realMs / 2;
+  state === 'running' && realMs >= 200 && ctxAdvance <= 0;
 
-// And nobody's CALL SITE owns the baseline. Round 1 let each caller compare
-// against whenever it last happened to look, which asks "did the clock move at
-// any point since then" — a context that ran for a moment and died inside that
-// window answers "alive". That is exactly the dictation: the last look is before
-// the Shortcut takes the microphone, so the tone goes into the corpse and the
-// cure arrives one tap too late. Here the window belongs to the beat, and the
-// beat only ever sets the verdict — the replacement itself waits for a gesture,
-// because iOS wants one to start the new context.
+// "Across a SHORT wait" is the whole of it. Comparing against whenever this
+// module last happened to look answers a different question — "did the clock
+// move at any point since then" — and a context that ran for a moment and died
+// inside that window answers it "alive". That is exactly the dictation: the
+// last look is before the Shortcut takes the microphone, so the tone goes into
+// the corpse and the cure arrives one tap too late.
+// So nobody's call site owns the baseline: a heartbeat does, and it is never
+// more than one beat old. Beats only ever set the verdict — the replacement
+// itself waits for a gesture, because iOS wants one to start the new context.
 const BEAT_MS = 500;
 let lastTime = 0, lastWall = 0, dead = false;
-
-// One look: how far the clock moved against how far the world did. The verdict
-// is STICKY, because nothing cures a corpse but a new context — ensureCtx() is
-// the only place that clears it. Returns whether the window just closed is proof
-// of life, which is what lets the watch stop.
 function beat() {
-  if (!ctx) return false;
-  const wall = performance.now(), advance = ctx.currentTime - lastTime;
-  if (needsRebuild(ctx.state, advance, wall - lastWall)) dead = true;
+  if (!ctx) return;
+  const wall = performance.now();
+  dead = needsRebuild(ctx.state, ctx.currentTime - lastTime, wall - lastWall);
   lastTime = ctx.currentTime; lastWall = wall;
-  return !dead && advance > 0;
 }
-
-// The looking is unavoidable — a dead context fires no event, that is what makes
-// it dead — but the looking FOREVER is not. Nothing takes the audio session
-// while the page sits still, so the watch is armed by the moments something
-// could have (a gesture, a statechange, the page coming back) and lets go the
-// instant it has seen the clock keeping up. An idle page with healthy audio runs
-// no timer at all.
-let watch = null;
-function disarm() { if (watch) clearInterval(watch); watch = null; }
-function look() { if (beat() || dead || !ctx) disarm(); }
-function watching() { if (!watch) { watch = setInterval(look, BEAT_MS); watch?.unref?.(); } }
-
-// Arming closes the window since the last look, however long it has been — the
-// shortfall answers for a long window too, which is the whole reason the watch
-// gets to sleep between the moments that could take the session. The answer is
-// ready in the same tick as the gesture, so it is ready before the ▶ that armed
-// it plays. And "alive" still leaves the watch running: a clock can always stop
-// a moment after being looked at, and only a later beat can catch that.
-function arm() {
-  if (!ctx) return;
-  beat();
-  if (dead) disarm(); else watching();
-}
-// Start a window over, judging nothing. Some stops are legitimate — Chrome
-// suspends a backgrounded context, iOS interrupts one on a locked screen, and
-// their clocks are SUPPOSED to be frozen for as long as that lasts. A window
-// containing one of those says nothing about the context, so it is thrown away
-// rather than answered: every statechange rebases, and so does the page leaving.
-function rebase() {
-  if (!ctx) return;
-  lastTime = ctx.currentTime; lastWall = performance.now();
-}
-// Nothing to watch while the page is away (iOS throttles the timer there
-// anyway), and the baseline belongs to the moment of leaving — so that coming
-// back measures the clock across exactly the interruption that could have taken
-// the audio session.
-function leaving() { rebase(); disarm(); }
+setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
 
 function ensureCtx() {
   if (ctx) return ctx;
@@ -99,17 +50,13 @@ function ensureCtx() {
   try {
     ctx = new AC();
     // Recover the moment iOS allows it, instead of finding out at the next tone.
-    // A statechange is also the audio session moving under the page: the window
-    // it lands in is unjudgeable (a legitimate suspension freezes the clock too),
-    // so throw that window away and watch the next one instead.
-    ctx.onstatechange = () => { rebase(); watching(); wake(ctx); };
+    ctx.onstatechange = () => wake(ctx);
     master = ctx.createGain(); master.gain.value = volume;
     comp = ctx.createDynamicsCompressor();
     comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
     comp.attack.value = 0.003; comp.release.value = 0.25;
     master.connect(comp); comp.connect(ctx.destination);
     lastTime = ctx.currentTime; lastWall = performance.now(); dead = false;
-    watching();   // a newborn context is unproven; the first beat that sees it run lets go
   } catch (e) { ctx = null; master = null; }
   return ctx;
 }
@@ -197,19 +144,12 @@ export function play(name) {
 // A fresh context is born suspended and iOS wants a gesture to start it, so the
 // primer is also where a corpse gets replaced: capture phase means this runs
 // BEFORE the handler of the ▶ that was tapped, and that play() gets the new one.
-// It arms the watch BEFORE it asks for the context, so the verdict the tap acts
-// on is the one that includes the wait it just ended, not the one from before it.
-function primeOnGesture() { arm(); wake(liveCtx()); }
+function primeOnGesture() { wake(liveCtx()); }
 for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEventListener(ev, primeOnGesture, { capture: true, passive: true });
 
 // Re-resume proactively on refocus so the next notification after a
 // backgrounded tab (or a locked phone) isn't the one that eats the latency.
-// This is also the pair of moments the watch is built around: the page going
-// away is where the baseline is taken, and the page coming back is where that
-// window is closed — and the window the page was away for is precisely the one
-// a Siri Shortcut takes the microphone in.
-document.addEventListener('visibilitychange', () => {
-  if (!ctx) return;                       // nothing built yet: leave that to a gesture
-  if (document.hidden) return leaving();
-  arm(); wake(liveCtx());
-});
+// The beat comes first: iOS throttles timers on a page it has put away, so the
+// sample waiting on return can be from before the interruption. Burning it here
+// means the verdict is one beat away instead of two.
+document.addEventListener('visibilitychange', () => { if (!document.hidden && ctx) { beat(); wake(liveCtx()); } });

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -23,7 +23,25 @@ const wake = (c) => { if (c && needsResume(c.state)) c.resume().catch(() => {});
 // and the only cure is the one a page reload performs: build a new one.
 export const needsRebuild = (state, ctxAdvance, realMs) =>
   state === 'running' && realMs >= 200 && ctxAdvance <= 0;
-let lastTime = 0, lastWall = 0;
+
+// "Across a SHORT wait" is the whole of it. Comparing against whenever this
+// module last happened to look answers a different question — "did the clock
+// move at any point since then" — and a context that ran for a moment and died
+// inside that window answers it "alive". That is exactly the dictation: the
+// last look is before the Shortcut takes the microphone, so the tone goes into
+// the corpse and the cure arrives one tap too late.
+// So nobody's call site owns the baseline: a heartbeat does, and it is never
+// more than one beat old. Beats only ever set the verdict — the replacement
+// itself waits for a gesture, because iOS wants one to start the new context.
+const BEAT_MS = 500;
+let lastTime = 0, lastWall = 0, dead = false;
+function beat() {
+  if (!ctx) return;
+  const wall = performance.now();
+  dead = needsRebuild(ctx.state, ctx.currentTime - lastTime, wall - lastWall);
+  lastTime = ctx.currentTime; lastWall = wall;
+}
+setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
 
 function ensureCtx() {
   if (ctx) return ctx;
@@ -38,25 +56,22 @@ function ensureCtx() {
     comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
     comp.attack.value = 0.003; comp.release.value = 0.25;
     master.connect(comp); comp.connect(ctx.destination);
-    lastTime = ctx.currentTime; lastWall = performance.now();
+    lastTime = ctx.currentTime; lastWall = performance.now(); dead = false;
   } catch (e) { ctx = null; master = null; }
   return ctx;
 }
 
 // The context every caller should use: the live one, or a replacement for the
-// corpse. The rebuild goes back through ensureCtx() so the graph (master at the
-// current volume, the compressor, the wiring) can never drift from the original.
+// corpse the last heartbeat found. The rebuild goes back through ensureCtx() so
+// the graph (master at the current volume, the compressor, the wiring) can never
+// drift from the original. It takes no sample of its own — the window belongs to
+// the heartbeat, and a call landing just after a beat must not shrink it.
 function liveCtx() {
   const c = ensureCtx();
-  if (!c) return null;
-  const wall = performance.now();
-  if (needsRebuild(c.state, c.currentTime - lastTime, wall - lastWall)) {
-    try { c.close(); } catch (e) {}
-    ctx = master = comp = null;
-    return ensureCtx();
-  }
-  lastTime = c.currentTime; lastWall = wall;
-  return c;
+  if (!c || !dead) return c;
+  try { c.close(); } catch (e) {}
+  ctx = master = comp = null;
+  return ensureCtx();
 }
 export function setVolume(v) {
   volume = Math.max(0, Math.min(1, Number(v)));
@@ -134,4 +149,7 @@ for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEv
 
 // Re-resume proactively on refocus so the next notification after a
 // backgrounded tab (or a locked phone) isn't the one that eats the latency.
-document.addEventListener('visibilitychange', () => { if (!document.hidden && ctx) wake(liveCtx()); });
+// The beat comes first: iOS throttles timers on a page it has put away, so the
+// sample waiting on return can be from before the interruption. Burning it here
+// means the verdict is one beat away instead of two.
+document.addEventListener('visibilitychange', () => { if (!document.hidden && ctx) { beat(); wake(liveCtx()); } });

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -19,29 +19,78 @@ const wake = (c) => { if (c && needsResume(c.state)) c.resume().catch(() => {});
 // Siri Shortcut taking the microphone, a call) can leave the context PERMANENTLY
 // dead: resume() resolves, state reads 'running', and not one sample ever comes
 // out of it again. So do not ask the state field, it lies — ask the clock. A
-// running context whose currentTime did not move across real time is a corpse,
+// running context whose currentTime did not keep up with real time is a corpse,
 // and the only cure is the one a page reload performs: build a new one.
+//
+// KEPT UP, not merely moved. currentTime IS real time for a running context —
+// that is what it means — so a clock holding less than half of the window it was
+// measured across stopped somewhere inside that window, and the shortfall says so
+// however long the window is. "Did it move at all" only answers for a window
+// short enough that moving and keeping up are the same question, and that is a
+// window somebody has to be awake to take. Measuring the shortfall is what lets
+// the watch sleep: the first look after a long quiet page is still a real answer.
 export const needsRebuild = (state, ctxAdvance, realMs) =>
-  state === 'running' && realMs >= 200 && ctxAdvance <= 0;
+  state === 'running' && realMs >= 200 && ctxAdvance * 1000 <= realMs / 2;
 
-// "Across a SHORT wait" is the whole of it. Comparing against whenever this
-// module last happened to look answers a different question — "did the clock
-// move at any point since then" — and a context that ran for a moment and died
-// inside that window answers it "alive". That is exactly the dictation: the
-// last look is before the Shortcut takes the microphone, so the tone goes into
-// the corpse and the cure arrives one tap too late.
-// So nobody's call site owns the baseline: a heartbeat does, and it is never
-// more than one beat old. Beats only ever set the verdict — the replacement
-// itself waits for a gesture, because iOS wants one to start the new context.
+// And nobody's CALL SITE owns the baseline. Round 1 let each caller compare
+// against whenever it last happened to look, which asks "did the clock move at
+// any point since then" — a context that ran for a moment and died inside that
+// window answers "alive". That is exactly the dictation: the last look is before
+// the Shortcut takes the microphone, so the tone goes into the corpse and the
+// cure arrives one tap too late. Here the window belongs to the beat, and the
+// beat only ever sets the verdict — the replacement itself waits for a gesture,
+// because iOS wants one to start the new context.
 const BEAT_MS = 500;
 let lastTime = 0, lastWall = 0, dead = false;
+
+// One look: how far the clock moved against how far the world did. The verdict
+// is STICKY, because nothing cures a corpse but a new context — ensureCtx() is
+// the only place that clears it. Returns whether the window just closed is proof
+// of life, which is what lets the watch stop.
 function beat() {
-  if (!ctx) return;
-  const wall = performance.now();
-  dead = needsRebuild(ctx.state, ctx.currentTime - lastTime, wall - lastWall);
+  if (!ctx) return false;
+  const wall = performance.now(), advance = ctx.currentTime - lastTime;
+  if (needsRebuild(ctx.state, advance, wall - lastWall)) dead = true;
   lastTime = ctx.currentTime; lastWall = wall;
+  return !dead && advance > 0;
 }
-setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
+
+// The looking is unavoidable — a dead context fires no event, that is what makes
+// it dead — but the looking FOREVER is not. Nothing takes the audio session
+// while the page sits still, so the watch is armed by the moments something
+// could have (a gesture, a statechange, the page coming back) and lets go the
+// instant it has seen the clock keeping up. An idle page with healthy audio runs
+// no timer at all.
+let watch = null;
+function disarm() { if (watch) clearInterval(watch); watch = null; }
+function look() { if (beat() || dead || !ctx) disarm(); }
+function watching() { if (!watch) { watch = setInterval(look, BEAT_MS); watch?.unref?.(); } }
+
+// Arming closes the window since the last look, however long it has been — the
+// shortfall answers for a long window too, which is the whole reason the watch
+// gets to sleep between the moments that could take the session. The answer is
+// ready in the same tick as the gesture, so it is ready before the ▶ that armed
+// it plays. And "alive" still leaves the watch running: a clock can always stop
+// a moment after being looked at, and only a later beat can catch that.
+function arm() {
+  if (!ctx) return;
+  beat();
+  if (dead) disarm(); else watching();
+}
+// Start a window over, judging nothing. Some stops are legitimate — Chrome
+// suspends a backgrounded context, iOS interrupts one on a locked screen, and
+// their clocks are SUPPOSED to be frozen for as long as that lasts. A window
+// containing one of those says nothing about the context, so it is thrown away
+// rather than answered: every statechange rebases, and so does the page leaving.
+function rebase() {
+  if (!ctx) return;
+  lastTime = ctx.currentTime; lastWall = performance.now();
+}
+// Nothing to watch while the page is away (iOS throttles the timer there
+// anyway), and the baseline belongs to the moment of leaving — so that coming
+// back measures the clock across exactly the interruption that could have taken
+// the audio session.
+function leaving() { rebase(); disarm(); }
 
 function ensureCtx() {
   if (ctx) return ctx;
@@ -50,13 +99,17 @@ function ensureCtx() {
   try {
     ctx = new AC();
     // Recover the moment iOS allows it, instead of finding out at the next tone.
-    ctx.onstatechange = () => wake(ctx);
+    // A statechange is also the audio session moving under the page: the window
+    // it lands in is unjudgeable (a legitimate suspension freezes the clock too),
+    // so throw that window away and watch the next one instead.
+    ctx.onstatechange = () => { rebase(); watching(); wake(ctx); };
     master = ctx.createGain(); master.gain.value = volume;
     comp = ctx.createDynamicsCompressor();
     comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
     comp.attack.value = 0.003; comp.release.value = 0.25;
     master.connect(comp); comp.connect(ctx.destination);
     lastTime = ctx.currentTime; lastWall = performance.now(); dead = false;
+    watching();   // a newborn context is unproven; the first beat that sees it run lets go
   } catch (e) { ctx = null; master = null; }
   return ctx;
 }
@@ -144,12 +197,19 @@ export function play(name) {
 // A fresh context is born suspended and iOS wants a gesture to start it, so the
 // primer is also where a corpse gets replaced: capture phase means this runs
 // BEFORE the handler of the ▶ that was tapped, and that play() gets the new one.
-function primeOnGesture() { wake(liveCtx()); }
+// It arms the watch BEFORE it asks for the context, so the verdict the tap acts
+// on is the one that includes the wait it just ended, not the one from before it.
+function primeOnGesture() { arm(); wake(liveCtx()); }
 for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEventListener(ev, primeOnGesture, { capture: true, passive: true });
 
 // Re-resume proactively on refocus so the next notification after a
 // backgrounded tab (or a locked phone) isn't the one that eats the latency.
-// The beat comes first: iOS throttles timers on a page it has put away, so the
-// sample waiting on return can be from before the interruption. Burning it here
-// means the verdict is one beat away instead of two.
-document.addEventListener('visibilitychange', () => { if (!document.hidden && ctx) { beat(); wake(liveCtx()); } });
+// This is also the pair of moments the watch is built around: the page going
+// away is where the baseline is taken, and the page coming back is where that
+// window is closed — and the window the page was away for is precisely the one
+// a Siri Shortcut takes the microphone in.
+document.addEventListener('visibilitychange', () => {
+  if (!ctx) return;                       // nothing built yet: leave that to a gesture
+  if (document.hidden) return leaving();
+  arm(); wake(liveCtx());
+});

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -43,6 +43,20 @@ function beat() {
 }
 setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
 
+// KNOWN HACK, kept on purpose. This beats for the life of the page, on a page
+// that is nearly always fine, and on a phone that costs battery. The obvious
+// cure — arm the watch on the moments that could take the audio session, disarm
+// it once the clock is seen keeping up — was built and REVERTED: it dropped the
+// hidden media element around the moment the screen locks, and that element is
+// the only reason iOS keeps this page alive with the screen off. Speech stopped
+// mid-sentence on lock and resumed on unlock, which is a far worse bug than a
+// timer. See the revert of cb2622e for what was tried.
+//
+// The likely real answer is not a cleverer watch but a switch: the captain turns
+// the corpse watch ON when he is working from his phone, and it does not run at
+// all otherwise. Whoever picks that up: the property that must not break is that
+// speech survives a locked screen. Everything else is negotiable.
+
 function ensureCtx() {
   if (ctx) return ctx;
   const AC = window.AudioContext || window.webkitAudioContext;

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -15,6 +15,16 @@ export const needsResume = (state) => state !== 'running' && state !== 'closed';
 // leave every recovery path armed for the next try.
 const wake = (c) => { if (c && needsResume(c.state)) c.resume().catch(() => {}); };
 
+// …and sometimes there is nothing to wake. An iOS audio-session interruption (a
+// Siri Shortcut taking the microphone, a call) can leave the context PERMANENTLY
+// dead: resume() resolves, state reads 'running', and not one sample ever comes
+// out of it again. So do not ask the state field, it lies — ask the clock. A
+// running context whose currentTime did not move across real time is a corpse,
+// and the only cure is the one a page reload performs: build a new one.
+export const needsRebuild = (state, ctxAdvance, realMs) =>
+  state === 'running' && realMs >= 200 && ctxAdvance <= 0;
+let lastTime = 0, lastWall = 0;
+
 function ensureCtx() {
   if (ctx) return ctx;
   const AC = window.AudioContext || window.webkitAudioContext;
@@ -28,8 +38,25 @@ function ensureCtx() {
     comp.threshold.value = -14; comp.knee.value = 26; comp.ratio.value = 3.2;
     comp.attack.value = 0.003; comp.release.value = 0.25;
     master.connect(comp); comp.connect(ctx.destination);
+    lastTime = ctx.currentTime; lastWall = performance.now();
   } catch (e) { ctx = null; master = null; }
   return ctx;
+}
+
+// The context every caller should use: the live one, or a replacement for the
+// corpse. The rebuild goes back through ensureCtx() so the graph (master at the
+// current volume, the compressor, the wiring) can never drift from the original.
+function liveCtx() {
+  const c = ensureCtx();
+  if (!c) return null;
+  const wall = performance.now();
+  if (needsRebuild(c.state, c.currentTime - lastTime, wall - lastWall)) {
+    try { c.close(); } catch (e) {}
+    ctx = master = comp = null;
+    return ensureCtx();
+  }
+  lastTime = c.currentTime; lastWall = wall;
+  return c;
 }
 export function setVolume(v) {
   volume = Math.max(0, Math.min(1, Number(v)));
@@ -83,7 +110,7 @@ export function play(name) {
   if (!name || name === 'none') return;
   const fn = PALETTE[name];
   if (!fn) return;
-  const c = ensureCtx();
+  const c = liveCtx();
   if (!c) return;
   const run = () => { try { fn(c.currentTime + 0.02); } catch (e) {} };
   if (needsResume(c.state)) { c.resume().then(run).catch(() => {}); }
@@ -99,9 +126,12 @@ export function play(name) {
 // It stays attached for the life of the page: the context can die again long
 // after the first gesture (screen lock), and a gesture must always be able to
 // unlock it. A no-op when the context is already running.
-function primeOnGesture() { wake(ensureCtx()); }
+// A fresh context is born suspended and iOS wants a gesture to start it, so the
+// primer is also where a corpse gets replaced: capture phase means this runs
+// BEFORE the handler of the ▶ that was tapped, and that play() gets the new one.
+function primeOnGesture() { wake(liveCtx()); }
 for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart']) window.addEventListener(ev, primeOnGesture, { capture: true, passive: true });
 
 // Re-resume proactively on refocus so the next notification after a
 // backgrounded tab (or a locked phone) isn't the one that eats the latency.
-document.addEventListener('visibilitychange', () => { if (!document.hidden) wake(ctx); });
+document.addEventListener('visibilitychange', () => { if (!document.hidden && ctx) wake(liveCtx()); });

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -34,7 +34,7 @@
    are arguments; neither has a default. When the engine refuses, the refusal is
    thrown to the caller — this module never quietly finds another way to speak. */
 
-let ctx;              // the AudioContext, made once and kept
+let ctx;              // the AudioContext, kept until it dies (see audio())
 let sink;             // MediaStreamAudioDestinationNode — null once the browser refuses
 let el;               // the <audio> the sound leaves through
 let live = null;      // the speech in flight, or null
@@ -81,6 +81,25 @@ function transport(on, title) {
 }
 
 /* ── the route to the speakers ───────────────────────────────────────── */
+
+// The context, alive. An iOS audio-session interruption — the microphone taken
+// by a Siri Shortcut, a call — can leave it PERMANENTLY dead: resume() resolves,
+// state reads 'running', and nothing is ever heard from it again. The state
+// field lies, so ask the clock instead: a running context whose currentTime did
+// not move across real time is a corpse, and only a new one cures it. The sink
+// is a node of the dead context and goes with it — openSink() then makes a fresh
+// one and hands the element its stream again, which is what re-arms the element
+// after the same interruption paused it.
+let ctxTime = 0, ctxWall = 0;
+function audio() {
+  if (ctx && ctx.state === 'running' && ctx.currentTime - ctxTime <= 0 && performance.now() - ctxWall >= 200) {
+    try { ctx.close(); } catch {}
+    ctx = undefined; sink = undefined;
+  }
+  ctx ??= new (window.AudioContext || window.webkitAudioContext)();
+  ctxTime = ctx.currentTime; ctxWall = performance.now();
+  return ctx;
+}
 
 // It renders nothing and has no controls of its own: the transport above is the
 // player people see. This one is the player the OS sees.
@@ -218,7 +237,7 @@ export async function speak({url, voice, input, params, title, artist, onFirstSo
   if (!url) throw new Error('speak() needs the engine url — there is no default');
   if (!voice) throw new Error('speak() needs a voice — there is no default');
   stop();                     // one voice at a time
-  ctx ??= new (window.AudioContext || window.webkitAudioContext)();
+  audio();                    // a corpse from an interruption is replaced here
   openSink();                 // before any await: iOS only allows play() inside the tap
   announce(title, artist);
   transport(true, title);

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -86,48 +86,28 @@ function transport(on, title) {
 // by a Siri Shortcut, a call — can leave it PERMANENTLY dead: resume() resolves,
 // state reads 'running', and nothing is ever heard from it again. The state
 // field lies, so ask the clock instead: a running context whose currentTime did
-// not keep up with real time is a corpse, and only a new one cures it. The sink
+// not move across real time is a corpse, and only a new one cures it. The sink
 // is a node of the dead context and goes with it — openSink() then makes a fresh
 // one and hands the element its stream again, which is what re-arms the element
 // after the same interruption paused it.
-// KEPT UP, not merely moved: currentTime is real time for a running context, so
-// a clock holding less than half of the window it was measured across stopped
-// somewhere inside it, however long that window was. Sampling only inside speak()
-// makes the window "since the previous message" and asks the weaker question, and
-// a dictation happens exactly in that gap: the clock moved since the last
-// message, verdict "alive", and the first message back is silent.
-// The beating is ARMED, not eternal: nothing takes the audio session while the
-// page sits still, so the moments that could have taken it (a gesture, the page
-// coming back) start the watch, and the first beat that sees the clock keeping up
-// stops it. An idle page runs no timer.
-// sound.js holds the same rule in needsRebuild() and the same watch around it;
-// the numbers and the shape are deliberately identical, and the two have to be
-// changed together. It is not imported because this file is a copy of
-// chatterbox_server's (see the header) and must not grow a dependency on the board.
+// The window has to be SHORT and it has to be fresh. Sampling only inside
+// speak() makes the baseline "the previous message", and a dictation happens
+// exactly in that gap: the clock moved since the last message, so the verdict is
+// "alive" and the first message back is silent. A heartbeat owns the sample
+// instead, so the answer is never more than one beat old.
+// sound.js holds the same rule in needsRebuild(); the numbers and the shape are
+// deliberately identical, and the two have to be changed together. It is not
+// imported because this file is a copy of chatterbox_server's (see the header)
+// and must not grow a dependency on the board.
 const BEAT_MS = 500;
-let ctxTime = 0, ctxWall = 0, dead = false, watch = null;
-// The verdict is sticky — only a new context cures a corpse, so only audio()
-// clears it. The return is "this window is proof of life", which stops the watch.
+let ctxTime = 0, ctxWall = 0, dead = false;
 function beat() {
-  if (!ctx) return false;
-  const wall = performance.now(), advance = ctx.currentTime - ctxTime, real = wall - ctxWall;
-  if (ctx.state === 'running' && real >= 200 && advance * 1000 <= real / 2) dead = true;
+  if (!ctx) return;
+  const wall = performance.now();
+  dead = ctx.state === 'running' && wall - ctxWall >= 200 && ctx.currentTime - ctxTime <= 0;
   ctxTime = ctx.currentTime; ctxWall = wall;
-  return !dead && advance > 0;
 }
-// Start a window over, judging nothing: pause() suspends the context on purpose
-// and a suspended clock is SUPPOSED to be frozen, so a window containing one of
-// those says nothing about anything and is thrown away rather than answered.
-function rebase() { if (ctx) { ctxTime = ctx.currentTime; ctxWall = performance.now(); } }
-function disarm() { if (watch) clearInterval(watch); watch = null; }
-function look() { if (beat() || dead || !ctx) disarm(); }
-// a timer is no reason to hold a process open
-function watching() { if (!watch) { watch = setInterval(look, BEAT_MS); watch?.unref?.(); } }
-// Arming closes the window since the last look, however long it has been: the
-// shortfall answers for a long window too, which is what lets the watch sleep
-// between the moments that could take the session. If it comes back "alive" the
-// watch still runs on — a clock can always stop a moment after being looked at.
-function arm() { if (!ctx) return; beat(); if (dead) disarm(); else watching(); }
+setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
 
 function audio() {
   if (ctx && dead) {
@@ -137,7 +117,6 @@ function audio() {
   if (!ctx) {
     ctx = new (window.AudioContext || window.webkitAudioContext)();
     ctxTime = ctx.currentTime; ctxWall = performance.now(); dead = false;
-    watching();      // a newborn context is unproven until a beat has seen it run
   }
   return ctx;
 }
@@ -145,24 +124,12 @@ function audio() {
 // A fresh context is born suspended and iOS wants an activation to start it, so
 // a gesture replaces the corpse too, not only speak(): a board message arrives
 // with no tap behind it and has to find a context that is already alive. Capture
-// phase and passive, the way sound.js primes its own. It arms the watch first,
-// so the verdict this tap acts on covers the wait the tap just ended. Optional
-// call so the module still imports where there is no window to listen on.
+// phase and passive, the way sound.js primes its own; a no-op unless the last
+// beat found the context dead. Optional call so the module still imports where
+// there is no window to listen on.
 for (const ev of ['click', 'pointerdown', 'touchstart', 'keydown'])
-  window.addEventListener?.(ev, () => { arm(); if (ctx && dead) audio().resume().catch(() => {}); },
+  window.addEventListener?.(ev, () => { if (ctx && dead) audio().resume().catch(() => {}); },
     { capture: true, passive: true });
-
-// The page leaving and coming back are the other pair: the baseline is taken at
-// the moment of leaving, so returning measures the clock across exactly the
-// interruption — a Shortcut taking the microphone happens in that window and
-// nowhere else. Nothing is watched while the page is away; the timer would be
-// throttled there anyway.
-document.addEventListener?.('visibilitychange', () => {
-  if (!ctx) return;
-  if (document.hidden) { rebase(); disarm(); return; }
-  arm();
-  if (dead) audio().resume().catch(() => {});
-});
 
 // It renders nothing and has no controls of its own: the transport above is the
 // player people see. This one is the player the OS sees.
@@ -234,12 +201,9 @@ export function pause() {
   playbackState('paused');
 }
 
-// Back in the same order, inside out: the clock first, then the element. The
-// pause the clock just came out of is not evidence of anything, so the window it
-// sat in goes with it.
+// Back in the same order, inside out: the clock first, then the element.
 export function resume() {
   ctx?.resume();
-  rebase();
   if (sink) element().play().catch(() => {});
   playbackState('playing');
 }
@@ -251,7 +215,7 @@ export function stop() {
   const s = live;
   live = null;
   s.ac.abort();
-  ctx?.resume(); rebase();       // stopped while paused: no frozen clock left behind
+  ctx?.resume();                 // stopped while paused: no frozen clock left behind
   for (const src of s.srcs) { src.onended = null; try { src.stop(); } catch {} }
   s.srcs = [];
   closeSink();
@@ -309,9 +273,8 @@ export async function speak({url, voice, input, params, title, artist, onFirstSo
   transport(true, title);
   const s = live = {ac: new AbortController(), srcs: [], pending: 0, over: false};
   // Anything but 'running' needs the resume: iOS parks it in 'interrupted'
-  // (not 'suspended') when the screen locks, and that is silence too. Whatever
-  // it was parked in froze the clock legitimately, so the window ends there.
-  if (ctx.state !== 'running') { await ctx.resume().catch(() => {}); rebase(); }
+  // (not 'suspended') when the screen locks, and that is silence too.
+  if (ctx.state !== 'running') await ctx.resume().catch(() => {});
 
   const t0 = performance.now();
   const chunks = [];

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -86,28 +86,48 @@ function transport(on, title) {
 // by a Siri Shortcut, a call — can leave it PERMANENTLY dead: resume() resolves,
 // state reads 'running', and nothing is ever heard from it again. The state
 // field lies, so ask the clock instead: a running context whose currentTime did
-// not move across real time is a corpse, and only a new one cures it. The sink
+// not keep up with real time is a corpse, and only a new one cures it. The sink
 // is a node of the dead context and goes with it — openSink() then makes a fresh
 // one and hands the element its stream again, which is what re-arms the element
 // after the same interruption paused it.
-// The window has to be SHORT and it has to be fresh. Sampling only inside
-// speak() makes the baseline "the previous message", and a dictation happens
-// exactly in that gap: the clock moved since the last message, so the verdict is
-// "alive" and the first message back is silent. A heartbeat owns the sample
-// instead, so the answer is never more than one beat old.
-// sound.js holds the same rule in needsRebuild(); the numbers and the shape are
-// deliberately identical, and the two have to be changed together. It is not
-// imported because this file is a copy of chatterbox_server's (see the header)
-// and must not grow a dependency on the board.
+// KEPT UP, not merely moved: currentTime is real time for a running context, so
+// a clock holding less than half of the window it was measured across stopped
+// somewhere inside it, however long that window was. Sampling only inside speak()
+// makes the window "since the previous message" and asks the weaker question, and
+// a dictation happens exactly in that gap: the clock moved since the last
+// message, verdict "alive", and the first message back is silent.
+// The beating is ARMED, not eternal: nothing takes the audio session while the
+// page sits still, so the moments that could have taken it (a gesture, the page
+// coming back) start the watch, and the first beat that sees the clock keeping up
+// stops it. An idle page runs no timer.
+// sound.js holds the same rule in needsRebuild() and the same watch around it;
+// the numbers and the shape are deliberately identical, and the two have to be
+// changed together. It is not imported because this file is a copy of
+// chatterbox_server's (see the header) and must not grow a dependency on the board.
 const BEAT_MS = 500;
-let ctxTime = 0, ctxWall = 0, dead = false;
+let ctxTime = 0, ctxWall = 0, dead = false, watch = null;
+// The verdict is sticky — only a new context cures a corpse, so only audio()
+// clears it. The return is "this window is proof of life", which stops the watch.
 function beat() {
-  if (!ctx) return;
-  const wall = performance.now();
-  dead = ctx.state === 'running' && wall - ctxWall >= 200 && ctx.currentTime - ctxTime <= 0;
+  if (!ctx) return false;
+  const wall = performance.now(), advance = ctx.currentTime - ctxTime, real = wall - ctxWall;
+  if (ctx.state === 'running' && real >= 200 && advance * 1000 <= real / 2) dead = true;
   ctxTime = ctx.currentTime; ctxWall = wall;
+  return !dead && advance > 0;
 }
-setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
+// Start a window over, judging nothing: pause() suspends the context on purpose
+// and a suspended clock is SUPPOSED to be frozen, so a window containing one of
+// those says nothing about anything and is thrown away rather than answered.
+function rebase() { if (ctx) { ctxTime = ctx.currentTime; ctxWall = performance.now(); } }
+function disarm() { if (watch) clearInterval(watch); watch = null; }
+function look() { if (beat() || dead || !ctx) disarm(); }
+// a timer is no reason to hold a process open
+function watching() { if (!watch) { watch = setInterval(look, BEAT_MS); watch?.unref?.(); } }
+// Arming closes the window since the last look, however long it has been: the
+// shortfall answers for a long window too, which is what lets the watch sleep
+// between the moments that could take the session. If it comes back "alive" the
+// watch still runs on — a clock can always stop a moment after being looked at.
+function arm() { if (!ctx) return; beat(); if (dead) disarm(); else watching(); }
 
 function audio() {
   if (ctx && dead) {
@@ -117,6 +137,7 @@ function audio() {
   if (!ctx) {
     ctx = new (window.AudioContext || window.webkitAudioContext)();
     ctxTime = ctx.currentTime; ctxWall = performance.now(); dead = false;
+    watching();      // a newborn context is unproven until a beat has seen it run
   }
   return ctx;
 }
@@ -124,12 +145,24 @@ function audio() {
 // A fresh context is born suspended and iOS wants an activation to start it, so
 // a gesture replaces the corpse too, not only speak(): a board message arrives
 // with no tap behind it and has to find a context that is already alive. Capture
-// phase and passive, the way sound.js primes its own; a no-op unless the last
-// beat found the context dead. Optional call so the module still imports where
-// there is no window to listen on.
+// phase and passive, the way sound.js primes its own. It arms the watch first,
+// so the verdict this tap acts on covers the wait the tap just ended. Optional
+// call so the module still imports where there is no window to listen on.
 for (const ev of ['click', 'pointerdown', 'touchstart', 'keydown'])
-  window.addEventListener?.(ev, () => { if (ctx && dead) audio().resume().catch(() => {}); },
+  window.addEventListener?.(ev, () => { arm(); if (ctx && dead) audio().resume().catch(() => {}); },
     { capture: true, passive: true });
+
+// The page leaving and coming back are the other pair: the baseline is taken at
+// the moment of leaving, so returning measures the clock across exactly the
+// interruption — a Shortcut taking the microphone happens in that window and
+// nowhere else. Nothing is watched while the page is away; the timer would be
+// throttled there anyway.
+document.addEventListener?.('visibilitychange', () => {
+  if (!ctx) return;
+  if (document.hidden) { rebase(); disarm(); return; }
+  arm();
+  if (dead) audio().resume().catch(() => {});
+});
 
 // It renders nothing and has no controls of its own: the transport above is the
 // player people see. This one is the player the OS sees.
@@ -201,9 +234,12 @@ export function pause() {
   playbackState('paused');
 }
 
-// Back in the same order, inside out: the clock first, then the element.
+// Back in the same order, inside out: the clock first, then the element. The
+// pause the clock just came out of is not evidence of anything, so the window it
+// sat in goes with it.
 export function resume() {
   ctx?.resume();
+  rebase();
   if (sink) element().play().catch(() => {});
   playbackState('playing');
 }
@@ -215,7 +251,7 @@ export function stop() {
   const s = live;
   live = null;
   s.ac.abort();
-  ctx?.resume();                 // stopped while paused: no frozen clock left behind
+  ctx?.resume(); rebase();       // stopped while paused: no frozen clock left behind
   for (const src of s.srcs) { src.onended = null; try { src.stop(); } catch {} }
   s.srcs = [];
   closeSink();
@@ -273,8 +309,9 @@ export async function speak({url, voice, input, params, title, artist, onFirstSo
   transport(true, title);
   const s = live = {ac: new AbortController(), srcs: [], pending: 0, over: false};
   // Anything but 'running' needs the resume: iOS parks it in 'interrupted'
-  // (not 'suspended') when the screen locks, and that is silence too.
-  if (ctx.state !== 'running') await ctx.resume().catch(() => {});
+  // (not 'suspended') when the screen locks, and that is silence too. Whatever
+  // it was parked in froze the clock legitimately, so the window ends there.
+  if (ctx.state !== 'running') { await ctx.resume().catch(() => {}); rebase(); }
 
   const t0 = performance.now();
   const chunks = [];

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -90,16 +90,46 @@ function transport(on, title) {
 // is a node of the dead context and goes with it — openSink() then makes a fresh
 // one and hands the element its stream again, which is what re-arms the element
 // after the same interruption paused it.
-let ctxTime = 0, ctxWall = 0;
+// The window has to be SHORT and it has to be fresh. Sampling only inside
+// speak() makes the baseline "the previous message", and a dictation happens
+// exactly in that gap: the clock moved since the last message, so the verdict is
+// "alive" and the first message back is silent. A heartbeat owns the sample
+// instead, so the answer is never more than one beat old.
+// sound.js holds the same rule in needsRebuild(); the numbers and the shape are
+// deliberately identical, and the two have to be changed together. It is not
+// imported because this file is a copy of chatterbox_server's (see the header)
+// and must not grow a dependency on the board.
+const BEAT_MS = 500;
+let ctxTime = 0, ctxWall = 0, dead = false;
+function beat() {
+  if (!ctx) return;
+  const wall = performance.now();
+  dead = ctx.state === 'running' && wall - ctxWall >= 200 && ctx.currentTime - ctxTime <= 0;
+  ctxTime = ctx.currentTime; ctxWall = wall;
+}
+setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
+
 function audio() {
-  if (ctx && ctx.state === 'running' && ctx.currentTime - ctxTime <= 0 && performance.now() - ctxWall >= 200) {
+  if (ctx && dead) {
     try { ctx.close(); } catch {}
-    ctx = undefined; sink = undefined;
+    ctx = undefined; sink = undefined;   // the sink is a node of the dead context
   }
-  ctx ??= new (window.AudioContext || window.webkitAudioContext)();
-  ctxTime = ctx.currentTime; ctxWall = performance.now();
+  if (!ctx) {
+    ctx = new (window.AudioContext || window.webkitAudioContext)();
+    ctxTime = ctx.currentTime; ctxWall = performance.now(); dead = false;
+  }
   return ctx;
 }
+
+// A fresh context is born suspended and iOS wants an activation to start it, so
+// a gesture replaces the corpse too, not only speak(): a board message arrives
+// with no tap behind it and has to find a context that is already alive. Capture
+// phase and passive, the way sound.js primes its own; a no-op unless the last
+// beat found the context dead. Optional call so the module still imports where
+// there is no window to listen on.
+for (const ev of ['click', 'pointerdown', 'touchstart', 'keydown'])
+  window.addEventListener?.(ev, () => { if (ctx && dead) audio().resume().catch(() => {}); },
+    { capture: true, passive: true });
 
 // It renders nothing and has no controls of its own: the transport above is the
 // player people see. This one is the player the OS sees.


### PR DESCRIPTION
# Description

Dictate into the board through a Siri Shortcut and the phone stays silent for the rest of the page's life — the ▶ previews in notification settings make no sound, TTS says nothing, and only a reload brings audio back. The microphone taking the audio session leaves the `AudioContext` permanently dead in a way #96 could not reach: `resume()` resolves, `state` reads `running`, and not one sample ever comes out of it again. A context you cannot resume back to life is a corpse, so this stops asking the state field — which lies — and asks the clock, then does what the reload does and builds a new one behind the same graph.

## Type of change

- [x] Bug fix (non-breaking)

## How has this change been tested?

- New automated tests added: the corpse verdict as a pure function over state and clock, a rebuild that has to come back with the volume and the whole graph on it, a healthy context that must survive any number of gestures untouched, and the captain's actual morning — a context that ran, then died, and a ▶ that has to sound on the first tap.
- Needs the captain's own verdict on his phone: dictate through the Shortcut, come back, press ▶ — no reload.

## Any specific deployment considerations

- None — browser-side only, no server change.
