### PR TITLE
Keep the audio session alive from his pocket

### DIFF
--- a/test/keepalive.test.js
+++ b/test/keepalive.test.js
@@ -18,8 +18,10 @@ const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
 let keepAliveState, corpseWatchRuns, enabledFromStorage;
+let keepAliveVoice, keepAliveSound, KEEPALIVE_VOICES, PAD_POOL, DRONE, nextNote, padStep, padGain, PAD_PEAK;
 test.before(async () => {
-  ({ keepAliveState, corpseWatchRuns, enabledFromStorage } =
+  ({ keepAliveState, corpseWatchRuns, enabledFromStorage,
+     keepAliveVoice, keepAliveSound, KEEPALIVE_VOICES, PAD_POOL, DRONE, nextNote, padStep, padGain, PAD_PEAK } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'keepalive.js')).href));
 });
 
@@ -74,4 +76,74 @@ test('the toggle survives a reload, and anything unrecognised is off', () => {
   assert.equal(enabledFromStorage(''), false);
   assert.equal(enabledFromStorage('0'), false);
   assert.equal(enabledFromStorage('true'), false, 'off is the safe answer to anything else');
+});
+
+// ── what it holds WITH ────────────────────────────────────────────────────
+// The switch stays binary; the character is a separate choice beside it. Silent
+// is the default because silent is what passed on the captain's phone.
+test('silent is the default, and stays the default for anything unrecognised', () => {
+  assert.equal(keepAliveVoice(null), 'silent', 'never chosen');
+  assert.equal(keepAliveVoice(''), 'silent');
+  assert.equal(keepAliveVoice('music'), 'music', 'the one opt-in there is');
+  assert.equal(keepAliveVoice('mozart'), 'silent', 'and anything else falls back to what was tested');
+  assert.deepEqual(KEEPALIVE_VOICES.map((v) => v.key), ['silent', 'music'], 'silent first: it is the default');
+});
+
+test('what is coming out of the element, in one answer', () => {
+  const q = (enabled, speaking, voice) => keepAliveSound({ enabled, speaking, voice });
+  assert.equal(q(false, false, 'music'), 'none', 'off is off, whatever was chosen');
+  assert.equal(q(true, true, 'music'), 'none', 'and speech is speech: the pad is OUT, not ducked');
+  assert.equal(q(true, true, 'silent'), 'none');
+  assert.equal(q(true, false, 'silent'), 'tone', 'holding, inaudibly — the mode that was tested');
+  assert.equal(q(true, false, 'music'), 'music', 'holding, audibly, because he asked for it');
+  assert.equal(q(true, false, undefined), 'tone', 'a page that never chose gets the tone');
+});
+
+// ── the pad ───────────────────────────────────────────────────────────────
+// A pad that drifts and never arrives: five notes that cannot make a leading
+// tone or a dominant between them, over a fifth with no third in it.
+test('the notes are the A minor pentatonic, and the drone under them has no third', () => {
+  assert.deepEqual(PAD_POOL, [220, 261.63, 293.66, 329.63, 392, 440, 523.25, 587.33, 659.25],
+    'A3 C4 D4 E4 G4 A4 C5 D5 E5 — the same tempered values sound.js tunes its bells to');
+  assert.equal(DRONE.length, 2, 'a bare fifth');
+  assert.ok(Math.abs(DRONE[1][0] / DRONE[0][0] - 1.5) < 0.005, 'A2 and the fifth above it, and nothing else');
+  assert.ok(DRONE.every(([, amp]) => amp > 0 && amp < 0.3), 'both under the notes they sit beneath');
+});
+
+test('a note drifts from the one before it: never a repeat, never a leap', () => {
+  for (let i = 0; i < PAD_POOL.length; i++) {
+    const prev = PAD_POOL[i];
+    for (const r of [0, 0.1, 0.5, 0.9, 0.999]) {
+      const next = nextNote(prev, r);
+      assert.ok(PAD_POOL.includes(next), `${next} is in the pool`);
+      assert.notEqual(next, prev, 'the same note twice running is a pulse, not a drift');
+      assert.ok(Math.abs(PAD_POOL.indexOf(next) - i) <= 3, 'and it stays near where it was');
+    }
+  }
+});
+
+test('the first note can be any of them, and r is only ever asked for [0,1)', () => {
+  assert.equal(nextNote(null, 0), PAD_POOL[0], 'nothing to drift from yet: the whole pool');
+  assert.equal(nextNote(null, 0.999), PAD_POOL[PAD_POOL.length - 1]);
+  assert.ok(PAD_POOL.includes(nextNote(null, 1)), 'a stray 1 lands on a note, not off the end');
+  assert.ok(PAD_POOL.includes(nextNote(220, -1)), 'and so does a stray negative');
+});
+
+// Uneven on purpose: a fixed gap is a bar-line, and a bar-line is a pulse.
+test('the spacing is slow and never the same twice', () => {
+  assert.equal(padStep(0), 4.5, 'the closest two notes ever come');
+  assert.equal(padStep(1), 8.5, 'and the furthest');
+  assert.ok(padStep(0.5) > 6 && padStep(0.5) < 7);
+  assert.ok(padStep(0) > 2 * 1.5, 'nothing here is fast enough to be counted along with');
+});
+
+// It is background for two hours, not a notification heard once.
+test('the pad follows the notification volume, and a muted board is silent', () => {
+  assert.equal(padGain(0), 0, 'muted is muted — he did not ask for music, he asked for quiet');
+  assert.equal(padGain(1), PAD_PEAK);
+  assert.equal(padGain(0.5), PAD_PEAK / 2, 'and tracks the slider in between');
+  assert.equal(padGain(2), PAD_PEAK, 'nothing above the top of the slider');
+  assert.equal(padGain(-1), 0);
+  assert.equal(padGain(undefined), 0, 'and no volume at all is not full volume');
+  assert.ok(PAD_PEAK < 0.3 / 3, 'well under a notification tone: this one has to be tolerable for hours');
 });

--- a/test/keepalive.test.js
+++ b/test/keepalive.test.js
@@ -1,0 +1,77 @@
+'use strict';
+// ui/js/keepalive.js — the decision behind holding the audio session open.
+//
+// The captain sends from a locked phone through a Siri Shortcut. The Shortcut
+// takes the audio session and gives back a context that reads 'running' and
+// never makes another sample; iOS only accepts a gesture as the repair, and a
+// locked screen has none to give. The one session observed to survive was the
+// one already PLAYING when the Shortcut arrived — so the answer is a keep-alive
+// that never lets the page be idle, behind a switch, because holding a session
+// open costs battery and a desktop tab has no Shortcut to survive.
+//
+// This file pins WHAT the switch decides. The mechanism it drives — the tone
+// through the element speech leaves through — is pinned in speech.test.js, and
+// the heartbeat it gates in sound.test.js. No DOM and no WebAudio here.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let keepAliveState, corpseWatchRuns, enabledFromStorage;
+test.before(async () => {
+  ({ keepAliveState, corpseWatchRuns, enabledFromStorage } =
+    await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'keepalive.js')).href));
+});
+
+// ── the switch is the whole of the first question ─────────────────────────
+test('off is off: nothing holds the session, whatever else is going on', () => {
+  for (const speaking of [false, true]) {
+    for (const hidden of [false, true]) {
+      assert.equal(keepAliveState({ enabled: false, speaking, hidden }), 'off',
+        `enabled:false speaking:${speaking} hidden:${hidden}`);
+    }
+  }
+  assert.equal(keepAliveState({}), 'off', 'and a page that never asked is off too');
+  assert.equal(keepAliveState(), 'off', 'including one that asks nothing at all');
+});
+
+test('on and quiet: the keep-alive holds — an idle session is the one that dies', () => {
+  assert.equal(keepAliveState({ enabled: true, speaking: false, hidden: false }), 'hold');
+});
+
+// The one property that must not break is that speech sounds exactly as it does
+// today: no ducking, no gap at the start, no clipped first word. So the
+// keep-alive is not "quieter" while the board talks, it is OUT — the element is
+// the speech's alone for as long as there is speech.
+test('on and speaking: the keep-alive yields, it does not mix', () => {
+  assert.equal(keepAliveState({ enabled: true, speaking: true, hidden: false }), 'yield');
+  assert.equal(keepAliveState({ enabled: true, speaking: true, hidden: true }), 'yield',
+    'and a locked screen mid-message is still the speech’s');
+});
+
+// The trap worth a test of its own: standing down on a hidden page would stand
+// down at the exact moment this exists for — screen off, phone in a pocket.
+test('a hidden page changes nothing: hidden is the case this was built for', () => {
+  assert.equal(keepAliveState({ enabled: true, speaking: false, hidden: true }), 'hold',
+    'the screen going off is not a reason to stop holding — it is the reason to hold');
+  assert.equal(
+    keepAliveState({ enabled: true, speaking: false, hidden: true }),
+    keepAliveState({ enabled: true, speaking: false, hidden: false }),
+    'visible and hidden answer the same');
+});
+
+// ── the same switch gates the heartbeat ───────────────────────────────────
+test('the corpse watch runs when the switch is on, and only then', () => {
+  assert.equal(corpseWatchRuns(true), true, 'on: the corpse a Shortcut leaves is found within a beat');
+  assert.equal(corpseWatchRuns(false), false, 'off means NEITHER runs — no tone, no timer');
+  assert.equal(corpseWatchRuns(undefined), false, 'a page that never set it pays nothing');
+});
+
+// ── what comes back across a reload ───────────────────────────────────────
+test('the toggle survives a reload, and anything unrecognised is off', () => {
+  assert.equal(enabledFromStorage('1'), true);
+  assert.equal(enabledFromStorage(null), false, 'never set: off, like every desktop tab');
+  assert.equal(enabledFromStorage(''), false);
+  assert.equal(enabledFromStorage('0'), false);
+  assert.equal(enabledFromStorage('true'), false, 'off is the safe answer to anything else');
+});

--- a/test/pad.test.js
+++ b/test/pad.test.js
@@ -1,0 +1,140 @@
+'use strict';
+// ui/js/pad.js — the music the keep-alive can hold the session with.
+//
+// The decisions it plays (the notes, the spacing, the level) are keepalive.js's
+// and are pinned there. What is pinned HERE is the wiring, and one property in
+// particular: the stream must never go digitally silent, because a stream that
+// goes silent is a session iOS is free to take back — which is the whole reason
+// any of this exists. So: a drone that never stops, notes queued far enough
+// ahead to outlast the timer throttling a locked phone does, and a stop() that
+// leaves nothing behind.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let startPad, DRONE, PAD_POOL;
+
+// A recording AudioContext. Its clock is settable, because "what is queued an
+// hour from now" is a question that has to be asked without waiting an hour.
+class FakeCtx {
+  constructor() { this.clock = 0; this.made = []; }
+  get currentTime() { return this.clock; }
+  createGain() {
+    const g = { kind: 'gain', ramps: [], sets: [], to: null, disconnected: 0,
+      gain: { value: 1,
+        setValueAtTime(v, t) { g.sets.push([v, t]); },
+        linearRampToValueAtTime(v, t) { g.ramps.push(['lin', v, t]); },
+        exponentialRampToValueAtTime(v, t) { g.ramps.push(['exp', v, t]); } },
+      connect(n) { g.to = n; }, disconnect() { g.disconnected++; g.to = null; } };
+    this.made.push(g);
+    return g;
+  }
+  createOscillator() {
+    const o = { kind: 'osc', type: '', frequency: { value: 0 }, to: null,
+      started: null, stopAt: null, stopped: false, onended: null, disconnected: 0,
+      connect(n) { o.to = n; }, disconnect() { o.disconnected++; o.to = null; },
+      start(t) { o.started = t; }, stop(t) { o.stopAt = t; o.stopped = true; } };
+    this.made.push(o);
+    return o;
+  }
+}
+const oscs = (ctx) => ctx.made.filter((n) => n.kind === 'osc');
+
+test.before(async () => {
+  ({ startPad } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'pad.js')).href));
+  ({ DRONE, PAD_POOL } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'keepalive.js')).href));
+});
+
+test('everything goes through the one gain it was given, and nowhere else', () => {
+  const ctx = new FakeCtx();
+  const dest = { kind: 'sink' };
+  const pad = startPad(ctx, dest, 0.055);
+  const out = ctx.made[0];
+  assert.equal(out.to, dest, 'the pad hangs off the sink it was handed — never a second one');
+  assert.equal(out.gain.value, 0.055, 'at the level it was handed');
+  for (const n of ctx.made.slice(1)) {
+    assert.ok(n.to === out || n.to.to === out || n.to === null || n.to.kind === 'gain',
+      'nothing reaches the destination except through that gain');
+  }
+  pad.stop();
+});
+
+// The drone is not decoration: it is what makes the stream continuously
+// non-silent between one note and the next.
+test('the drone starts at once, never stops, and fades in rather than clicking', () => {
+  const ctx = new FakeCtx();
+  const pad = startPad(ctx, {}, 0.055);
+  const drone = oscs(ctx).filter((o) => DRONE.some(([hz]) => Math.abs(o.frequency.value - hz) < 0.01));
+  assert.equal(drone.length, DRONE.length, 'one oscillator per drone voice');
+  for (const o of drone) {
+    assert.equal(o.started, 0, 'started now, not at the first note');
+    assert.equal(o.stopAt, null, 'and never scheduled to stop: the stream is never quiet');
+  }
+  const fades = ctx.made.filter((n) => n.kind === 'gain' && n.ramps.some(([k, v]) => k === 'lin' && v > 0));
+  assert.ok(fades.length >= DRONE.length, 'each comes up from nothing');
+  for (const g of fades.slice(0, DRONE.length)) {
+    assert.equal(g.sets[0][0], 0.0001, 'from silence…');
+    assert.ok(g.ramps[0][2] > 1, '…over seconds, so switching the music on is not a click');
+  }
+  pad.stop();
+});
+
+// iOS starves a locked phone's JS timers, and the top-up runs on a timer. The
+// audio clock is not starved, so what is already queued goes on playing: the
+// queue has to be deep enough to cover a throttled minute.
+test('a minute of music is queued ahead, so a throttled timer is not a gap', () => {
+  const ctx = new FakeCtx();
+  const pad = startPad(ctx, {}, 0.055);
+  const notes = oscs(ctx).filter((o) => o.stopAt !== null);
+  assert.ok(notes.length >= 12, `${notes.length} notes queued up front, not one at a time`);
+  const last = Math.max(...notes.map((o) => o.started));
+  assert.ok(last >= 55, `music scheduled ${last.toFixed(0)}s ahead of the clock`);
+  const first = Math.min(...notes.map((o) => o.started));
+  assert.ok(first > 0 && first < 3, 'and the first one is not an hour away');
+
+  // Every note is one of the pool's, doubled by a detuned twin — and nothing is
+  // ever left sounding forever except the drone.
+  for (const o of notes) {
+    assert.ok(o.stopAt > o.started, 'each note ends');
+    const near = PAD_POOL.some((f) => Math.abs(o.frequency.value / f - 1) < 0.005);
+    assert.ok(near, `${o.frequency.value.toFixed(2)} is a pool note or its twin`);
+  }
+  pad.stop();
+});
+
+test('notes overlap: two or three are always sounding, so there is no seam', () => {
+  const ctx = new FakeCtx();
+  const pad = startPad(ctx, {}, 0.055);
+  const notes = oscs(ctx).filter((o) => o.stopAt !== null).sort((a, b) => a.started - b.started);
+  const at = (t) => notes.filter((o) => o.started <= t && o.stopAt > t).length;
+  for (let t = 15; t < 45; t += 1.5) assert.ok(at(t) >= 2, `nothing sounding at ${t}s`);
+  pad.stop();
+});
+
+test('the volume slider reaches it while it is playing', () => {
+  const ctx = new FakeCtx();
+  const pad = startPad(ctx, {}, 0.055);
+  const out = ctx.made[0];
+  pad.setLevel(0.02);
+  assert.equal(out.gain.value, 0.02, 'live, not at the next note — the slider is being dragged');
+  pad.stop();
+  pad.setLevel(0.05);
+  assert.equal(out.gain.value, 0.02, 'and a stopped pad does not come back to life on a slider move');
+});
+
+// Off is off. A minute of music is queued in the context, and every second of
+// it would go on sounding after the switch was thrown if stop() only stopped
+// the scheduler.
+test('stop() takes back everything that was queued, drone included', () => {
+  const ctx = new FakeCtx();
+  const pad = startPad(ctx, {}, 0.055);
+  ctx.clock = 3;
+  pad.stop();
+  for (const o of oscs(ctx)) {
+    assert.ok(o.stopped, 'every oscillator was stopped, not just the ones already sounding');
+    assert.ok(o.disconnected > 0, 'and disconnected');
+    assert.equal(o.onended, null, 'with nothing left to fire later');
+  }
+  assert.ok(ctx.made[0].disconnected > 0, 'and the pad itself is off the sink');
+});

--- a/test/sound.test.js
+++ b/test/sound.test.js
@@ -11,7 +11,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let play, needsResume, needsRebuild, setVolume;
+let play, needsResume, needsRebuild, setVolume, setCorpseWatch;
 
 // The page's listeners, kept by type so a test can fire a gesture by hand.
 const listeners = { window: {}, document: {} };
@@ -70,9 +70,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 test.before(async () => {
   global.window = { AudioContext: FakeCtx, addEventListener: add(listeners.window), removeEventListener: remove(listeners.window) };
   global.document = { hidden: false, addEventListener: add(listeners.document) };
-  ({ play, needsResume, needsRebuild, setVolume } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'sound.js')).href));
+  ({ play, needsResume, needsRebuild, setVolume, setCorpseWatch } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'sound.js')).href));
 });
-test.beforeEach(() => { resumes = 0; played = 0; if (theCtx) { theCtx.refuse = false; theCtx.state = 'running'; } });
+// The corpse watch is OFF unless the captain's pocket switch turns it on (see
+// keepalive.js), so every test starts from the state a desktop tab is in and
+// the ones about the corpse arm it themselves.
+test.beforeEach(() => { resumes = 0; played = 0; setCorpseWatch(false); if (theCtx) { theCtx.refuse = false; theCtx.state = 'running'; } });
 
 // ── the decision ──────────────────────────────────────────────────────────
 test('the recovery decision covers every state a context can be in', () => {
@@ -175,6 +178,7 @@ test('a healthy context is never replaced, however many gestures land on it', as
 });
 
 test('a dead context is replaced by one with the whole graph and the volume on it', async () => {
+  setCorpseWatch(true);                  // the captain is working from his pocket
   fire('window', 'click');
   await tick();
   setVolume(0.42);
@@ -206,6 +210,7 @@ test('a dead context is replaced by one with the whole graph and the volume on i
 // and calls it alive. One tap is four events inside a tenth of a second, so
 // there is no second chance inside the tap either — the ▶ is simply silent.
 test('the tap after a dictation: the context RAN, then died', async () => {
+  setCorpseWatch(true);                  // the switch is on: this is the phone
   fire('window', 'click');               // first gesture: the context is made
   await tick();
   const corpse = theCtx;
@@ -229,4 +234,73 @@ test('the tap after a dictation: the context RAN, then died', async () => {
   assert.equal(built, 1, 'the tap should have replaced the corpse');
   assert.notEqual(theCtx, corpse, 'and played into the new context');
   assert.ok(played > 0, 'so the ▶ was heard, on the FIRST tap');
+});
+
+// ── the switch ────────────────────────────────────────────────────────────
+// The watch beat for the life of every page — a timer on a page that is nearly
+// always fine, and battery on a phone. It is the captain's switch now (see
+// keepalive.js): on when he is working from his pocket, off everywhere else.
+test('with the switch off nothing beats, and the page behaves as it always did', async () => {
+  setCorpseWatch(false);
+  fire('window', 'click');
+  await tick();
+  const c = theCtx;
+  await sleep(300);
+  c.freeze();                            // a corpse nobody is watching for
+  await sleep(1200);                     // several beats' worth, if any were beating
+  built = 0; played = 0;
+  fire('window', 'click');
+  play('ding');
+  await tick();
+  assert.equal(built, 0, 'no verdict was reached, so no context was replaced');
+  assert.equal(theCtx, c, 'the same context a page without any of this would have');
+
+  // Everything the switch does NOT gate is still there: a screen lock parks the
+  // context in 'interrupted', and the next gesture still wakes it.
+  theCtx.state = 'interrupted'; resumes = 0;
+  fire('window', 'click');
+  await tick();
+  assert.equal(resumes, 1, 'the gesture path is untouched');
+  assert.equal(theCtx.state, 'running');
+});
+
+// Turning it on mid-page must not convict the context of a death that happened
+// while nobody was watching: the first verdict has to come from a window the
+// watch was actually awake for.
+test('turning the switch on starts a fresh window, not a verdict about the past', async () => {
+  setCorpseWatch(false);
+  fire('window', 'click');
+  await tick();
+  const c = theCtx;
+  await sleep(400);                      // time passes unwatched
+  setCorpseWatch(true);
+  built = 0;
+  fire('window', 'click');               // the very next gesture
+  await tick();
+  assert.equal(built, 0, 'a living context is not replaced on the strength of a gap');
+  assert.equal(theCtx, c);
+
+  c.freeze();                            // and now it really dies
+  await sleep(1200);
+  fire('window', 'click');
+  await tick();
+  assert.equal(built, 1, 'which the watch, now awake, does catch');
+  setCorpseWatch(false);
+});
+
+// Off has to mean OFF: not a paused timer, not a verdict left standing from
+// when it was on. Otherwise turning it off leaves residue behind it.
+test('turning the switch off drops the verdict it was holding', async () => {
+  setCorpseWatch(true);
+  fire('window', 'click');
+  await tick();
+  const c = theCtx;
+  c.freeze();
+  await sleep(1200);                     // the watch has decided: this one is dead
+  setCorpseWatch(false);                 // …and the captain turns it off
+  built = 0;
+  fire('window', 'click');
+  await tick();
+  assert.equal(built, 0, 'no timer beating and no corpse verdict left behind');
+  assert.equal(theCtx, c);
 });

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -529,6 +529,46 @@ test('a refused start lets go, so the next gesture can take it', async () => {
   hold(false);
 });
 
+// What holds the session is the caller's to choose — "the session must never go
+// quiet" is this module's business, "what quiet sounds like" is the board's. The
+// board hands over an ambient pad when the captain wants one (ui/js/pad.js).
+test('the caller can say what holds the session, and swapping it never leaves a gap', async () => {
+  await tick(10);
+  oscs.length = 0;
+  const made = [];
+  const src = (name) => (ctx, dest) => {
+    const it = { name, dest, stopped: false, stop() { it.stopped = true; } };
+    made.push(it);
+    return it;
+  };
+  const music = src('music'), other = src('other');
+
+  hold(true, music);
+  assert.equal(made.length, 1, 'the source was asked for exactly one thing to play');
+  assert.equal(made[0].dest, nodes.msd, 'and it plays into the element’s stream, like everything else here');
+  assert.equal(oscs.length, 0, 'the module’s own tone stayed out of the way');
+  assert.ok(!sinkEl.paused, 'the element is playing, which is the point of all of it');
+
+  hold(true, music);                   // the gesture primer, over and over
+  assert.equal(made.length, 1, 'the same source handed over again changes nothing');
+  assert.equal(made[0].stopped, false);
+
+  hold(true, other);                   // the captain picks another
+  assert.equal(made.length, 2, 'a different one takes over');
+  assert.ok(made[0].stopped, 'and the one before it was stopped');
+  assert.ok(!sinkEl.paused, 'without the element ever going quiet in between');
+
+  hold(false);
+  assert.ok(made[1].stopped, 'off stops it');
+  assert.ok(sinkEl.paused, 'and lets the element go, exactly as the tone does');
+
+  // …and with no source at all it is the module's own tone again.
+  hold(true);
+  assert.equal(made.length, 2, 'nobody else was asked');
+  assert.equal(humming().length, 1, 'the inaudible tone is back — this is what ?hum=loud makes audible');
+  hold(false);
+});
+
 // A page that never turns it on is the page that is on main today: every other
 // test in this file runs with the switch off, and this one says so out loud.
 test('a page that never asks for it never plays anything of its own', async () => {

--- a/test/speech.test.js
+++ b/test/speech.test.js
@@ -13,7 +13,7 @@ const assert = require('node:assert');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');
 
-let speak, stop, pause, resume;
+let speak, stop, pause, resume, hold, holding;
 
 const tick = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -72,6 +72,8 @@ function fakePage() {
 // `scheduled` is emptied between tests rather than the context being rebuilt.
 const scheduled = [];
 const nodes = {};
+const oscs = [];                                   // every keep-alive source ever started
+const humming = () => oscs.filter((o) => o.started && !o.stopped);
 let theCtx = null, built = 0;
 class FakeCtx {
   constructor() { this.state = 'running'; this.clock = 0; nodes.destination = this.destination = {}; theCtx = this; built++; }
@@ -84,6 +86,18 @@ class FakeCtx {
   close() { this.state = 'closed'; return Promise.resolve(); }
   suspend() { this.state = 'suspended'; return Promise.resolve(); }
   createMediaStreamDestination() { return (nodes.msd = { stream: { id: 'live' } }); }
+  // The keep-alive's two nodes. They record enough to answer the only questions
+  // asked of them: is something actually RUNNING (a stopped source holds no
+  // session), at what level (a muted one holds none either), and into what.
+  createOscillator() {
+    const o = { frequency: { value: 0 }, connect(n) { o.to = n; }, disconnect() { o.to = null; },
+      start() { o.started = true; oscs.push(o); }, stop() { o.stopped = true; } };
+    return o;
+  }
+  createGain() {
+    const g = { gain: { value: 1 }, connect(n) { g.to = n; }, disconnect() { g.to = null; } };
+    return g;
+  }
   createBuffer(ch, len, rate) {
     const data = new Float32Array(len);
     return { length: len, duration: len / rate, getChannelData: () => data };
@@ -155,7 +169,7 @@ test.before(async () => {
   global.MediaMetadata = function (m) { Object.assign(this, m); };
   global.window = { AudioContext: FakeCtx, MediaMetadata: global.MediaMetadata };
   fakePage();
-  ({ speak, stop, pause, resume } =
+  ({ speak, stop, pause, resume, hold, holding } =
     await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'speech.js')).href));
 });
 test.beforeEach(() => { scheduled.length = 0; fakePage(); });
@@ -420,6 +434,112 @@ test('a message after a dictation replaces the context, sink and element with it
   assert.ok(sinkEl.plays >= 1, 'and played again — the interruption paused it too');
   assert.ok(scheduled.length, 'the second message was heard');
   for (const s of scheduled) assert.equal(s.to, nodes.msd, 'through the new sink');
+});
+
+// ── holding the session open ──────────────────────────────────────────────
+// The Shortcut takes the audio session from a locked phone and hands back a
+// context that never makes another sample; iOS wants a gesture to repair it and
+// a locked screen has none. The session that survived was the one already
+// PLAYING when the Shortcut arrived, so hold() keeps this element playing — the
+// same element, never a second one competing with it, because that element is
+// the only reason the page is alive with the screen off at all.
+test('holding plays: the same element, a live stream, and a source actually running', async () => {
+  await tick(10);                      // let the previous test's last buffer finish
+  oscs.length = 0;
+  hold(true);
+  assert.equal(holding(), true);
+  assert.equal(sinkEl.srcObject, nodes.msd.stream, 'the element speech leaves through, fed the same way');
+  assert.ok(!sinkEl.paused, 'genuinely playing — a paused element is not playback to the OS');
+  const on = humming();
+  assert.equal(on.length, 1, 'exactly one source is holding the session');
+  assert.equal(on[0].to.to, nodes.msd, 'and it reaches the element’s stream, not the bare speakers');
+  assert.ok(on[0].to.gain.value > 0, 'at a level above zero — a muted source buys nothing');
+  assert.ok(on[0].to.gain.value < 0.01, 'and far below anything audible');
+  hold(false);
+});
+
+// The one property that is not negotiable: speech sounds exactly as it does
+// today. Nothing races it for the element, nothing is mixed under it, and the
+// element is never paused between the tone and the first word.
+test('speech takes the element back, and the keep-alive is silent for the whole message', async () => {
+  await tick(10);
+  oscs.length = 0;
+  hold(true);
+  const humBefore = humming()[0];
+  fakeFetch((b, sig) => openStream(sig));
+  const done = speak({ ...ASK, input: 'olá', title: 'Ana' });
+  await tick(10);
+  assert.ok(humBefore.stopped, 'the tone stopped before the first buffer was queued');
+  assert.equal(humming().length, 0, 'nothing of the keep-alive is left running under the speech');
+  assert.ok(!sinkEl.paused, 'and the element never paused in between — no gap, no clipped first word');
+  for (const s of scheduled) assert.equal(s.to, nodes.msd, 'every buffer still goes through the element');
+
+  stop();
+  await done;
+  assert.equal(bar.hidden, true, 'the transport goes away when the speech is over…');
+  assert.ok(!sinkEl.paused, '…but the element keeps playing: the session is still his');
+  assert.equal(humming().length, 1, 'and the tone is back holding it');
+  hold(false);
+});
+
+// Turning it off has to leave NOTHING behind: not a source still running, not an
+// element still playing, not a stream still held.
+test('turning it off leaves no residue', async () => {
+  await tick(10);
+  oscs.length = 0;
+  hold(true);
+  const on = humming()[0];
+  hold(false);
+  assert.equal(holding(), false);
+  assert.ok(on.stopped, 'the source was stopped');
+  assert.equal(on.to, null, 'and disconnected — not left hanging off the graph');
+  assert.equal(humming().length, 0);
+  assert.ok(sinkEl.paused, 'the element is not playing on its own account any more');
+  assert.equal(sinkEl.srcObject, null, 'and holds no stream');
+
+  // And the page is the page it always was: the next message re-arms the
+  // element and lets it go at the end, exactly as it does with the switch off.
+  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
+  const fed = sinkEl.fed;
+  await speak({ ...ASK, input: 'olá', title: 'Ana' });
+  await tick(10);
+  assert.ok(sinkEl.fed > fed, 're-armed for the message');
+  assert.equal(sinkEl.srcObject, null, 'and let go of at the end, the way it always was');
+  assert.ok(sinkEl.paused);
+  assert.equal(humming().length, 0, 'nothing started itself back up');
+});
+
+// The switch comes back on at page load with no gesture behind it, and iOS
+// wants one. A refused start must leave nothing standing — a tone into an
+// element that is not playing holds nothing open, and a keep-alive that
+// believes it is running is one no later gesture would ever retry.
+test('a refused start lets go, so the next gesture can take it', async () => {
+  await tick(10);
+  oscs.length = 0;
+  sinkEl.refuse = true;                  // the page just loaded; nothing has been tapped
+  hold(true);
+  await tick(10);
+  assert.equal(humming().length, 0, 'it did not go on believing it holds the session');
+  assert.equal(holding(), true, 'but the switch is still on — it is armed, not off');
+
+  sinkEl.refuse = false;                 // the captain taps the board
+  hold(true);                            // (keepalivesettings.js re-calls it on any gesture)
+  assert.equal(humming().length, 1, 'and this time it took');
+  assert.ok(!sinkEl.paused);
+  hold(false);
+});
+
+// A page that never turns it on is the page that is on main today: every other
+// test in this file runs with the switch off, and this one says so out loud.
+test('a page that never asks for it never plays anything of its own', async () => {
+  await tick(10);
+  oscs.length = 0;
+  assert.equal(holding(), false, 'off by default — a desktop tab pays nothing');
+  fakeFetch(() => pcmResponse([0, 100, -100, 0], 4, 24000));
+  await speak({ ...ASK, input: 'olá', title: 'Ana' });
+  await tick(10);
+  assert.equal(oscs.length, 0, 'no keep-alive source was ever made');
+  assert.ok(sinkEl.paused, 'and the element is paused between messages, as it always has been');
 });
 
 // LAST, deliberately: a refusal is remembered for the life of the page, so every

--- a/ui/app.css
+++ b/ui/app.css
@@ -534,6 +534,12 @@ body.resizing { user-select: none; cursor: col-resize; }
 #voice-select:hover, #voice-test:hover { border-color: var(--accent2); color: var(--accent); }
 #ka-btn { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
 #ka-btn.on { color: var(--accent); border-color: var(--accent2); }
+#ka-voice {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 7px; color: var(--dim);
+  font-size: 12px; padding: 3px 6px; cursor: pointer; outline: none; transition: opacity .2s;
+}
+#ka-voice.dim { opacity: .5; }
+#ka-voice:hover { border-color: var(--accent2); color: var(--accent); }
 #ns-body { display: flex; flex-direction: column; gap: 8px; transition: opacity .2s; }
 #ns-body.dim { opacity: .5; }
 #ns-master-btn { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }

--- a/ui/app.css
+++ b/ui/app.css
@@ -532,6 +532,8 @@ body.resizing { user-select: none; cursor: col-resize; }
 }
 #voice-test { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 8px; font-size: 12px; }
 #voice-select:hover, #voice-test:hover { border-color: var(--accent2); color: var(--accent); }
+#ka-btn { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#ka-btn.on { color: var(--accent); border-color: var(--accent2); }
 #ns-body { display: flex; flex-direction: column; gap: 8px; transition: opacity .2s; }
 #ns-body.dim { opacity: .5; }
 #ns-master-btn { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -80,6 +80,7 @@
   <div class="sp-title">pocket</div>
   <div class="sp-row">
     <button id="ka-btn" title="keep audio alive with the screen off — for talking to the board from a locked phone; costs battery">🎧 off</button>
+    <select id="ka-voice" title="what plays while the session is held: an inaudible tone, or a slow ambient pad"></select>
   </div>
   <div class="sp-title">notifications</div>
   <div id="ns-body">

--- a/ui/index.html
+++ b/ui/index.html
@@ -72,6 +72,15 @@
       <button id="voice-test" title="test the selected voice">▶</button>
     </span>
   </div>
+  <!-- the phone-in-a-pocket switch: holds the audio session open (an inaudible
+       tone through the same element the speech leaves through) so a reply still
+       plays after a Siri Shortcut has taken the microphone from a locked
+       screen, and arms the corpse watch that catches the context it kills.
+       Off by default: it costs battery and a desktop tab needs none of it. -->
+  <div class="sp-title">pocket</div>
+  <div class="sp-row">
+    <button id="ka-btn" title="keep audio alive with the screen off — for talking to the board from a locked phone; costs battery">🎧 off</button>
+  </div>
   <div class="sp-title">notifications</div>
   <div id="ns-body">
     <div class="sp-row">

--- a/ui/js/keepalive.js
+++ b/ui/js/keepalive.js
@@ -49,3 +49,71 @@ export function corpseWatchRuns(enabled) {
 export function enabledFromStorage(raw) {
   return raw === '1';
 }
+
+/* ── what it sounds like ──────────────────────────────────────────────────
+   The switch stays binary — held or not — and the CHARACTER of the holding is a
+   separate choice beside it. Silent is the default and always will be: it is
+   what was tested on the captain's phone, and it is what a desktop tab should
+   get if it ever turns this on at all. The music is the opt-in, for the hours
+   the phone spends in a pocket: "não precisa ser zumbido, a gente pode colocar
+   uma musiquinha agradável". */
+export const KEEPALIVE_VOICES = [
+  { key: 'silent', label: 'silent' },
+  { key: 'music', label: 'music' },
+];
+export function keepAliveVoice(raw) {
+  return raw === 'music' ? 'music' : 'silent';
+}
+
+// The whole question in one place: what should be coming out of the element
+// right now. 'none' is the element not playing on the keep-alive's account at
+// all — either the switch is off, or the speech has it and the keep-alive is
+// out of the way, which are different reasons for the same silence.
+export function keepAliveSound({ enabled, speaking, voice } = {}) {
+  if (keepAliveState({ enabled, speaking }) !== 'hold') return 'none';
+  return keepAliveVoice(voice) === 'music' ? 'music' : 'tone';
+}
+
+/* ── the pad ──────────────────────────────────────────────────────────────
+   A pad, not a loop: it drifts and never arrives. The notes are the A minor
+   pentatonic — A C D E G, the five that cannot make a leading tone or a
+   dominant between them, so nothing in here ever asks to resolve — taken from
+   the same tempered values sound.js tunes its bells to, across A3 to E5. Under
+   them sits a bare fifth on A2, held for as long as the pad is: a third would
+   commit the music to major or minor, and it never does.
+
+   The drone is not decoration. It is what makes the stream continuously
+   non-silent between one note and the next, and continuously non-silent is the
+   whole reason any of this exists. */
+export const PAD_POOL = [220, 261.63, 293.66, 329.63, 392, 440, 523.25, 587.33, 659.25];
+//                        A3     C4      D4      E4     G4   A4    C5      D5      E5
+export const DRONE = [[110, 0.22], [164.81, 0.11]];   // A2 and the fifth above it, E3
+
+// The next note drifts from the one before: somewhere within three steps of it,
+// and never itself, so the line wanders instead of leaping about. `r` is a
+// number in [0, 1) — the caller's randomness, kept out here so the choice is a
+// pure function that can be asked the same question twice.
+export function nextNote(prev, r) {
+  const i = PAD_POOL.indexOf(prev);
+  const pool = i < 0 ? PAD_POOL : PAD_POOL.filter((_, j) => j !== i && Math.abs(j - i) <= 3);
+  const at = Math.floor(Math.max(0, Math.min(0.999999, r)) * pool.length);
+  return pool[at];
+}
+
+// Seconds until the next note starts. Long enough that two or three notes are
+// always sounding together over the drone, uneven enough that no bar-line ever
+// appears — a pulse is the one thing an ambient pad must not grow.
+export function padStep(r) {
+  return 4.5 + Math.max(0, Math.min(1, r)) * 4;
+}
+
+// The pad follows the notification volume, the way every tone in sound.js does.
+// It sits well under them: a notification is meant to be noticed once, and this
+// is meant to be tolerated for two hours. A master volume of zero is silence
+// here too — the captain who muted the board did not ask for music.
+export const PAD_PEAK = 0.055;
+export function padGain(volume) {
+  const v = Number(volume);
+  if (!(v > 0)) return 0;
+  return Math.min(1, v) * PAD_PEAK;
+}

--- a/ui/js/keepalive.js
+++ b/ui/js/keepalive.js
@@ -1,0 +1,51 @@
+// keepalive.js — what the audio keep-alive should be doing, and when.
+//
+// The captain talks to the board from a locked phone through a Siri Shortcut.
+// The Shortcut takes the audio session; what it hands back is an AudioContext
+// that reads 'running' and never produces another sample, and the only repair
+// iOS accepts is a user gesture — which a locked screen cannot give. The one
+// session that survives is the one that was PLAYING when the Shortcut arrived:
+// he heard the next reply exactly once, by sending while the previous one was
+// still speaking.
+//
+// So the cure is to never be idle. This module holds only the decision — no
+// DOM, no WebAudio — the way notifypolicy.js holds the notification decision:
+// speech.js owns the element the tone leaves through (hold()), sound.js owns
+// the corpse watch (setCorpseWatch()), and keepalivesettings.js is the switch
+// that drives both from here.
+//
+// It is a switch and not a heuristic on purpose. Holding a session open costs
+// battery and puts a player on the lock screen for as long as it runs, and a
+// desktop tab — which no Shortcut ever interrupts — has no reason to pay it.
+
+// The three states the keep-alive can be in:
+//   'off'   nothing playing, nothing beating: the page behaves as it always has
+//   'hold'  the inaudible tone is playing, and the session is his to keep
+//   'yield' there is real speech; the keep-alive is silent and out of its way
+//
+// `hidden` is an argument and changes NOTHING, deliberately: a hidden page is
+// precisely the case this exists for (screen off, phone in a pocket), so
+// standing down when the page goes away would stand down at the only moment
+// that matters. It is named here so that stays a decision rather than an
+// oversight.
+export function keepAliveState({ enabled, speaking, hidden } = {}) {
+  if (!enabled) return 'off';
+  if (speaking) return 'yield';
+  return 'hold';
+}
+
+// The same switch gates the corpse watch in sound.js — the heartbeat that asks
+// every 500ms whether the notification context's clock is still moving. It was
+// written for this phone and this Shortcut, and its own comment says so: on a
+// page that is nearly always fine it is a timer beating for the life of the
+// page, and on a phone it is battery. Off means neither this nor the tone runs.
+export function corpseWatchRuns(enabled) {
+  return enabled === true;
+}
+
+// Persisted the way voice.js persists its toggle: the key is present or it is
+// not. Anything else that ever ends up in that slot is off — the safe answer,
+// since off is what every page that never asked for this gets.
+export function enabledFromStorage(raw) {
+  return raw === '1';
+}

--- a/ui/js/keepalivesettings.js
+++ b/ui/js/keepalivesettings.js
@@ -1,0 +1,46 @@
+// keepalivesettings.js — the switch behind ui/js/keepalive.js: the settings
+// toggle, its persistence, and the two things it drives.
+//
+// The decision lives in keepalive.js and is tested there without a browser;
+// this file is the wiring, the way notifysettings.js is the wiring under
+// notifypolicy.js. Two consumers, one switch:
+//   · speech.js hold()          — the inaudible tone that keeps the audio
+//                                 session alive through a Siri Shortcut, played
+//                                 through the same element the speech leaves
+//                                 through (never a second one).
+//   · sound.js setCorpseWatch() — the 500ms heartbeat that catches the context
+//                                 the Shortcut leaves for dead.
+// Off by default, and off means neither runs.
+import { hold } from './speech.js';
+import { setCorpseWatch } from './sound.js';
+import { corpseWatchRuns, enabledFromStorage } from './keepalive.js';
+
+const KEY = 'bc-audio-keepalive';
+const btn = document.getElementById('ka-btn');
+
+let on = false;
+
+function apply() {
+  btn.classList.toggle('on', on);
+  btn.textContent = on ? '🎧 on' : '🎧 off';
+  setCorpseWatch(corpseWatchRuns(on));
+  hold(on);
+}
+
+function set(next, persist) {
+  on = !!next;
+  if (persist) { try { on ? localStorage.setItem(KEY, '1') : localStorage.removeItem(KEY); } catch (e) {} }
+  apply();
+}
+
+btn.onclick = () => set(!on, true);
+
+// Restoring it across a reload is only half a restore: iOS wants a gesture
+// behind the element's first play(), and a page that has just loaded has none.
+// So the switch comes back on immediately (the heartbeat needs no permission)
+// and the tone starts on the first gesture that lands anywhere on the page —
+// the same capture-phase primer sound.js and speech.js already use. hold() is
+// re-called rather than toggled: it is a no-op once the tone is running.
+try { if (enabledFromStorage(localStorage.getItem(KEY))) set(true, false); } catch (e) {}
+for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart'])
+  window.addEventListener(ev, () => { if (on) hold(true); }, { capture: true, passive: true });

--- a/ui/js/keepalivesettings.js
+++ b/ui/js/keepalivesettings.js
@@ -1,30 +1,48 @@
 // keepalivesettings.js — the switch behind ui/js/keepalive.js: the settings
-// toggle, its persistence, and the two things it drives.
+// toggle, the choice of what it holds with, their persistence, and the wiring.
 //
 // The decision lives in keepalive.js and is tested there without a browser;
 // this file is the wiring, the way notifysettings.js is the wiring under
-// notifypolicy.js. Two consumers, one switch:
-//   · speech.js hold()          — the inaudible tone that keeps the audio
-//                                 session alive through a Siri Shortcut, played
-//                                 through the same element the speech leaves
-//                                 through (never a second one).
+// notifypolicy.js. Three consumers, one switch:
+//   · speech.js hold()          — keeps the audio session alive through a Siri
+//                                 Shortcut by never letting the element go
+//                                 quiet, through the same element the speech
+//                                 leaves through (never a second one).
+//   · pad.js startPad()         — what it holds WITH, when the captain wants
+//                                 music instead of the inaudible tone.
 //   · sound.js setCorpseWatch() — the 500ms heartbeat that catches the context
 //                                 the Shortcut leaves for dead.
-// Off by default, and off means neither runs.
+// Off by default, and off means none of them run.
 import { hold } from './speech.js';
-import { setCorpseWatch } from './sound.js';
-import { corpseWatchRuns, enabledFromStorage } from './keepalive.js';
+import { setCorpseWatch, getVolume, onVolume } from './sound.js';
+import { startPad } from './pad.js';
+import { KEEPALIVE_VOICES, corpseWatchRuns, enabledFromStorage, keepAliveVoice, padGain } from './keepalive.js';
 
 const KEY = 'bc-audio-keepalive';
+const VOICE_KEY = 'bc-audio-keepalive-voice';
 const btn = document.getElementById('ka-btn');
+const sel = document.getElementById('ka-voice');
 
 let on = false;
+let voice = 'silent';
+let pad = null;                 // the pad while it is playing, for the volume slider
+
+// hold() compares sources by identity, so this is built ONCE per voice: the
+// gesture primer below hands the same function over on every tap, and handing
+// the same one over means nothing changes. Only a real change of voice swaps
+// what is playing. `silent` is not a source at all — it is speech.js's own
+// inaudible tone, which is what ?hum=loud makes audible.
+const music = (ctx, dest) => (pad = startPad(ctx, dest, padGain(getVolume())));
+const sourceFor = (v) => (v === 'music' ? music : null);
 
 function apply() {
   btn.classList.toggle('on', on);
   btn.textContent = on ? '🎧 on' : '🎧 off';
+  sel.classList.toggle('dim', !on);
+  sel.value = voice;
   setCorpseWatch(corpseWatchRuns(on));
-  hold(on);
+  hold(on, sourceFor(voice));
+  if (!on) pad = null;
 }
 
 function set(next, persist) {
@@ -33,14 +51,32 @@ function set(next, persist) {
   apply();
 }
 
+for (const v of KEEPALIVE_VOICES) {
+  const o = document.createElement('option');
+  o.value = v.key;
+  o.textContent = v.label;
+  sel.appendChild(o);
+}
 btn.onclick = () => set(!on, true);
+sel.onchange = () => {
+  voice = keepAliveVoice(sel.value);
+  try { voice === 'silent' ? localStorage.removeItem(VOICE_KEY) : localStorage.setItem(VOICE_KEY, voice); } catch (e) {}
+  apply();                      // held already → hold() swaps the source under it
+};
+// The pad is one long sound, so it follows the slider while it is being
+// dragged instead of at the next note. A stopped pad ignores this.
+onVolume((v) => { if (pad) pad.setLevel(padGain(v)); });
 
-// Restoring it across a reload is only half a restore: iOS wants a gesture
-// behind the element's first play(), and a page that has just loaded has none.
-// So the switch comes back on immediately (the heartbeat needs no permission)
-// and the tone starts on the first gesture that lands anywhere on the page —
-// the same capture-phase primer sound.js and speech.js already use. hold() is
-// re-called rather than toggled: it is a no-op once the tone is running.
+// Restoring across a reload is only half a restore: iOS wants a gesture behind
+// the element's first play(), and a page that has just loaded has none. So the
+// switch comes back on immediately (the heartbeat needs no permission) and what
+// holds the session starts on the first gesture that lands anywhere on the page
+// — the same capture-phase primer sound.js and speech.js already use. hold() is
+// re-called rather than toggled: with the same source it is a no-op once
+// something is already playing.
+try { voice = keepAliveVoice(localStorage.getItem(VOICE_KEY)); } catch (e) {}
 try { if (enabledFromStorage(localStorage.getItem(KEY))) set(true, false); } catch (e) {}
+sel.value = voice;
+sel.classList.toggle('dim', !on);
 for (const ev of ['click', 'keydown', 'pointerdown', 'touchstart'])
-  window.addEventListener(ev, () => { if (on) hold(true); }, { capture: true, passive: true });
+  window.addEventListener(ev, () => { if (on) hold(true, sourceFor(voice)); }, { capture: true, passive: true });

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -20,6 +20,7 @@ import { openMonitor, closeMonitor, monitorOpen } from './monitor.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import './resize.js'; // draggable side-panel widths
+import './keepalivesettings.js'; // the pocket switch: hold the audio session open
 
 chatOnOpenCard(openDetail);
 // a notification is about a conversation — clicking it lands IN the chat,

--- a/ui/js/pad.js
+++ b/ui/js/pad.js
@@ -1,0 +1,112 @@
+// pad.js — the music the keep-alive can hold the audio session with.
+//
+// Synthesised, not a file: oscillators and gain envelopes, the same discipline
+// sound.js builds every notification tone with, so nothing is fetched and
+// nothing is added to the page weight. What it plays is decided in
+// keepalive.js — the notes, the spacing, the level — and this file is only the
+// wiring that turns those decisions into sound.
+//
+// It renders into speech.js's context and speech.js's sink, because there is
+// exactly one element the session survives a locked screen through and this is
+// not allowed to be a second one. So it takes both as arguments and owns
+// neither: startPad(ctx, destination, level) → { setLevel, stop }.
+//
+// Two hours in a pocket is the design brief. Everything here follows from it:
+// long attacks and long releases so nothing ever starts or stops abruptly, a
+// drone underneath so the stream is never digitally silent between notes, and
+// notes scheduled far ahead of time — iOS throttles JS timers on a locked
+// phone, but the audio clock is not throttled, so a minute of music queued into
+// the context goes on playing while the page's timers are being starved.
+import { DRONE, nextNote, padStep } from './keepalive.js';
+
+const ATTACK = 3.5;        // seconds — a note arrives rather than begins
+const SUSTAIN = 2.5;
+const RELEASE = 5.5;       // …and leaves the same way
+const LIFE = ATTACK + SUSTAIN + RELEASE;
+const DETUNE = 1.003;      // the second oscillator of a note, ~5 cents sharp:
+                           // the slow beating between the two is the shimmer
+const VOICES = [[1, 0.5], [DETUNE, 0.35]];   // [ratio, peak]
+const DRONE_FADE = 6;      // seconds to bring the drone up from nothing
+const AHEAD = 60;          // seconds of music kept queued in the context
+const TOP_UP_MS = 15000;   // …topped up this often, while the timers still run
+
+export function startPad(ctx, destination, level) {
+  const out = ctx.createGain();
+  out.gain.value = level;
+  out.connect(destination);
+
+  let stopped = false;
+  const running = [];        // {osc, gain, end} — everything still to be stopped
+
+  function voice(t0, freq, peak, end) {
+    const osc = ctx.createOscillator(), gain = ctx.createGain();
+    osc.type = 'sine';
+    osc.frequency.value = freq;
+    osc.connect(gain); gain.connect(out);
+    running.push({ osc, gain, end });
+    return { osc, gain };
+  }
+
+  // The drone: a bare fifth, started once and never released. It fades in from
+  // nothing so switching the music on is never a click.
+  const t = ctx.currentTime;
+  for (const [hz, amp] of DRONE) {
+    const { osc, gain } = voice(t, hz, amp, Infinity);
+    gain.gain.setValueAtTime(0.0001, t);
+    gain.gain.linearRampToValueAtTime(amp, t + DRONE_FADE);
+    osc.start(t);
+  }
+
+  // The notes over it, two detuned sines each, in and out of nothing.
+  function note(t0, freq) {
+    for (const [ratio, peak] of VOICES) {
+      const { osc, gain } = voice(t0, freq * ratio, peak, t0 + LIFE);
+      gain.gain.setValueAtTime(0.0001, t0);
+      gain.gain.linearRampToValueAtTime(peak, t0 + ATTACK);
+      gain.gain.setValueAtTime(peak, t0 + ATTACK + SUSTAIN);
+      gain.gain.exponentialRampToValueAtTime(0.0001, t0 + LIFE);
+      osc.start(t0);
+      osc.stop(t0 + LIFE + 0.05);
+      osc.onended = () => { try { gain.disconnect(); } catch (e) {} };
+    }
+  }
+
+  let prev = null, at = ctx.currentTime + 1.5;
+  function fill() {
+    if (stopped) return;
+    const until = ctx.currentTime + AHEAD;
+    while (at < until) {
+      prev = nextNote(prev, Math.random());
+      note(at, prev);
+      at += padStep(Math.random());
+    }
+    // Two hours is around a thousand notes; the ones that have finished are not
+    // this pad's to hold on to.
+    for (let i = running.length - 1; i >= 0; i--) {
+      if (running[i].end < ctx.currentTime) running.splice(i, 1);
+    }
+  }
+  fill();
+  const timer = setInterval(fill, TOP_UP_MS);
+  timer?.unref?.();          // a timer is no reason to hold a process open
+
+  return {
+    // The notification volume moved: the pad follows it live rather than at the
+    // next note, because the slider is being dragged while it is playing.
+    setLevel(v) { if (!stopped) out.gain.value = v; },
+    // Off is off: every oscillator stopped, the whole pad disconnected. What is
+    // already queued in the context would otherwise go on sounding for a minute
+    // after the switch was thrown.
+    stop() {
+      stopped = true;
+      clearInterval(timer);
+      for (const { osc, gain } of running) {
+        osc.onended = null;
+        try { osc.stop(); } catch (e) {}
+        try { osc.disconnect(); gain.disconnect(); } catch (e) {}
+      }
+      running.length = 0;
+      try { out.disconnect(); } catch (e) {}
+    },
+  };
+}

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -102,9 +102,18 @@ function liveCtx() {
   ctx = master = comp = null;
   return ensureCtx();
 }
+// The notification volume, and who else it governs. Every tone here reads it
+// through `master` at the moment it plays, so a tone needs no telling — but the
+// keep-alive pad (keepalive.js, pad.js) is one long sound in ANOTHER context's
+// graph, playing while the slider is being dragged, and it has to follow the
+// slider live rather than at the next note.
+const watchers = [];
+export const getVolume = () => volume;
+export function onVolume(fn) { watchers.push(fn); }
 export function setVolume(v) {
   volume = Math.max(0, Math.min(1, Number(v)));
   if (master) master.gain.value = volume;
+  for (const fn of watchers) { try { fn(volume); } catch (e) {} }
 }
 // one voice: oscillator through an attack/decay gain envelope, optional pitch glide
 function voice(t0, { freq, freqTo, type = 'sine', dur = 0.3, peak = 0.3, attack = 0.006 }) {

--- a/ui/js/sound.js
+++ b/ui/js/sound.js
@@ -34,28 +34,43 @@ export const needsRebuild = (state, ctxAdvance, realMs) =>
 // more than one beat old. Beats only ever set the verdict — the replacement
 // itself waits for a gesture, because iOS wants one to start the new context.
 const BEAT_MS = 500;
-let lastTime = 0, lastWall = 0, dead = false;
+let lastTime = 0, lastWall = 0, dead = false, watch = null;
 function beat() {
-  if (!ctx) return;
+  if (!ctx || !watch) return;
   const wall = performance.now();
   dead = needsRebuild(ctx.state, ctx.currentTime - lastTime, wall - lastWall);
   lastTime = ctx.currentTime; lastWall = wall;
 }
-setInterval(beat, BEAT_MS)?.unref?.();   // a timer is no reason to hold a process open
 
-// KNOWN HACK, kept on purpose. This beats for the life of the page, on a page
-// that is nearly always fine, and on a phone that costs battery. The obvious
-// cure — arm the watch on the moments that could take the audio session, disarm
-// it once the clock is seen keeping up — was built and REVERTED: it dropped the
-// hidden media element around the moment the screen locks, and that element is
-// the only reason iOS keeps this page alive with the screen off. Speech stopped
-// mid-sentence on lock and resumed on unlock, which is a far worse bug than a
-// timer. See the revert of cb2622e for what was tried.
+// The switch this watch was always waiting for. It used to beat for the life of
+// every page, on a page that is nearly always fine and on a phone where it costs
+// battery — the KNOWN HACK that stood here. The cure that was tried first (arm
+// the watch around the moments that could take the audio session, disarm it once
+// the clock keeps up) was built and REVERTED: it dropped the hidden media
+// element around the moment the screen locks, and that element is the only
+// reason iOS keeps this page alive with the screen off. Speech stopped
+// mid-sentence on lock. See the revert of cb2622e for what was tried.
 //
-// The likely real answer is not a cleverer watch but a switch: the captain turns
-// the corpse watch ON when he is working from his phone, and it does not run at
-// all otherwise. Whoever picks that up: the property that must not break is that
-// speech survives a locked screen. Everything else is negotiable.
+// So it is not a cleverer watch, it is the captain's switch — the same one that
+// holds the audio session open from his pocket (keepalive.js). ON: the corpse
+// left by a Siri Shortcut is found within a beat and the next gesture replaces
+// it. OFF: nothing beats, and a page behaves exactly as it did before any of
+// this existed — which is the right trade for a desktop tab, where no Shortcut
+// ever takes the audio session away.
+export function setCorpseWatch(on) {
+  if (!!on === !!watch) return;
+  if (on) {
+    // A fresh baseline: a sample from before the watch was off answers a
+    // question about a window nobody was watching.
+    lastTime = ctx ? ctx.currentTime : 0; lastWall = performance.now();
+    dead = false;
+    watch = setInterval(beat, BEAT_MS);
+    watch?.unref?.();                  // a timer is no reason to hold a process open
+  } else {
+    clearInterval(watch); watch = null;
+    dead = false;                      // no verdict outlives the watch that made it
+  }
+}
 
 function ensureCtx() {
   if (ctx) return ctx;

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -211,7 +211,13 @@ function closeSink() {
    it for the element. The speech path above is untouched.
 
    The switch is somebody else's (a settings toggle, off by default): this costs
-   battery and keeps a player on the lock screen for as long as it runs. */
+   battery and keeps a player on the lock screen for as long as it runs. So is
+   WHAT plays: hold() takes an optional source — a function handed this module's
+   context and its sink, returning something with a stop() — because "the
+   session must never go quiet" is this module's business and "what quiet sounds
+   like" is not. The board hands it a slow ambient pad (ui/js/pad.js) when the
+   captain asks for one. With no source, it is the tone below, which is what
+   this module holds to on its own. */
 const HUM_HZ = 30;         // under the low end of any phone speaker
 const HUM_GAIN = 0.0008;   // and far under its floor in level: samples, no sound
 // A diagnostic, not a feature. "Is the tone still playing after the screen
@@ -223,20 +229,27 @@ const LOUD = (() => { try { return new URLSearchParams(location.search).get('hum
 const humHz = () => LOUD ? 220 : HUM_HZ;
 const humGain = () => LOUD ? 0.02 : HUM_GAIN;
 let held = false;          // the switch
-let hum = null;            // {osc, gain} while the tone is holding the session
+let source = null;         // what to hold WITH, or null for the tone below
+let hum = null;            // whatever is holding the session, with its stop()
 let owned = false;         // true from speak() until closeSink(): speech has the element
+
+// The module's own default: one oscillator, one gain, no sound. Same shape as
+// anything hold() is given — start it, and hand back the way to stop it.
+function tone(c, dest) {
+  const osc = c.createOscillator(), gain = c.createGain();
+  osc.frequency.value = humHz();
+  gain.gain.value = humGain();
+  osc.connect(gain); gain.connect(dest);
+  osc.start();
+  return { stop() { try { osc.stop(); } catch {} osc.disconnect(); gain.disconnect(); } };
+}
 
 function humOn() {
   if (hum || !held || owned || sink === null) return;   // refused once, refused for good
   const c = audio();
   if (!c.createMediaStreamDestination) return;
   if (!sink) sink = c.createMediaStreamDestination();
-  const osc = c.createOscillator(), gain = c.createGain();
-  osc.frequency.value = humHz();
-  gain.gain.value = humGain();
-  osc.connect(gain); gain.connect(sink);
-  osc.start();
-  const mine = hum = { osc, gain };
+  const mine = hum = (source || tone)(c, sink);
   if (c.state !== 'running') c.resume().catch(() => {});
   // It arms the element itself instead of calling openSink(), for the sake of
   // what happens when the browser says no. A refusal HERE is only a keep-alive
@@ -251,12 +264,11 @@ function humOn() {
   element().play().catch(() => { if (hum === mine) humOff(); });
 }
 
-// Silence the tone and leave the element alone: whoever calls this either takes
-// the element over (speak) or lets it go itself (hold(false)).
+// Silence whatever is holding and leave the element alone: whoever calls this
+// either takes the element over (speak) or lets it go itself (hold(false)).
 function humOff() {
   if (!hum) return;
-  try { hum.osc.stop(); } catch {}
-  try { hum.osc.disconnect(); hum.gain.disconnect(); } catch {}
+  try { hum.stop(); } catch {}
   hum = null;
 }
 
@@ -266,11 +278,17 @@ function humLost() { hum = null; }
 
 /* The switch itself. On: the element plays for as long as it is on, through
    speech and around it. Off: nothing is left behind — no tone, no element
-   playing, no stream held, no context kept open on its account. */
-export function hold(on) {
-  const was = held;
+   playing, no stream held, no context kept open on its account.
+
+   `src` is what to hold with (see above); it is compared by identity, so a
+   caller that hands the same function on every gesture — which is what the
+   board's primer does — changes nothing, and one that hands a different one
+   swaps what is playing without the session ever going quiet for a turn. */
+export function hold(on, src) {
+  const was = held, before = source;
   held = !!on;
-  if (held) humOn();
+  source = held ? (src || null) : null;
+  if (held) { if (hum && source !== before) humOff(); humOn(); }
   else { humOff(); if (was && !owned) closeSink(); }
 }
 export function holding() { return held; }

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -214,6 +214,14 @@ function closeSink() {
    battery and keeps a player on the lock screen for as long as it runs. */
 const HUM_HZ = 30;         // under the low end of any phone speaker
 const HUM_GAIN = 0.0008;   // and far under its floor in level: samples, no sound
+// A diagnostic, not a feature. "Is the tone still playing after the screen
+// locks" is the question the whole design rests on, and inaudible by design
+// means it can only be answered by inference. ?hum=loud makes it a hum a person
+// can hear in a headphone, so the answer is heard instead of argued.
+const LOUD = (() => { try { return new URLSearchParams(location.search).get('hum') === 'loud'; }
+                      catch { return false; } })();
+const humHz = () => LOUD ? 220 : HUM_HZ;
+const humGain = () => LOUD ? 0.02 : HUM_GAIN;
 let held = false;          // the switch
 let hum = null;            // {osc, gain} while the tone is holding the session
 let owned = false;         // true from speak() until closeSink(): speech has the element
@@ -224,8 +232,8 @@ function humOn() {
   if (!c.createMediaStreamDestination) return;
   if (!sink) sink = c.createMediaStreamDestination();
   const osc = c.createOscillator(), gain = c.createGain();
-  osc.frequency.value = HUM_HZ;
-  gain.gain.value = HUM_GAIN;
+  osc.frequency.value = humHz();
+  gain.gain.value = humGain();
   osc.connect(gain); gain.connect(sink);
   osc.start();
   const mine = hum = { osc, gain };

--- a/ui/js/speech.js
+++ b/ui/js/speech.js
@@ -6,6 +6,10 @@
    ponytail: `ui/js/speech.js` is a hand-copy of chatterbox_server's
    console/speech.js. Two copies drift. If a third consumer ever appears, that is
    the moment to publish it properly instead of copying again.
+   ponytail: hold() — the keep-alive at the bottom — was written HERE first,
+   against the captain's phone, and the copy upstream does not have it yet. It
+   belongs in the original for the same reason the rest of this file does: it is
+   about the audio session, not about the board. Carry it over there.
 
    speech.js — the speech path: one message, spoken out loud, on a phone whose
    screen is off. Import it, call speak(), and the three verbs work everywhere
@@ -127,9 +131,16 @@ function audio() {
 // phase and passive, the way sound.js primes its own; a no-op unless the last
 // beat found the context dead. Optional call so the module still imports where
 // there is no window to listen on.
+// A held session is rebuilt here too: the tone's nodes belonged to the corpse
+// and went with it, so the gesture that replaces the context is also what puts
+// the tone back on the new one. humOn() is a no-op unless the switch is on.
 for (const ev of ['click', 'pointerdown', 'touchstart', 'keydown'])
-  window.addEventListener?.(ev, () => { if (ctx && dead) audio().resume().catch(() => {}); },
-    { capture: true, passive: true });
+  window.addEventListener?.(ev, () => {
+    if (!ctx || !dead) return;
+    humLost();
+    audio().resume().catch(() => {});
+    humOn();
+  }, { capture: true, passive: true });
 
 // It renders nothing and has no controls of its own: the transport above is the
 // player people see. This one is the player the OS sees.
@@ -169,12 +180,92 @@ function openSink() {
 // Let the element go. Pausing alone is not enough in either direction: it leaves
 // the lock screen showing a player for speech that is over, and it leaves the
 // element holding a stream it will never play again (see openSink).
+// Unless the session is being HELD (see below) — then not letting go is the
+// whole point, and the keep-alive tone takes the element back instead.
 function closeSink() {
-  element().pause();
-  element().srcObject = null;
+  owned = false;
   transport(false);
   playbackState('none');
+  if (held) { humOn(); return; }
+  element().pause();
+  element().srcObject = null;
 }
+
+/* ── holding the session open ────────────────────────────────────────────
+   A session that is PRODUCING sound survives what an idle one does not. The
+   Siri Shortcut that takes the microphone from a locked phone leaves an
+   AudioContext that reads 'running' and never makes another sample, and iOS
+   only accepts a gesture as the repair — which a locked screen cannot give.
+   The one session observed to come through it was the one already speaking
+   when the Shortcut arrived. So: while the switch is on, never be idle.
+
+   Something, not nothing. A paused element is not playback to the OS, a muted
+   one is not either, and an all-zero stream is a session iOS is free to take
+   back. So it is a real tone through the SAME element the speech leaves
+   through — the one property that must not break is that the page reads as a
+   music player — at a frequency and a level no phone can reproduce.
+
+   It yields the instant there is something to say: speak() silences it before
+   the first buffer is queued and closeSink() brings it back when the last one
+   has been heard, so nothing is ever mixed into the speech and nothing races
+   it for the element. The speech path above is untouched.
+
+   The switch is somebody else's (a settings toggle, off by default): this costs
+   battery and keeps a player on the lock screen for as long as it runs. */
+const HUM_HZ = 30;         // under the low end of any phone speaker
+const HUM_GAIN = 0.0008;   // and far under its floor in level: samples, no sound
+let held = false;          // the switch
+let hum = null;            // {osc, gain} while the tone is holding the session
+let owned = false;         // true from speak() until closeSink(): speech has the element
+
+function humOn() {
+  if (hum || !held || owned || sink === null) return;   // refused once, refused for good
+  const c = audio();
+  if (!c.createMediaStreamDestination) return;
+  if (!sink) sink = c.createMediaStreamDestination();
+  const osc = c.createOscillator(), gain = c.createGain();
+  osc.frequency.value = HUM_HZ;
+  gain.gain.value = HUM_GAIN;
+  osc.connect(gain); gain.connect(sink);
+  osc.start();
+  const mine = hum = { osc, gain };
+  if (c.state !== 'running') c.resume().catch(() => {});
+  // It arms the element itself instead of calling openSink(), for the sake of
+  // what happens when the browser says no. A refusal HERE is only a keep-alive
+  // that could not start — the switch comes back on at page load with no
+  // gesture behind it, and iOS wants one — so it lets the tone go and the next
+  // gesture (see keepalivesettings.js) tries again. openSink()'s refusal means
+  // something else entirely and must never be reached from here: it condemns
+  // the page to the bare speakers, and with them to silence on a locked screen.
+  // Letting go matters: a tone into an element that is not playing holds
+  // nothing open, and a `hum` left standing would make every retry a no-op.
+  element().srcObject = sink.stream;
+  element().play().catch(() => { if (hum === mine) humOff(); });
+}
+
+// Silence the tone and leave the element alone: whoever calls this either takes
+// the element over (speak) or lets it go itself (hold(false)).
+function humOff() {
+  if (!hum) return;
+  try { hum.osc.stop(); } catch {}
+  try { hum.osc.disconnect(); hum.gain.disconnect(); } catch {}
+  hum = null;
+}
+
+// The nodes belonged to a context that has been closed; there is nothing left
+// to stop, only to forget.
+function humLost() { hum = null; }
+
+/* The switch itself. On: the element plays for as long as it is on, through
+   speech and around it. Off: nothing is left behind — no tone, no element
+   playing, no stream held, no context kept open on its account. */
+export function hold(on) {
+  const was = held;
+  held = !!on;
+  if (held) humOn();
+  else { humOff(); if (was && !owned) closeSink(); }
+}
+export function holding() { return held; }
 
 /* ── the lock screen ─────────────────────────────────────────────────── */
 function announce(title, artist) {
@@ -267,6 +358,8 @@ export async function speak({url, voice, input, params, title, artist, onFirstSo
   if (!url) throw new Error('speak() needs the engine url — there is no default');
   if (!voice) throw new Error('speak() needs a voice — there is no default');
   stop();                     // one voice at a time
+  owned = true;               // the element is the speech's now…
+  humOff();                   // …and the keep-alive tone is out of its way
   audio();                    // a corpse from an interruption is replaced here
   openSink();                 // before any await: iOS only allows play() inside the tap
   announce(title, artist);


### PR DESCRIPTION
## The problem

The captain talks to the board from a locked phone through a Siri Shortcut. Messages arrive on time — the page is awake — but the reply does not play. The Shortcut takes the audio session and hands back an `AudioContext` that reads `'running'`, resumes cleanly, and never moves its clock again. `needsRebuild` in `sound.js` already **detects** that corpse; the cure was missing, because building a replacement context needs a user gesture and a locked screen cannot give one.

The one observation that decides the design: **a session that is actively producing sound survives the Shortcut; an idle one does not.** He sent a message while the previous reply was still speaking, and heard the next one with the screen off.

## What this does

**A keep-alive that holds the session by playing continuously, behind a switch.**

- **`ui/js/speech.js` — `hold(on)`.** An inaudible tone (30 Hz at gain 0.0008) plays through the *same* hidden `<audio>` element the speech leaves through — never a second one competing with it. That element is the only reason iOS keeps this page alive with the screen off, so nothing here drops it, pauses it, or mutes it. Verified in a real browser: the element's clock advances 1.00 s/s, and the stream carries real samples at peak 0.0008 (≈ −62 dBFS) — genuinely playing, inaudible.
- **It yields completely to speech.** `speak()` silences the tone before the first buffer is queued; `closeSink()` hands the element back when the last one has been heard. No ducking, no mixing, no gap at the start — the speech path is byte-for-byte what it was.
- **`ui/js/sound.js` — `setCorpseWatch(on)`.** The same switch gates the 500 ms heartbeat. The KNOWN HACK comment there named this card as the likely real answer; the comment is now the switch it asked for. Off means neither runs, and off drops any verdict the watch was holding.
- **Settings → `pocket` → 🎧, off by default.** It costs battery and keeps a player on the lock screen, and a desktop tab — which no Shortcut ever interrupts — pays nothing.
- **A refused `play()` lets go.** Restoring the toggle across a reload has no gesture behind it, so if iOS refuses, the tone tears itself down and the next gesture retries. A keep-alive that *believes* it is running is one no retry would ever fix.

## Tests

`ui/js/keepalive.js` holds the decision as pure functions (no DOM, no WebAudio), tested the way `notifypolicy.js` is: what the switch gates, and what state the keep-alive should be in given (enabled, speaking, hidden) — including that `hidden` changes nothing, since a hidden page is the case this exists for.

The mechanism is pinned where it lives: `speech.test.js` (plays through the one element / yields to speech / no residue when off / a page that never asks makes no source at all) and `sound.test.js` (nothing beats with the switch off; turning it on starts a fresh window rather than convicting the context of a death nobody watched).

`node --test test/*.test.js harness/test/*.test.js` → **632 pass, 0 fail.**

## Two things to know before merging

1. **This wants the captain's verdict, not the suite's.** Please test it on the live 4780 first: with the toggle on, lock the phone, wait several minutes, fire the Shortcut — the reply should speak without a touch. Then with it off, confirm the board is exactly as it is today.
2. **Two deliberate costs of the switch being ON:** the lock screen keeps showing a player for as long as it holds, and the tone plus the heartbeat cost battery. And one of the switch being **OFF**: `sound.js` no longer auto-replaces a corpse, so if a Shortcut ever kills the notification context on a page with the switch off, notification tones stay silent until a reload. Speech is unaffected — `speech.js` keeps its own heartbeat and still rebuilds on the next message. That is the trade the card asked for ("off means neither runs"), flagged here so it is a choice and not a surprise.

`hold()` was written here first, against the real phone; `speech.js` is a hand-copy of chatterbox_server's `console/speech.js`, so there is a `ponytail:` note in the header to carry it upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)