### PR TITLE
The board becomes a wall, and a face is how you filter it

### DIFF
--- a/dev/room-shots.js
+++ b/dev/room-shots.js
@@ -288,7 +288,9 @@ async function main() {
     // Three things a still photograph of the wall cannot tell you, and the
     // third one is the reason the wall is built the way it is.
     //
-    //   · how many titles are on it at once, with nothing filtered
+    //   · how many titles are LEGIBLE at once — bound to a row, shown whole
+    //     with no ellipsis, and with nothing covering them. Counting rows that
+    //     merely exist is what put "53 of 70" on a wall of 16-character stubs
     //   · that pressing a lieutenant's FACE filters it, with no typing
     //   · that scrolling a lane to the bottom of its column changes the uikit
     //     node count by exactly zero
@@ -341,8 +343,14 @@ async function main() {
       const flat = !!(full && after && afterFilter
         && full.nodes === after.nodes && full.nodes === afterFilter.nodes);
       wall = { full, scrolled, after, filtered: afterFilter, beat, shut, shutRoom, openRoom, poolHeldFlat: flat };
-      console.log('· ' + 'the wall'.padEnd(24) + full.shown + ' of ' + full.cards
-        + ' titles at once, ' + full.nodes + ' uikit nodes');
+      console.log('· ' + 'the wall'.padEnd(24) + full.legible + ' of ' + full.cards
+        + ' titles LEGIBLE at once (' + full.shown + ' rows bound, ' + full.chars
+        + ' chars a lane, titles run ' + full.titleLen.min + '-' + full.titleLen.max
+        + ', median ' + full.titleLen.median + ')');
+      console.log('· ' + 'do tiles cover tiles'.padEnd(24)
+        + full.tileGapDeg + '° between neighbours from the arc centre, '
+        + full.tileGapLeaningDeg + '° leaning 20 cm — '
+        + (Math.min(full.tileGapDeg, full.tileGapLeaningDeg) > 0 ? 'no tile covers another' : 'OCCLUDED'));
       console.log('· ' + 'what it costs'.padEnd(24)
         + shutRoom.calls + ' -> ' + openRoom.calls + ' draws, '
         + shut.median.toFixed(1) + ' -> ' + beat.median.toFixed(1) + ' ms median frame ('

--- a/dev/room-shots.js
+++ b/dev/room-shots.js
@@ -263,8 +263,17 @@ async function main() {
     // hidden panel that is still pointable at, a pointer flag the library
     // rewrites the moment you set it. So the run points at one of each kind of
     // thing and checks it lights up.
-    await evaluate(cdp, setScene('world'));
+    let probeScene = '';
     for (const p of PROBES) {
+      const want = p.scene || 'world';
+      if (want !== probeScene) {
+        probeScene = want;
+        await evaluate(cdp, setScene(want));
+        await evaluate(cdp, 'window.__xr.frames(3)');
+      }
+      // The hand converges with the gaze at 1.75 m unless it is told otherwise,
+      // and a ray converging out there sails straight past the rail at 1.20 m.
+      if (p.reach) await evaluate(cdp, `window.__xr.reach(${p.reach})`);
       await evaluate(cdp, `window.__xr.aim(${p.yaw}, ${p.pitch})`);
       await evaluate(cdp, 'window.__xr.frames(4)');
       const lit = await evaluate(cdp, 'window.__bridge.lit()');
@@ -272,6 +281,83 @@ async function main() {
       probes.push({ ...p, lit, ok: !!on });
       console.log((on ? '· ' : '✗ ') + ('ray on ' + p.name).padEnd(24)
         + (on ? on.state + ' at ' + on.distance.toFixed(2) + ' m' : 'NOTHING — the ray reaches nothing there'));
+    }
+
+    // ---- the wall, worked ------------------------------------------------
+    //
+    // Three things a still photograph of the wall cannot tell you, and the
+    // third one is the reason the wall is built the way it is.
+    //
+    //   · how many titles are on it at once, with nothing filtered
+    //   · that pressing a lieutenant's FACE filters it, with no typing
+    //   · that scrolling a lane to the bottom of its column changes the uikit
+    //     node count by exactly zero
+    //
+    // The last one is not a nicety. The version of this surface that held one
+    // live node per card killed his headset browser at about sixty rows, and
+    // the wall holds ninety. So the pool is fixed and this is the proof.
+    //
+    // The frame time here is measured on whatever GPU this machine has, which
+    // in CI is a software rasteriser — an absolute figure off it means nothing
+    // against a 13.9 ms budget. What DOES travel is the ratio: the same room
+    // with the wall shut and with the wall open, on the same renderer, plus
+    // the draw calls and triangles, which are the same numbers everywhere.
+    const BEAT = `(async () => {
+      const t = [];
+      let last = performance.now();
+      for (let i = 0; i < 40; i++) {
+        await new Promise((r) => requestAnimationFrame(r));
+        const now = performance.now(); t.push(now - last); last = now;
+      }
+      t.sort((a, b) => a - b);
+      return { median: t[Math.floor(t.length / 2)], p95: t[Math.floor(t.length * 0.95)], frames: t.length };
+    })()`;
+    let wall = null;
+    try {
+      await evaluate(cdp, setScene('world'));
+      await evaluate(cdp, 'window.__xr.frames(4)');
+      const shut = await evaluate(cdp, BEAT);
+      const shutRoom = await evaluate(cdp, 'window.__bridge.stats()');
+      await evaluate(cdp, setScene('board'));
+      await evaluate(cdp, 'window.__xr.look("board")');
+      await evaluate(cdp, 'window.__xr.frames(4)');
+      const full = await evaluate(cdp, 'window.__bridge.wall()');
+      const openRoom = await evaluate(cdp, 'window.__bridge.stats()');
+      const beat = await evaluate(cdp, BEAT);
+      const scrolled = await evaluate(cdp, 'window.__bridge.wallScroll()');
+      await evaluate(cdp, 'window.__xr.frames(6)');
+      const after = await evaluate(cdp, 'window.__bridge.wall()');
+      await evaluate(cdp, `window.__xr.look("board")`);
+      await evaluate(cdp, 'window.__xr.frames(3)');
+      let { data } = await cdp.send('Page.captureScreenshot', { format: 'png' });
+      fs.writeFileSync(path.join(args.out, 'wall-scrolled.png'), Buffer.from(data, 'base64'));
+
+      const filtered = await evaluate(cdp, 'window.__bridge.wallFilter()');
+      await evaluate(cdp, 'window.__xr.frames(4)');
+      ({ data } = await cdp.send('Page.captureScreenshot', { format: 'png' }));
+      fs.writeFileSync(path.join(args.out, 'wall-filtered.png'), Buffer.from(data, 'base64'));
+      const afterFilter = await evaluate(cdp, 'window.__bridge.wall()');
+
+      const flat = !!(full && after && afterFilter
+        && full.nodes === after.nodes && full.nodes === afterFilter.nodes);
+      wall = { full, scrolled, after, filtered: afterFilter, beat, shut, shutRoom, openRoom, poolHeldFlat: flat };
+      console.log('· ' + 'the wall'.padEnd(24) + full.shown + ' of ' + full.cards
+        + ' titles at once, ' + full.nodes + ' uikit nodes');
+      console.log('· ' + 'what it costs'.padEnd(24)
+        + shutRoom.calls + ' -> ' + openRoom.calls + ' draws, '
+        + shut.median.toFixed(1) + ' -> ' + beat.median.toFixed(1) + ' ms median frame ('
+        + (beat.median / shut.median).toFixed(2) + 'x, on THIS machine\'s renderer, not a headset)');
+      console.log((flat ? '· ' : '✗ ') + 'the row pool'.padEnd(24)
+        + (flat
+          ? 'scrolled lane ' + scrolled.lane + ' (' + scrolled.held + ' cards) to its end and filtered — '
+            + after.nodes + ' nodes throughout, unchanged'
+          : 'GREW: ' + full.nodes + ' -> ' + after.nodes + ' -> ' + afterFilter.nodes));
+      console.log((afterFilter.shown < full.shown ? '· ' : '✗ ') + 'a face filters'.padEnd(24)
+        + 'pressing a face left ' + afterFilter.shown + ' of ' + afterFilter.cards
+        + ' showing (' + (afterFilter.filters.join(', ') || 'nothing') + ')');
+    } catch (e) {
+      wall = { error: String((e && e.message) || e) };
+      console.log('✗ the wall'.padEnd(26) + 'could not be driven: ' + wall.error);
     }
 
     // And can he MOVE a window? Grabbing is the one interaction the captain
@@ -315,7 +401,7 @@ async function main() {
 
     const manifest = {
       generatedAt: new Date().toISOString(),
-      grab,
+      grab, wall,
       url, size: args.width + 'x' + args.height,
       chrome: bin, board: args.url ? 'live server' : 'dev/ui-server.js fixture',
       note: 'Screenshots are structural evidence only — every arc figure is asserted in test/bridge3d.test.js, and every design number lives in the vr-design skill.',

--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -378,7 +378,7 @@ test('full white is clamped, and colour never travels alone', async () => {
   // in the title bar beside the chip. None of the three is optional — a colour
   // on its own names nobody.
   assert.match(fs.readFileSync(path.join(UI, 'agents.js'), 'utf8'), /label\.setProperties\(\{ text: safe\(lt\.name/);
-  assert.match(fs.readFileSync(path.join(UI, 'board.js'), 'utf8'), /title\.setProperties\(\{ text: safe\(c\.title/);
+  assert.match(fs.readFileSync(path.join(UI, 'board.js'), 'utf8'), /const full = safe\(c\.title/);
   assert.match(fs.readFileSync(path.join(UI, 'panel.js'), 'utf8'), /this\.chip = new Container/);
 });
 
@@ -398,10 +398,19 @@ test('the wall is a wall: fifty-odd cards at once, and every one of them legible
   // drawn through — which is exactly what the first rendered frame showed.
   assert.ok(ext.maxDistM < W.AGENT.distM - W.AGENT.diaM / 2,
     `the wall reaches ${ext.maxDistM.toFixed(2)} m and the crew's near side is ${(W.AGENT.distM - W.AGENT.diaM / 2).toFixed(2)} m`);
-  // Two flat neighbours on an arc must not saw into each other.
-  const a = W.wallLaneAt(0), b = W.wallLaneAt(1);
-  assert.ok(a.widthM < Math.hypot(a.pos.x - b.pos.x, a.pos.z - b.pos.z),
-    'a lane is wider than the gap between two lane centres, so the tiles intersect');
+  // **Does a tile ever cover its neighbour?** A title cut at its own lane's
+  // edge and a title hidden behind the next panel look identical in a
+  // photograph, and this wall was read as the second when it was the first. So
+  // it is measured: the gap between two neighbours, from the arc centre AND
+  // from an eye leaned 20 cm along the wall, which is further than a seated
+  // head goes. Negative would mean one really does eat the other.
+  for (const lean of [0, 0.032, 0.10, 0.20]) {
+    const gap = W.wallTileGap(lean);
+    assert.ok(gap > 0.5,
+      `leaning ${lean * 100} cm, two lanes leave ${gap.toFixed(2)}° between them`);
+  }
+  assert.ok(Math.abs(W.wallTileGap(0) - W.WALL.laneGapDeg) < 0.15,
+    'from the arc centre the gap between two tiles is the gap they were built with');
   // It is deliberately wider than the ±45° a bounded region is held to — a
   // board you scan by turning your head is the whole point of it — but a tile
   // is still a flat surface and past about 34° off-normal a flat surface
@@ -410,35 +419,64 @@ test('the wall is a wall: fifty-odd cards at once, and every one of them legible
   assert.ok(W.WALL.spanDeg >= 100 && W.WALL.spanDeg <= 120,
     `the wall spans ${W.WALL.spanDeg}°, and a neck does not`);
 
-  // The cap height the captain set — and it has to hold on the WORST row, not
-  // on the size the type is cut at. The top of a lane is further away and more
-  // turned than its middle, and reading the floor off `TYPE.wall × CAP` would
-  // have shipped the top two rows 10% under it.
+  // **The floor is the TITLE, and it is the thing this surface exists for.**
+  // Sized the other way round — cap height first — the lane came out at 16
+  // characters against a median card title of 53, and every row read "Archon
+  // as the exe". This assertion is the one that stops that coming back.
+  assert.ok(W.wallChars() >= W.WALL_CHARS,
+    `a lane holds ${W.wallChars()} characters of title, under the ${W.WALL_CHARS} floor`);
+
+  // One lane per board column. Six was a number with nothing behind it; the
+  // board's own frame is fixed at four and this is read off the server rather
+  // than restated, so adding a column fails here instead of silently vanishing.
+  const cols = fs.readFileSync(path.join(ROOT, 'server', 'server.js'), 'utf8')
+    .match(/const COLUMNS = \[([\s\S]*?)\];/)[1].match(/id:/g).length;
+  assert.strictEqual(W.WALL.lanes, cols,
+    `the wall has ${W.WALL.lanes} lanes and the board has ${cols} columns`);
+
+  // The cap height it lands at, measured on the WORST row rather than on the
+  // size the type is cut at — the top of a lane is further away and more turned
+  // than its middle. It clears the room's own 0.7° floor and its 1.0° body
+  // text; it does NOT clear the 1.3° this was first built to, and that is the
+  // price of the 32 characters, on purpose.
   const cap = W.wallCap();
-  assert.ok(cap.worstDeg >= 1.3,
-    `the worst row's cap is ${cap.worstDeg.toFixed(2)}°, under the 1.3° he asked for `
-    + `(the type is cut at ${cap.cutDeg.toFixed(2)}°)`);
+  assert.ok(cap.worstDeg >= W.CAP,
+    `the worst row's cap is ${cap.worstDeg.toFixed(2)}°, under the ${W.CAP}° floor`);
+  // Cut at the size the room's own prose is set at — that is where the type
+  // stopped being pushed down for characters — and a third clear of the floor
+  // once the worst row's foreshortening is taken off it.
+  assert.ok(cap.cutDeg >= W.TYPE.body * W.CAP,
+    `wall type is cut at ${cap.cutDeg.toFixed(2)}° of cap, under the room's own body prose`);
+  assert.ok(cap.worstDeg >= W.CAP * 1.25,
+    `the worst wall row is ${cap.worstDeg.toFixed(2)}°, too near the ${W.CAP}° floor to have any margin`);
   assert.ok(cap.worstDeg <= cap.bestDeg && cap.bestDeg <= cap.cutDeg + 1e-9,
     'the foreshortening runs the wrong way');
   assert.ok(W.WALL.rowDeg >= W.TYPE.wall * 1.15,
     `a ${W.WALL.rowDeg}° row cannot hold a ${(W.TYPE.wall * 1.15).toFixed(2)}° line`);
 
-  // And the count, which is the whole card. Seventy-eight seats, and on the
-  // live shape of the board — 35 backlog, 4 working, 31 in review, 0 peer —
-  // fifty-six of them are filled with no filter applied.
-  assert.strictEqual(W.wallRows(), 13);
-  assert.ok(W.wallSeats() >= 50, `${W.wallSeats()} seats is not a wall`);
+  // Seventy-two seats, and on the live shape of the board — 35 backlog, 4
+  // working, 31 in review, 0 peer — forty are filled with no filter. One lane
+  // per column is what caps it: a column shows at most `rows` of its own.
+  assert.strictEqual(W.wallRows(), 18);
+  assert.strictEqual(W.wallSeats(), 72);
   const live = [35, 4, 31, 0];
-  const per = W.wallLanesFor(live);
-  assert.strictEqual(per.reduce((a, b) => a + b), W.WALL.lanes, 'every lane belongs to a column');
-  assert.ok(per.every((n) => n >= 1), 'a column with no lane has no header and no count');
-  const shown = live.reduce((n, c, i) => n + Math.min(c, per[i] * W.wallRows()), 0);
-  assert.ok(shown >= 50, `only ${shown} of the live board's cards are on the wall at once`);
+  const shown = live.reduce((n, c) => n + Math.min(c, W.wallRows()), 0);
+  assert.strictEqual(shown, 40, `${shown} of the live board's cards are on the wall at once`);
 
-  // A title has to survive the lane it sits in. Sixteen is short and it is what
-  // 1.3° of cap leaves; the assertion exists so that shrinking a lane to buy a
-  // seventh one fails loudly rather than quietly.
-  assert.ok(W.wallChars() >= 16, `a lane holds ${W.wallChars()} characters of title`);
+  // And the trade is arguable rather than asserted: more characters is fewer
+  // rows, every time, and the curve has to run the right way.
+  // Characters and rows do NOT trade against each other — both come out of the
+  // type size, and both are bought with cap height. So a wider character floor
+  // buys MORE rows and smaller letters, and the only thing that stops it is the
+  // floor above. That is why 32 is the number: one more character and the worst
+  // row drops under the 1.0° cap the room's own body text carries.
+  const wide = W.wallTrade(40), tight = W.wallTrade(24);
+  assert.ok(wide.emDeg < tight.emDeg && wide.rows >= tight.rows,
+    'the character/cap trade does not run the way the arithmetic says');
+  // And the type really is pushed as far down as the body-prose rule allows:
+  // one more character and the cut cap goes under it.
+  assert.ok(W.wallTrade(W.wallChars() + 1).capCutDeg < W.TYPE.body * W.CAP,
+    `${W.wallChars()} characters is not where the cap rule actually bites`);
 
   const src = fs.readFileSync(path.join(UI, 'board.js'), 'utf8');
   assert.match(src, /new Input\(/, 'the wall still takes free text');
@@ -761,6 +799,28 @@ test('kit components are imported one at a time, never the package barrel', asyn
   }
 });
 
+test('every module in the room actually parses', async () => {
+  // A syntax error in here costs a four-minute capture run to find, because the
+  // room's modules import three.js and uikit and so cannot be imported from a
+  // test. `node --check` can read them without running them — through a copy
+  // with an .mjs extension, which is how node is told they are modules.
+  const { execFileSync } = require('node:child_process');
+  const os = require('node:os');
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'room-parse-'));
+  try {
+    for (const f of fs.readdirSync(UI)) {
+      if (!f.endsWith('.js')) continue;
+      const copy = path.join(tmp, f.replace(/\.js$/, '.mjs'));
+      fs.writeFileSync(copy, fs.readFileSync(path.join(UI, f)));
+      try {
+        execFileSync(process.execPath, ['--check', copy], { stdio: 'pipe' });
+      } catch (e) {
+        assert.fail(`${f} does not parse:\n${e.stderr || e.message}`);
+      }
+    }
+  } finally { fs.rmSync(tmp, { recursive: true, force: true }); }
+});
+
 test('the room the captain opens never loads the dev loop', async () => {
   // The flags are OFF by default, and "off" has to mean not fetched rather than
   // merely not used: the emulator is reachable only through a dynamic import
@@ -805,7 +865,12 @@ test('no viewpoint asks for a turn of the head the room does not', async () => {
   const W = await load('world.js');
   for (const v of VIEWPOINTS) {
     const a = aimAt(v.eye, v.look);
-    assert.ok(Math.abs(a.yaw) <= 45, `${v.name} turns the head ${a.yaw.toFixed(1)}° off centre`);
+    // 45° unless the viewpoint declares otherwise, and the only thing that
+    // does is the wall's outer lane — a surface built to be read by turning
+    // has to be photographed turned. Declared, not assumed: `turn` is on the
+    // viewpoint so the exception is visible where it is taken.
+    const turn = v.turn || 45;
+    assert.ok(Math.abs(a.yaw) <= turn, `${v.name} turns the head ${a.yaw.toFixed(1)}° off centre, past ${turn}°`);
     assert.ok(a.pitch <= W.RISE, `${v.name} looks ${a.pitch.toFixed(1)}° up`);
     const down = v.floor ? W.FLOOR_LOOK : 45;
     assert.ok(a.pitch >= -down, `${v.name} looks ${a.pitch.toFixed(1)}° down — that is a neck, not a glance`);

--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -383,42 +383,104 @@ test('full white is clamped, and colour never travels alone', async () => {
 });
 
 
-test('the board is the escape hatch: every card, filterable, and each row pressable', async () => {
+test('the wall is a wall: fifty-odd cards at once, and every one of them legible', async () => {
   const W = await load('world.js');
-  assert.ok(W.BOARD.distM >= W.NEAR && W.BOARD.distM <= W.FAR,
-    `the board stands at ${W.BOARD.distM} m, outside the comfort band`);
-  const centre = -W.BOARD.elevDeg;
-  assert.ok(centre >= 10 && centre <= 20, `the board is centred ${centre}° below the horizon`);
-  const top = W.BOARD.elevDeg + W.BOARD.heightDeg / 2;
-  const bottom = W.BOARD.elevDeg - W.BOARD.heightDeg / 2;
-  assert.ok(top <= W.RISE, `the board reaches ${top.toFixed(1)}°, over the +${W.RISE}° ceiling`);
-  assert.ok(bottom >= -W.SINK, `the board reaches ${bottom.toFixed(1)}°, under the -${W.SINK}° floor`);
-  assert.ok(W.BOARD.widthDeg / 2 <= 45, 'the board runs past the shoulders');
+  assert.ok(W.WALL.distM >= W.NEAR && W.WALL.distM <= W.FAR,
+    `the wall stands at ${W.WALL.distM} m, outside the comfort band`);
+  // Measured after the turn and the tilt, not read off the two constants: a
+  // flat 44° tile does not subtend 44° symmetrically, and the tilt moves the
+  // whole thing. The authored numbers are the input, these are the room.
+  const ext = W.wallExtent();
+  assert.ok(ext.topDeg <= W.RISE, `the wall reaches ${ext.topDeg.toFixed(1)}°, over the +${W.RISE}° ceiling`);
+  assert.ok(ext.bottomDeg >= -W.SINK, `the wall reaches ${ext.bottomDeg.toFixed(1)}°, under the -${W.SINK}° floor`);
+  // And it stands IN FRONT of the crew. The tilt throws the top edge away from
+  // the eye, and a wall whose top is behind the lieutenants is a wall they are
+  // drawn through — which is exactly what the first rendered frame showed.
+  assert.ok(ext.maxDistM < W.AGENT.distM - W.AGENT.diaM / 2,
+    `the wall reaches ${ext.maxDistM.toFixed(2)} m and the crew's near side is ${(W.AGENT.distM - W.AGENT.diaM / 2).toFixed(2)} m`);
+  // Two flat neighbours on an arc must not saw into each other.
+  const a = W.wallLaneAt(0), b = W.wallLaneAt(1);
+  assert.ok(a.widthM < Math.hypot(a.pos.x - b.pos.x, a.pos.z - b.pos.z),
+    'a lane is wider than the gap between two lane centres, so the tiles intersect');
+  // It is deliberately wider than the ±45° a bounded region is held to — a
+  // board you scan by turning your head is the whole point of it — but a tile
+  // is still a flat surface and past about 34° off-normal a flat surface
+  // turned to face the eye stops facing it, which is why it is SIX tiles.
+  assert.ok(W.wallLaneDeg() <= 34, `a lane is ${W.wallLaneDeg().toFixed(1)}° of flat surface`);
+  assert.ok(W.WALL.spanDeg >= 100 && W.WALL.spanDeg <= 120,
+    `the wall spans ${W.WALL.spanDeg}°, and a neck does not`);
 
-  // Its rows ARE pressed — unlike the flat list this replaced, whose rows were
-  // read — so each one is the padded hit floor tall with clear air beside it,
-  // and the count of them falls out of the height rather than being declared.
-  const rows = W.boardRows();
-  assert.ok(rows >= 4, `${rows} rows is not a board`);
-  assert.ok(rows * W.PITCH <= W.BOARD.heightDeg - 2 * W.BUILD.hit + 1e-9,
-    'the rows do not fit under the bar and the filter at the lattice pitch');
-  assert.ok(rows * W.BOARD.cols >= 8, 'fewer than eight cards visible is a keyhole');
-  // And a title has to survive the row it sits in: 45 characters is the floor
-  // for a card title, below which he is guessing from a prefix.
-  const rowDeg = W.BOARD.widthDeg / W.BOARD.cols;
-  assert.ok(Math.floor(rowDeg / (W.TYPE.meta * 0.494)) >= 45,
-    `a row holds ${Math.floor(rowDeg / (W.TYPE.meta * 0.494))} characters of title`);
+  // The cap height the captain set — and it has to hold on the WORST row, not
+  // on the size the type is cut at. The top of a lane is further away and more
+  // turned than its middle, and reading the floor off `TYPE.wall × CAP` would
+  // have shipped the top two rows 10% under it.
+  const cap = W.wallCap();
+  assert.ok(cap.worstDeg >= 1.3,
+    `the worst row's cap is ${cap.worstDeg.toFixed(2)}°, under the 1.3° he asked for `
+    + `(the type is cut at ${cap.cutDeg.toFixed(2)}°)`);
+  assert.ok(cap.worstDeg <= cap.bestDeg && cap.bestDeg <= cap.cutDeg + 1e-9,
+    'the foreshortening runs the wrong way');
+  assert.ok(W.WALL.rowDeg >= W.TYPE.wall * 1.15,
+    `a ${W.WALL.rowDeg}° row cannot hold a ${(W.TYPE.wall * 1.15).toFixed(2)}° line`);
 
-  // A row is a target, so the arc it covers has to clear the same floor as
-  // every other target in the room — measured at the distance the board stands.
-  const rowW = W.boardSize().widthM / W.BOARD.cols;
-  assert.ok(W.arcDeg(rowW, W.BOARD.distM) >= W.BUILD.hit,
-    'a row is narrower than the hit floor');
+  // And the count, which is the whole card. Seventy-eight seats, and on the
+  // live shape of the board — 35 backlog, 4 working, 31 in review, 0 peer —
+  // fifty-six of them are filled with no filter applied.
+  assert.strictEqual(W.wallRows(), 13);
+  assert.ok(W.wallSeats() >= 50, `${W.wallSeats()} seats is not a wall`);
+  const live = [35, 4, 31, 0];
+  const per = W.wallLanesFor(live);
+  assert.strictEqual(per.reduce((a, b) => a + b), W.WALL.lanes, 'every lane belongs to a column');
+  assert.ok(per.every((n) => n >= 1), 'a column with no lane has no header and no count');
+  const shown = live.reduce((n, c, i) => n + Math.min(c, per[i] * W.wallRows()), 0);
+  assert.ok(shown >= 50, `only ${shown} of the live board's cards are on the wall at once`);
+
+  // A title has to survive the lane it sits in. Sixteen is short and it is what
+  // 1.3° of cap leaves; the assertion exists so that shrinking a lane to buy a
+  // seventh one fails loudly rather than quietly.
+  assert.ok(W.wallChars() >= 16, `a lane holds ${W.wallChars()} characters of title`);
 
   const src = fs.readFileSync(path.join(UI, 'board.js'), 'utf8');
-  assert.match(src, /new Input\(/, 'the board is filterable');
-  assert.match(src, /overflow: 'scroll'/, 'every card, which means it scrolls');
+  assert.match(src, /new Input\(/, 'the wall still takes free text');
+  assert.match(src, /overflow: 'scroll'/, 'every card, which means a lane scrolls');
   assert.match(src, /onCard/, 'a row opens the card it names');
+  // Filtering is PRESSING. A face, and a column header, and neither of them is
+  // a keystroke.
+  assert.match(src, /toggleOwner/, 'a face does not filter by its lieutenant');
+  assert.match(src, /toggleColumn/, 'a header does not filter by its column');
+  // And the pool: rows are built in the constructor and bound afterwards, never
+  // made on paint. `_row` called from anywhere but `_lane` is the regression.
+  assert.ok(!/repaint[\s\S]*?this\._row\(/.test(src), 'repaint builds rows');
+  assert.match(src, /nodes\(\)/, 'nothing reports the node count, so nothing can assert it');
+});
+
+test('the rail is under the wall, above the deck, and every control on it is a target', async () => {
+  const W = await load('world.js');
+  const top = W.RAIL.elevDeg + W.railHeightDeg() / 2;
+  const bottom = W.RAIL.elevDeg - W.railHeightDeg() / 2;
+  // It is below the wall with air between them, and it is a GLANCE down rather
+  // than a neck — the same budget the mat on the floor spends.
+  const wallBottom = W.wallExtent().bottomDeg;
+  assert.ok(top <= wallBottom - W.BUILD.gap,
+    `the rail's top edge is ${top.toFixed(1)}° and the wall's bottom is ${wallBottom.toFixed(1)}°`);
+  assert.ok(bottom >= -W.FLOOR_LOOK, `the rail reaches ${bottom.toFixed(1)}°, past a glance`);
+  // And it stands ABOVE the deck, which the wall's own distance cannot do down
+  // there: 1.80 m at this elevation is underground.
+  const low = W.pointAt(0, bottom, W.RAIL.distM);
+  assert.ok(low.y > 0.05, `the rail's bottom edge is ${low.y.toFixed(2)} m off the floor`);
+  assert.ok(W.pointAt(0, bottom, W.WALL.distM).y < low.y,
+    'the rail gains nothing by being nearer, so it should not be');
+
+  // Four faces to a strip at the full hit floor, and they have to fit.
+  const perStrip = 4;
+  const need = perStrip * W.BUILD.hit + (perStrip - 1) * W.BUILD.gap;
+  assert.ok(need <= W.RAIL.widthDeg,
+    `${perStrip} faces want ${need.toFixed(1)}° and a rail tile is ${W.RAIL.widthDeg}°`);
+  // The crew all fits on the left tile, four to a strip, two strips.
+  assert.ok(W.RAIL.rows * perStrip >= W.AGENT.slots,
+    `${W.RAIL.rows * perStrip} face slots for ${W.AGENT.slots} berths`);
+  assert.ok(W.RAIL.rows * W.BUILD.hit + (W.RAIL.rows - 1) * W.BUILD.gap <= W.railHeightDeg() + 1e-9,
+    'the strips do not fit in the rail');
 });
 
 // ---- the crew is alive, and on real state ----------------------------------
@@ -576,7 +638,7 @@ test('the place is bounded, and the bound sits under the band he reads in', asyn
     'the parapet rises through the panels');
   // And it is far enough away to be scenery rather than something he keeps
   // walking into: well outside every surface the room opens.
-  assert.ok(wallR > W.BOARD.distM * 2, 'the parapet crowds the board');
+  assert.ok(wallR > W.WALL.distM * 2, 'the parapet crowds the wall');
 });
 
 // ---- the six states -------------------------------------------------------

--- a/ui/js/bridge3d/README.md
+++ b/ui/js/bridge3d/README.md
@@ -40,6 +40,20 @@ all invisible in a PNG. So the run aims the head at one of each kind of thing �
 a lieutenant, the mat that opens the board — and fails if any of them does not
 light up.
 
+Then it **works the wall**, which is where the three things a photograph cannot
+show live: how many titles are on it with nothing filtered, that pressing a
+lieutenant's face filters it with no typing, and that scrolling a lane to the
+bottom of its column changes the uikit node count by **exactly zero**. The last
+one is the reason the wall is built out of a fixed row pool at all — the surface
+that held one live node per card is the one that killed the headset browser at
+about sixty rows, and the wall holds seventy-eight. It writes `wall-scrolled.png`
+and `wall-filtered.png` beside the viewpoints, and the numbers into the manifest.
+
+Frame time is in there too, as a RATIO: the same room with the wall shut and
+with it open, on whatever renderer this machine has. An absolute millisecond
+figure off a software rasteriser means nothing against a 13.9 ms headset budget;
+the ratio and the draw-call count travel.
+
 And it **grabs a window**: opens a chat, aims at its title bar, squeezes, turns
 its head, releases, and checks the panel came along. Moving a window is the one
 interaction he named as a requirement rather than a nicety, and it is invisible
@@ -166,7 +180,7 @@ emulate; `window.__bridge` is not, so the room can still be driven by hand.
 | `agents.js` | the eight fixed berths and the lieutenants in them |
 | `panel.js` | a surface with prose on it he can read, move and put down — the bar is the handle, the body scrolls, the foot holds a composer |
 | `chat.js` | a conversation on a panel: the thread, and a composer that really sends |
-| `board.js` | the board (every card, filterable, each row one press deep) and the card it opens |
+| `board.js` | the wall — six flat tiles on a 120° arc carrying 78 rows out of one fixed pool, the rail of faces that filters it by pressing, and the card a row opens |
 | `windows.js` | how many panels are open, where they land, and the rule that the room never moves one he has placed |
 | `grab.js` | squeeze to pick a window up, and what happens when he lets go |
 | `sound.js` | the music bed, and the sound a press, a grab and a release make |

--- a/ui/js/bridge3d/board.js
+++ b/ui/js/bridge3d/board.js
@@ -4,11 +4,16 @@
 // around: **what you HUNT for and what you READ are not the same thing.**
 //
 // The WALL is hunting, and it is a wall rather than a panel because eight rows
-// out of sixty-eight is a peephole with a search box attached. It is six flat
-// tiles laid along a 120° arc at 1.80 m — flat text, curved surface — carrying
-// fifteen rows each. Sixty-two cards at once on the live board, no filter, and
-// you scan it by turning your head. Every figure in it is derived in world.js
-// and the arithmetic is written out there; this file spends them.
+// out of sixty-eight is a peephole with a search box attached. It is FOUR flat
+// tiles laid along a 120° arc at 1.50 m — one per board column, flat text on a
+// curved surface — carrying eighteen rows each. Every figure in it is derived in
+// world.js and the arithmetic is written out there; this file spends them.
+//
+// The lane is sized by the TITLE and not the other way round: 32 characters is
+// the floor and it lands at 36, and that is what makes a lane 27.75° instead of
+// 18.6°. The version that solved for cap height first fitted six lanes and
+// sixteen characters, and sixteen characters of a fifty-three-character title
+// is not a title.
 //
 // The RAIL under it is how you filter, and the point of it is that **filtering
 // is one press and never a keystroke**. The lieutenants' faces are the control:
@@ -22,13 +27,12 @@
 //
 // ---- the row pool, which is the part that is load-bearing ------------------
 //
-// Ninety rows are built ONCE at startup and never again. Scrolling a lane
+// Seventy-two rows are built ONCE at startup and never again. Scrolling a lane
 // re-binds data into rows that already exist; it never makes or destroys a
 // uikit node. The version of this that held a live node per card is the version
-// that killed his headset browser at about sixty rows, and ninety is more than
-// sixty. `nodes()` is here so the claim can be checked rather than believed —
-// dev/room-shots.js scrolls a lane to its end and asserts the count did not
-// move by one.
+// that killed his headset browser at about sixty rows. `nodes()` is here so the
+// claim can be checked rather than believed — dev/room-shots.js scrolls a lane
+// to its end and asserts the count did not move by one.
 
 import * as THREE from 'three';
 import * as W from './world.js';
@@ -40,16 +44,23 @@ import { Target } from './hover.js';
 const D = W.WALL.distM;
 const ROWS = W.wallRows();
 const LANES = W.WALL.lanes;
+const CHARS = W.wallChars();
 
 // Everything on the wall, in metres at the distance the wall stands.
 const ROW_M = W.sizeForArc(W.WALL.rowDeg, D);
 const HEAD_M = W.sizeForArc(W.WALL.headDeg, D);
 const PAD_M = W.sizeForArc(0.7, D);
-const BAR_M = W.sizeForArc(1.0, D);
+// The row's own chrome, and it adds up to WALL_ROW_CHROME exactly — 0.5° of
+// padding each side, a 0.9° owner bar, 0.3° of gap. What is left is the title,
+// and the title is what the lane was sized for.
+const ROW_PAD_M = W.sizeForArc(0.5, D);
+const ROW_BAR_M = W.sizeForArc(0.9, D);
+const ROW_GAP_M = W.sizeForArc(0.3, D);
 
-// A tile: one flat uikit surface, turned to face the eye and then tilted back
-// about its OWN horizontal axis. Tilting in the room's frame instead would make
-// the outer lanes lean sideways, and at ±52° that is very visible.
+// A tile: one flat uikit surface, turned to face the eye. Every tile stands at
+// exactly WALL.distM and every one of them faces the head — the outer ones look
+// bigger in a wide-angle frame because a 90° projection stretches its own
+// edges, which is a property of the picture and not of the wall.
 function tile(spec, properties) {
   const group = new THREE.Group();
   const ui = root({
@@ -90,11 +101,9 @@ export class BoardWall {
     this.lanes = [];
     for (let i = 0; i < LANES; i++) this.lanes.push(this._lane(i));
     this._rail();
-    // Until a board arrives, one lane per column and the lanes in board order.
-    this.share = this.lanes.map(() => null);
   }
 
-  // ---- a lane: a header you press, and fifteen rows that recycle ------------
+  // ---- a lane: a header you press, and eighteen rows that recycle ----------
   _lane(i) {
     const spec = W.wallLaneAt(i);
     const t = tile(spec, {});
@@ -157,20 +166,20 @@ export class BoardWall {
   }
 
   // One row. A colour bar for the owner and a title, and the whole row is the
-  // target — at 18.6° wide the horizontal scatter of a hand-held ray is
+  // target — at 27.75° wide the horizontal scatter of a hand-held ray is
   // absorbed whole, and only the vertical is left to aim.
   _row(lane, r) {
     const box = new Container({
       width: '100%', height: cm(ROW_M), flexShrink: 0,
       flexDirection: 'row', alignItems: 'center',
-      paddingX: cm(PAD_M), gap: cm(W.sizeForArc(0.4, D)),
-      // Zebra rather than a rim: ninety rimmed boxes is a grid, and the shape
+      paddingX: cm(ROW_PAD_M), gap: cm(ROW_GAP_M),
+      // Zebra rather than a rim: seventy-two rimmed boxes is a grid, and the shape
       // of a row at this density is carried better by an alternating fill. The
       // hover rim is what says "this one" — and it is the only affordance the
       // wall has, so it is loud.
       backgroundColor: r % 2 ? COL.slot : COL.panel, backgroundOpacity: 1,
       // The rim is always THERE and only ever changes COLOUR, so hovering a row
-      // cannot reflow the seventy-eight rows under it. It hides by matching the
+      // cannot reflow the seventy-two rows under it. It hides by matching the
       // plate rather than by going to zero opacity — `borderOpacity: 0` drew a
       // full-strength accent line on every row in the rendered frame, and a
       // wall where every row is lit is a wall with no hover state at all.
@@ -180,7 +189,7 @@ export class BoardWall {
       display: 'none',
     });
     const bar = new Container({
-      width: cm(BAR_M), height: '62%', flexShrink: 0,
+      width: cm(ROW_BAR_M), height: '62%', flexShrink: 0,
       borderRadius: cm(0.002), backgroundColor: COL.faint,
     });
     const title = new Text({
@@ -364,27 +373,7 @@ export class BoardWall {
 
   // Which lanes belong to which column. Recomputed on OPEN and never while he
   // is standing in front of it — see world.js.
-  share_() {
-    const cols = this.doc.columns || [];
-    const counts = cols.map((c) => (this.doc.cards || []).filter((x) => x.column === c.id).length);
-    const per = W.wallLanesFor(counts);
-    const out = [];
-    cols.forEach((c, i) => {
-      for (let k = 0; k < per[i]; k++) out.push({ column: c, cont: k > 0, last: k === per[i] - 1 });
-    });
-    while (out.length < LANES) out.push({ column: null, cont: true, last: true });
-    this.share = out.slice(0, LANES);
-    this._sharedFor = this.columnKey();
-  }
-
-  // The board's own column list, as one string. The share is rebuilt when THIS
-  // changes and never when a count does — a column gaining a card must not
-  // move the row he is reaching for. It is also what catches the wall being
-  // opened one tick before the first board arrives, which is the ordinary case.
-  columnKey() { return (this.doc.columns || []).map((c) => c.id).join(','); }
-
   repaint() {
-    if (!this.share || this._sharedFor !== this.columnKey()) this.share_();
     const q = this.query.trim().toLowerCase();
     const lts = new Map((this.doc.lieutenants || []).map((l) => [l.id, l]));
     const cols = new Map((this.doc.columns || []).map((c) => [c.id, c.title || c.id]));
@@ -399,30 +388,22 @@ export class BoardWall {
     };
     const kept = all.filter(hit);
 
-    // Each lane takes its column's cards, newest activity first, and a column
-    // spread over two lanes takes the second lane's slice from where the first
-    // one ended.
+    // **One lane per board column.** That is what makes a column a column, and
+    // it is the whole reason a lane is 27.75° wide and a title is 36 characters
+    // rather than 16: sharing lanes out by how full a column was bought twenty
+    // more rows and cost half of every title.
+    const frame = this.doc.columns || [];
     let shown = 0;
-    const seen = new Map();
     this.lanes.forEach((lane, i) => {
-      const s = this.share[i] || {};
-      lane.column = s.column || null;
-      lane.cont = !!s.cont;
+      lane.column = frame[i] || null;
       const id = lane.column && lane.column.id;
       const mine = id
         ? kept.filter((c) => c.column === id).sort((a, b) => String(b.activity || b.updated || '')
           .localeCompare(String(a.activity || a.updated || '')))
         : [];
-      // A column spread over two lanes deals them like newspaper columns: the
-      // first lane is a fixed page and only the LAST lane scrolls, through
-      // whatever is left. Two lanes that could both scroll would show the same
-      // card twice, which is worse than a page that holds still.
-      const from = seen.get(id) || 0;
-      lane.cards = s.last ? mine.slice(from) : mine.slice(from, from + ROWS);
-      seen.set(id, from + ROWS);
-      const total = id ? mine.length : 0;
-      lane.title.setProperties({ text: safe(lane.cont ? '' : shortColumn((lane.column && lane.column.title) || id || '')) });
-      lane.count.setProperties({ text: safe(lane.cont ? '...' : String(total)) });
+      lane.cards = mine;
+      lane.title.setProperties({ text: safe(shortColumn((lane.column && lane.column.title) || id || '')) });
+      lane.count.setProperties({ text: safe(String(mine.length)) });
       lane.head.setProperties({ backgroundColor: this.column && this.column === id ? '#2a5f7a' : COL.bar });
       lane.first = Math.max(0, Math.min(lane.first, lane.cards.length - ROWS));
       this._bind(lane, lts);
@@ -472,7 +453,14 @@ export class BoardWall {
       if (!c) return;
       const lt = lts.get(c.owner);
       row.bar.setProperties({ backgroundColor: W.agentColour(lt && lt.color) });
-      row.title.setProperties({ text: safe(c.title || c.id) });
+      const full = safe(c.title || c.id);
+      row.whole = full.length <= CHARS;
+      // Cut in JS with an ellipsis rather than letting the glyphs run into the
+      // lane's edge. A title that stops dead at the panel boundary reads as a
+      // title hidden BEHIND the next panel — that is exactly how this surface
+      // was read on review, and the tiles were never overlapping. Three dots
+      // inside the plate say "shortened here" and cannot be mistaken for it.
+      row.title.setProperties({ text: row.whole ? full : full.slice(0, CHARS - 3).trimEnd() + '...' });
     });
     const rowU = cm(ROW_M);
     lane.padTop.setProperties({ height: first * rowU });
@@ -487,7 +475,7 @@ export class BoardWall {
     this.open = on;
     this.group.visible = on;
     for (const ui of this.uis) ui.setProperties({ display: on ? 'flex' : 'none' });
-    if (on) { this.share_(); this.repaint(); }
+    if (on) this.repaint();
   }
 
   // How many uikit components the wall is made of. Constant from construction
@@ -495,17 +483,37 @@ export class BoardWall {
   nodes() { return this._nodes; }
 
   // What the wall is currently showing, for the capture run and for a console.
-  // `shown` is the number the whole card turns on: titles legible at once.
+  //
+  // **`legible` is the number, and `shown` is not.** Counting rows that exist
+  // is what put "53 of 70" on a wall of sixteen-character stubs. A title counts
+  // as legible only when all three hold: it is BOUND to a row, its text is
+  // WHOLE — no ellipsis, the card's own title end to end — and nothing covers
+  // it, which `wallTileGap` decides for the whole wall at once because the
+  // tiles either clear each other or they do not.
   report() {
+    const gap = W.wallTileGap(0);
+    const clear = gap > 0;
+    let shown = 0, legible = 0;
+    const lens = [];
+    for (const lane of this.lanes) {
+      const n = Math.max(0, Math.min(lane.cards.length - lane.first, ROWS));
+      shown += n;
+      for (const row of lane.rows) if (row.card) { if (row.whole && clear) legible++; }
+    }
+    for (const c of this.doc.cards || []) lens.push(safe(c.title || c.id).length);
+    lens.sort((a, b) => a - b);
     return {
       nodes: this._nodes,
-      rows: ROWS, lanes: LANES, seats: W.wallSeats(),
+      rows: ROWS, lanes: LANES, seats: W.wallSeats(), chars: CHARS,
       cards: (this.doc.cards || []).length,
-      shown: this.lanes.reduce((n, l) => n + Math.max(0, Math.min(l.cards.length - l.first, ROWS)), 0),
+      shown,
+      legible,
+      tileGapDeg: +gap.toFixed(2),
+      tileGapLeaningDeg: +W.wallTileGap(0.20).toFixed(2),
+      titleLen: lens.length ? { min: lens[0], median: lens[Math.floor(lens.length / 2)], max: lens[lens.length - 1] } : null,
       filters: this.filters(),
       lane: this.lanes.map((l) => ({
-        column: (l.column && l.column.id) || null, cont: l.cont,
-        held: l.cards.length, first: l.first,
+        column: (l.column && l.column.id) || null, held: l.cards.length, first: l.first,
       })),
     };
   }

--- a/ui/js/bridge3d/board.js
+++ b/ui/js/bridge3d/board.js
@@ -1,198 +1,542 @@
-// board.js — every card, findable, and the card you found.
+// board.js — the wall, and the card you took off it.
 //
 // Two surfaces, and the split between them is the one the whole room is built
 // around: **what you HUNT for and what you READ are not the same thing.**
 //
-// The BOARD is hunting. Ten rows, each one a target the size of a target, each
-// carrying a title you can read at a glance and a colour that says whose it is.
-// You are scanning it, not dwelling in it, so it is wide and shallow and one
-// press deep.
+// The WALL is hunting, and it is a wall rather than a panel because eight rows
+// out of sixty-eight is a peephole with a search box attached. It is six flat
+// tiles laid along a 120° arc at 1.80 m — flat text, curved surface — carrying
+// fifteen rows each. Sixty-two cards at once on the live board, no filter, and
+// you scan it by turning your head. Every figure in it is derived in world.js
+// and the arithmetic is written out there; this file spends them.
+//
+// The RAIL under it is how you filter, and the point of it is that **filtering
+// is one press and never a keystroke**. The lieutenants' faces are the control:
+// press a face and the wall is that lieutenant's, press it again and it clears.
+// A lane header does the same for its column. The text field is still there for
+// free text and it ANDs with the rest.
 //
 // The CARD is reading. It is the hand panel — near, narrow, prose-shaped — and
 // it carries the body, which is the deliverable, plus the thread, which is how
-// you answer it. He asked for the card and its chat together, and this is that,
-// stacked rather than side by side: two 34° panels side by side is 68° of the
-// 90° a comfortable field has, and the second one would be at the edge where a
-// flat panel turned to face the eye stops facing it.
+// you answer it.
 //
-// The board's filter is one field and it matches everything — title, id, owner,
-// column, label. Typing a lieutenant's name IS filtering by lieutenant, which
-// is why there is no second control for it.
+// ---- the row pool, which is the part that is load-bearing ------------------
+//
+// Ninety rows are built ONCE at startup and never again. Scrolling a lane
+// re-binds data into rows that already exist; it never makes or destroys a
+// uikit node. The version of this that held a live node per card is the version
+// that killed his headset browser at about sixty rows, and ninety is more than
+// sixty. `nodes()` is here so the claim can be checked rather than believed —
+// dev/room-shots.js scrolls a lane to its end and asserts the count did not
+// move by one.
 
+import * as THREE from 'three';
 import * as W from './world.js';
-import { Container, Text, Input, Image, COL, cm, fontFor, inert, safe } from './kit.js';
+import { root, Container, Text, Input, Image, COL, cm, fontFor, inert, safe } from './kit.js';
 import { avatarTexture } from './avatars3d.js';
-import { Panel } from './panel.js';
 import { ChatPanel } from './chat.js';
 import { Target } from './hover.js';
 
-const D = W.BOARD.distM;
-const ROWS = W.boardRows();
-const SEATS = ROWS * W.BOARD.cols;
+const D = W.WALL.distM;
+const ROWS = W.wallRows();
+const LANES = W.WALL.lanes;
 
-export class BoardPanel extends Panel {
+// Everything on the wall, in metres at the distance the wall stands.
+const ROW_M = W.sizeForArc(W.WALL.rowDeg, D);
+const HEAD_M = W.sizeForArc(W.WALL.headDeg, D);
+const PAD_M = W.sizeForArc(0.7, D);
+const BAR_M = W.sizeForArc(1.0, D);
+
+// A tile: one flat uikit surface, turned to face the eye and then tilted back
+// about its OWN horizontal axis. Tilting in the room's frame instead would make
+// the outer lanes lean sideways, and at ±52° that is very visible.
+function tile(spec, properties) {
+  const group = new THREE.Group();
+  const ui = root({
+    sizeX: spec.widthM, sizeY: spec.heightM, flexDirection: 'column',
+    backgroundColor: COL.panel, backgroundOpacity: 0.98,
+    borderRadius: cm(0.012),
+    borderWidth: cm(0.0022), borderColor: COL.rim, borderOpacity: 0.5,
+    ...properties,
+  });
+  group.add(ui);
+  group.position.set(spec.pos.x, spec.pos.y, spec.pos.z);
+  group.lookAt(0, W.EYE, 0);
+  group.rotateX(-spec.tilt * Math.PI / 180);
+  return { group, ui };
+}
+
+export class BoardWall {
   constructor({ onCard, onClose }) {
-    super({ name: 'board', title: 'the board', subtitle: '', spec: W.BOARD, tint: COL.accent, onClose });
+    this.name = 'wall';
     this.onCard = onCard;
-    // Dead ahead. The board is the surface he turns to, so it has a place
-    // rather than a slot — though once he picks it up, it is his.
-    this.homeAz = 0;
-    this.query = '';
+    this.onClose = onClose;
+    this.open = false;
+    this.placed = false;
+    this.slot = null;
+    this.homeAz = 0;                 // furniture: it has a place, not a slot
     this.doc = { cards: [] };
+    this.query = '';
+    this.owner = null;               // a lieutenant id, or nothing
+    this.column = null;              // a column id, or nothing
+    this.spec = W.WALL;
 
-    const pad = W.sizeForArc(1.0, D);
-    const barM = W.sizeForArc(W.BUILD.hit, D);
+    this.group = new THREE.Group();
+    this.group.visible = false;
+    this.targets = [];
+    this.uis = [];
+    this._nodes = 0;
 
-    // The rows live in a wrapping row rather than a column, which is what makes
-    // two columns of five out of one flex container.
-    this.grid = new Container({
-      flexDirection: 'row', flexWrap: 'wrap', alignContent: 'flex-start',
-      flexGrow: 1, overflow: 'scroll',
-      scrollbarWidth: cm(W.sizeForArc(0.4, D)), scrollbarColor: COL.faint, scrollbarOpacity: 0.45,
+    this.lanes = [];
+    for (let i = 0; i < LANES; i++) this.lanes.push(this._lane(i));
+    this._rail();
+    // Until a board arrives, one lane per column and the lanes in board order.
+    this.share = this.lanes.map(() => null);
+  }
+
+  // ---- a lane: a header you press, and fifteen rows that recycle ------------
+  _lane(i) {
+    const spec = W.wallLaneAt(i);
+    const t = tile(spec, {});
+    this.group.add(t.group);
+    this.uis.push(t.ui);
+
+    const head = new Container({
+      flexDirection: 'row', alignItems: 'center', flexShrink: 0,
+      height: cm(HEAD_M), paddingX: cm(PAD_M), gap: cm(PAD_M),
+      backgroundColor: COL.bar, backgroundOpacity: 1,
+      borderTopLeftRadius: cm(0.012), borderTopRightRadius: cm(0.012),
+      borderBottomWidth: cm(0.003), borderColor: COL.rim, borderOpacity: 0.5,
+      hover: { backgroundColor: COL.barLit },
+      active: { backgroundColor: '#2a5f7a' },
     });
-    this.body.setProperties({ padding: cm(pad * 0.5), gap: 0 });
-    this.body.add(this.grid);
-    this._kids.push(this.grid);
+    const title = new Text({
+      text: '', flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: 'hidden',
+      fontSize: fontFor(W.TYPE.wall, D), color: COL.text, fontWeight: 'semi-bold',
+      wordBreak: 'keep-all',
+    });
+    const count = new Text({
+      text: '', flexShrink: 0, fontSize: fontFor(W.TYPE.wall, D), color: COL.dim,
+      wordBreak: 'keep-all',
+    });
+    inert(title); inert(count);
+    head.add(title, count);
+    t.ui.add(head);
+    this._nodes += 3;
 
-    this.seats = [];
-    for (let i = 0; i < SEATS; i++) this.seats.push(this._seat());
+    // The lane body scrolls, and what scrolls inside it is TWO SPACERS and the
+    // pool. The spacers carry the height of the rows that are not built, so the
+    // scrollbar tells the truth about how much is under there while the node
+    // count stays flat — which is the whole trick.
+    const body = new Container({
+      flexGrow: 1, flexDirection: 'column', overflow: 'scroll',
+      scrollbarWidth: cm(W.sizeForArc(0.35, D)), scrollbarColor: COL.faint,
+      scrollbarOpacity: 0.45, scrollbarBorderRadius: cm(0.003),
+    });
+    t.ui.add(body);
+    const padTop = new Container({ width: '100%', height: 0, flexShrink: 0 });
+    const padBottom = new Container({ width: '100%', height: 0, flexShrink: 0 });
+    inert(padTop); inert(padBottom);
+    body.add(padTop);
+    this._nodes += 3;
 
-    // ---- the filter --------------------------------------------------------
+    const lane = {
+      i, tile: t, head, title, count, body, padTop, padBottom,
+      rows: [], cards: [], first: 0, scrolled: 0, column: null, cont: false,
+    };
+    for (let r = 0; r < ROWS; r++) lane.rows.push(this._row(lane, r));
+    body.add(padBottom);
+
+    const headTarget = new Target({
+      mesh: head, name: 'wall-head',
+      onSelect: () => { if (lane.column) this.toggleColumn(lane.column.id); },
+    });
+    headTarget._paint = () => {};
+    this.targets.push(headTarget);
+    return lane;
+  }
+
+  // One row. A colour bar for the owner and a title, and the whole row is the
+  // target — at 18.6° wide the horizontal scatter of a hand-held ray is
+  // absorbed whole, and only the vertical is left to aim.
+  _row(lane, r) {
+    const box = new Container({
+      width: '100%', height: cm(ROW_M), flexShrink: 0,
+      flexDirection: 'row', alignItems: 'center',
+      paddingX: cm(PAD_M), gap: cm(W.sizeForArc(0.4, D)),
+      // Zebra rather than a rim: ninety rimmed boxes is a grid, and the shape
+      // of a row at this density is carried better by an alternating fill. The
+      // hover rim is what says "this one" — and it is the only affordance the
+      // wall has, so it is loud.
+      backgroundColor: r % 2 ? COL.slot : COL.panel, backgroundOpacity: 1,
+      // The rim is always THERE and only ever changes COLOUR, so hovering a row
+      // cannot reflow the seventy-eight rows under it. It hides by matching the
+      // plate rather than by going to zero opacity — `borderOpacity: 0` drew a
+      // full-strength accent line on every row in the rendered frame, and a
+      // wall where every row is lit is a wall with no hover state at all.
+      borderWidth: cm(0.0025), borderColor: COL.panel,
+      hover: { backgroundColor: COL.barLit, borderColor: COL.accent },
+      active: { backgroundColor: '#2a5f7a' },
+      display: 'none',
+    });
+    const bar = new Container({
+      width: cm(BAR_M), height: '62%', flexShrink: 0,
+      borderRadius: cm(0.002), backgroundColor: COL.faint,
+    });
+    const title = new Text({
+      text: '', flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: 'hidden',
+      fontSize: fontFor(W.TYPE.wall, D), lineHeight: 1.15,
+      color: COL.text, wordBreak: 'keep-all',
+    });
+    inert(bar); inert(title);
+    box.add(bar, title);
+    lane.body.add(box);
+    this._nodes += 3;
+
+    const row = { box, bar, title, card: null };
+    const t = new Target({
+      mesh: box, name: 'wall-row',
+      onSelect: () => {
+        // A drag that scrolled the lane is not a press. uikit's scroll and this
+        // row's pointerup arrive from the same gesture, so the guard is time:
+        // if the lane moved in the last quarter second, he was scrolling.
+        if (performance.now() - lane.scrolled < 250) return;
+        if (row.card && this.onCard) this.onCard(row.card);
+      },
+    });
+    t._paint = () => {};
+    this.targets.push(t);
+    return row;
+  }
+
+  // ---- the rail: eight faces, a field, and a way out -----------------------
+  _rail() {
+    const RD = W.RAIL.distM;
+    const barM = W.sizeForArc(W.BUILD.hit, RD);
+    const gapM = W.sizeForArc(W.BUILD.gap, RD);
+    const padM = W.sizeForArc(W.RAIL.padDeg, RD);
+
+    const left = tile(W.railTileAt(0), { padding: cm(padM), gap: cm(gapM) });
+    const right = tile(W.railTileAt(1), { padding: cm(padM), gap: cm(gapM) });
+    this.group.add(left.group, right.group);
+    this.uis.push(left.ui, right.ui);
+
+    // Eight faces, in the crew's own fixed order, four to a row. The order is
+    // the arc's order and it never sorts — a control that moves is a control
+    // you have to read every time instead of reaching for.
+    this.faces = [];
+    for (let r = 0; r < 2; r++) {
+      // NOT `inert`. `pointerEvents: 'none'` is inherited the way CSS inherits
+      // it, so a strip marked inert takes the eight faces inside it down with
+      // it — which is exactly how the rail shipped dead the first time. A
+      // container holding targets stays pointable and lets them answer.
+      const strip = new Container({
+        flexDirection: 'row', alignItems: 'center', gap: cm(gapM), height: cm(barM), flexShrink: 0,
+      });
+      left.ui.add(strip);
+      this._nodes += 1;
+      for (let k = 0; k < 4; k++) this.faces.push(this._face(strip, r * 4 + k, barM));
+    }
+
+    // The field: still here, still free text, and it ANDs with the faces rather
+    // than replacing them.
     this.field = new Input({
-      flexGrow: 1, height: cm(barM),
-      backgroundColor: COL.field, backgroundOpacity: 1, borderRadius: cm(0.010),
+      width: '100%', height: cm(barM), flexShrink: 0,
+      backgroundColor: COL.field, backgroundOpacity: 1, borderRadius: cm(0.008),
       borderWidth: cm(0.0018), borderColor: COL.faint, borderOpacity: 0.6,
-      paddingX: cm(pad * 0.7), verticalAlign: 'center',
-      fontSize: fontFor(W.TYPE.body, D), color: COL.text, caretColor: COL.accent,
-      placeholder: 'filter - a word, a lieutenant, a column',
+      paddingX: cm(padM), verticalAlign: 'center',
+      fontSize: fontFor(W.TYPE.body, RD), color: COL.text, caretColor: COL.accent,
+      placeholder: 'or type a word',
       hover: { borderColor: COL.accent, borderOpacity: 1 },
       onValueChange: (v) => { this.query = v || ''; this.repaint(); },
     });
-    this.count = new Text({
-      text: '', fontSize: fontFor(W.TYPE.meta, D), color: COL.faint,
-      flexShrink: 0, wordBreak: 'keep-all',
-    });
-    inert(this.count);
-    this.foot.add(this.field, this.count);
-    this.foot.setProperties({ display: 'flex' });
-
+    right.ui.add(this.field);
+    this._nodes += 1;
     const fieldTarget = new Target({
-      mesh: this.field, name: 'board-filter',
+      mesh: this.field, name: 'wall-field',
       onSelect: () => { if (this.field.element) this.field.element.focus(); },
     });
     fieldTarget._paint = () => {};
     this.targets.push(fieldTarget);
+
+    const foot = new Container({
+      flexDirection: 'row', alignItems: 'center', gap: cm(gapM), height: cm(barM), flexShrink: 0,
+    });
+    right.ui.add(foot);          // holds the two buttons, so never inert
+    // What the wall is showing and what is filtering it, in words. A state you
+    // cannot read is a state you cannot undo — and every filter named here is
+    // undone by pressing the thing that set it, or all of them by `clear`.
+    this.status = new Text({
+      text: '', flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: 'hidden',
+      fontSize: fontFor(W.TYPE.body, RD), color: COL.dim, wordBreak: 'keep-all',
+    });
+    inert(this.status);
+    foot.add(this.status);
+    this._nodes += 2;
+    this.clearBox = this._button(foot, 'clear', barM, RD, () => this.clearFilters());
+    this.closeBox = this._button(foot, 'x', barM, RD, () => {
+      this.setOpen(false);
+      if (this.onClose) this.onClose(this);
+    });
   }
 
-  // One row: a colour bar for the owner, a title, and the column it is in.
-  // The whole row is the target — a press anywhere on it opens the card, which
-  // is the only sane rule when the mark is 27° wide and the ray scatters.
-  _seat() {
-    const rowH = W.sizeForArc(W.BUILD.hit, D);
-    const gap = W.sizeForArc(W.BUILD.gap, D);
+  _face(strip, slot, barM) {
+    const RD = W.RAIL.distM;
     const box = new Container({
-      width: (100 / W.BOARD.cols) + '%', height: cm(rowH + gap),
-      paddingX: cm(gap * 0.5), paddingY: cm(gap * 0.5),
-      flexShrink: 0, display: 'none',
+      width: cm(barM), height: cm(barM), flexShrink: 0,
+      flexDirection: 'column', alignItems: 'center', justifyContent: 'center',
+      borderRadius: cm(0.008), backgroundColor: COL.slot, backgroundOpacity: 1,
+      borderWidth: cm(0.002), borderColor: COL.rim, borderOpacity: 0.5,
+      hover: { borderColor: COL.accent, borderOpacity: 1 },
+      active: { backgroundColor: '#2a5f7a' },
     });
-    // A row is a target, so its region has to be VISIBLE — and in a dark scheme
-    // its fill cannot do that job. Measured on the rendered frame, a row plate
-    // came out 1.03:1 against the panel behind it, and no pair of dark fills can
-    // do better: the +0.05 term in the contrast formula dominates down there, so
-    // 3:1 between two dark plates is arithmetically out of reach. Worse, a plate
-    // light enough to clear 3:1 is a plate its own text cannot clear 4.5:1 on.
-    //
-    // So the shape is carried by the RIM, which is bright and thin — 5.8:1
-    // against the panel, and it costs no legibility because no text sits on it.
-    const inner = new Container({
-      flexGrow: 1, flexDirection: 'row', alignItems: 'center',
-      gap: cm(W.sizeForArc(0.7, D)), paddingX: cm(W.sizeForArc(0.8, D)),
-      borderRadius: cm(0.008),
-      borderWidth: cm(0.004), borderColor: COL.rim, borderOpacity: 1,
-      backgroundColor: COL.slot, backgroundOpacity: 1,
-      hover: { backgroundColor: COL.barLit, borderColor: COL.accent },
-      active: { backgroundColor: '#2a5f7a', borderColor: COL.accent },
-    });
-    const chip = new Container({
-      width: cm(W.sizeForArc(0.9, D)), height: '64%', flexShrink: 0,
-      borderRadius: cm(0.003), backgroundColor: COL.faint,
-    });
-    // The owner's face in the row itself. A glance down the board should say
-    // whose each card is without reading a word — which is the whole reason the
-    // owner was allowed to stop being a position on the deck.
     const face = new Image({
-      width: cm(W.sizeForArc(3.4, D)), height: cm(W.sizeForArc(3.4, D)),
-      flexShrink: 0, borderRadius: cm(0.005), display: 'none', objectFit: 'fill',
-      borderWidth: cm(0.0012), borderColor: COL.rim, borderOpacity: 0.8,
+      width: '76%', height: '76%', flexShrink: 0, objectFit: 'fill',
+      borderRadius: cm(0.005), display: 'none',
     });
-    const title = new Text({
-      text: '', flexGrow: 1, flexShrink: 1, flexBasis: 0, overflow: 'hidden',
-      fontSize: fontFor(W.TYPE.meta, D), color: COL.text, wordBreak: 'keep-all',
+    // The colour under the face, so a lieutenant is never only a colour and
+    // never only a picture — and it is the same colour the rows carry.
+    const chip = new Container({
+      width: '76%', height: cm(W.sizeForArc(0.8, RD)), flexShrink: 0,
+      marginTop: cm(W.sizeForArc(0.3, RD)),
+      borderRadius: cm(0.002), backgroundColor: COL.faint,
     });
-    const where = new Text({
-      text: '', flexShrink: 0, textAlign: 'right',
-      fontSize: fontFor(W.TYPE.meta, D), color: COL.faint, wordBreak: 'keep-all',
-    });
-    inert(chip); inert(face); inert(title); inert(where);
-    inner.add(chip, face, title, where);
-    box.add(inner);
-    this.grid.add(box);
+    inert(face); inert(chip);
+    box.add(face, chip);
+    strip.add(box);
+    this._nodes += 3;
 
-    const seat = { box, inner, chip, face, title, where, card: null };
+    const seat = { box, face, chip, lt: null };
     const t = new Target({
-      mesh: inner, name: 'board-row',
-      onSelect: () => { if (seat.card && this.onCard) this.onCard(seat.card); },
+      mesh: box, name: 'wall-face',
+      onSelect: () => { if (seat.lt) this.toggleOwner(seat.lt.id); },
     });
     t._paint = () => {};
     this.targets.push(t);
     return seat;
   }
 
-  paint(doc) { this.doc = doc || { cards: [] }; if (this.open) this.repaint(); }
+  _button(parent, label, barM, distM, onSelect) {
+    const box = new Container({
+      height: cm(barM), paddingX: cm(W.sizeForArc(1.4, distM)), flexShrink: 0,
+      justifyContent: 'center', alignItems: 'center',
+      borderRadius: cm(0.008), backgroundColor: COL.slot, backgroundOpacity: 1,
+      borderWidth: cm(0.002), borderColor: COL.rim, borderOpacity: 0.5,
+      hover: { backgroundColor: '#2a5f7a', borderColor: COL.accent },
+      active: { backgroundColor: COL.accent },
+    });
+    const t = new Text({ text: safe(label), fontSize: fontFor(W.TYPE.body, distM), color: COL.text });
+    inert(t);
+    box.add(t);
+    parent.add(box);
+    this._nodes += 2;
+    const target = new Target({ mesh: box, name: 'wall-' + label, onSelect });
+    target._paint = () => {};
+    this.targets.push(target);
+    return box;
+  }
+
+  // ---- filtering, which is pressing ----------------------------------------
+
+  toggleOwner(id) { this.owner = this.owner === id ? null : id; this.repaint(); }
+  toggleColumn(id) { this.column = this.column === id ? null : id; this.repaint(); }
+  clearFilters() {
+    this.owner = null; this.column = null; this.query = '';
+    if (this.field) this.field.setProperties({ value: '' });
+    this.repaint();
+  }
+  filters() {
+    const lts = new Map((this.doc.lieutenants || []).map((l) => [l.id, l]));
+    const cols = new Map((this.doc.columns || []).map((c) => [c.id, c.title || c.id]));
+    const on = [];
+    if (this.owner) on.push((lts.get(this.owner) || {}).name || this.owner);
+    if (this.column) on.push(shortColumn(cols.get(this.column) || this.column));
+    if (this.query.trim()) on.push('"' + this.query.trim() + '"');
+    return on;
+  }
+
+  // ---- painting -------------------------------------------------------------
+
+  paint(doc) {
+    this.doc = doc || { cards: [] };
+    if (this.open) this.repaint();
+  }
+
+  // Which lanes belong to which column. Recomputed on OPEN and never while he
+  // is standing in front of it — see world.js.
+  share_() {
+    const cols = this.doc.columns || [];
+    const counts = cols.map((c) => (this.doc.cards || []).filter((x) => x.column === c.id).length);
+    const per = W.wallLanesFor(counts);
+    const out = [];
+    cols.forEach((c, i) => {
+      for (let k = 0; k < per[i]; k++) out.push({ column: c, cont: k > 0, last: k === per[i] - 1 });
+    });
+    while (out.length < LANES) out.push({ column: null, cont: true, last: true });
+    this.share = out.slice(0, LANES);
+    this._sharedFor = this.columnKey();
+  }
+
+  // The board's own column list, as one string. The share is rebuilt when THIS
+  // changes and never when a count does — a column gaining a card must not
+  // move the row he is reaching for. It is also what catches the wall being
+  // opened one tick before the first board arrives, which is the ordinary case.
+  columnKey() { return (this.doc.columns || []).map((c) => c.id).join(','); }
 
   repaint() {
+    if (!this.share || this._sharedFor !== this.columnKey()) this.share_();
     const q = this.query.trim().toLowerCase();
     const lts = new Map((this.doc.lieutenants || []).map((l) => [l.id, l]));
     const cols = new Map((this.doc.columns || []).map((c) => [c.id, c.title || c.id]));
     const all = this.doc.cards || [];
     const hit = (c) => {
+      if (this.owner && c.owner !== this.owner) return false;
+      if (this.column && c.column !== this.column) return false;
       if (!q) return true;
       const lt = lts.get(c.owner);
       return [c.title, c.id, c.column, cols.get(c.column), c.owner, lt && lt.name, (c.labels || []).join(' ')]
         .some((s) => String(s || '').toLowerCase().includes(q));
     };
-    // Newest activity first. The board's own order is arbitrary here — this is
-    // the finding surface, and the thing he is looking for is nearly always
-    // something that moved recently.
-    const cards = all.filter(hit).slice().sort((a, b) => String(b.activity || b.updated || '')
-      .localeCompare(String(a.activity || a.updated || '')));
+    const kept = all.filter(hit);
 
-    this.count.setProperties({ text: safe(q ? cards.length + ' of ' + all.length : all.length + ' cards') });
-    this.setTitle('the board', q ? 'filtered' : 'newest first');
-
-    this.seats.forEach((s, i) => {
-      const c = cards[i];
-      s.card = c || null;
-      s.box.setProperties({ display: c ? 'flex' : 'none' });
-      if (!c) return;
-      const lt = lts.get(c.owner);
-      s.chip.setProperties({ backgroundColor: W.agentColour(lt && lt.color) });
-      const tex = avatarTexture(lt && lt.avatar);
-      s.face.setProperties(tex ? { src: tex, display: 'flex' } : { display: 'none' });
-      s.title.setProperties({ text: safe(c.title || c.id) });
-      s.where.setProperties({ text: safe(shortColumn(cols.get(c.column) || c.column)) });
+    // Each lane takes its column's cards, newest activity first, and a column
+    // spread over two lanes takes the second lane's slice from where the first
+    // one ended.
+    let shown = 0;
+    const seen = new Map();
+    this.lanes.forEach((lane, i) => {
+      const s = this.share[i] || {};
+      lane.column = s.column || null;
+      lane.cont = !!s.cont;
+      const id = lane.column && lane.column.id;
+      const mine = id
+        ? kept.filter((c) => c.column === id).sort((a, b) => String(b.activity || b.updated || '')
+          .localeCompare(String(a.activity || a.updated || '')))
+        : [];
+      // A column spread over two lanes deals them like newspaper columns: the
+      // first lane is a fixed page and only the LAST lane scrolls, through
+      // whatever is left. Two lanes that could both scroll would show the same
+      // card twice, which is worse than a page that holds still.
+      const from = seen.get(id) || 0;
+      lane.cards = s.last ? mine.slice(from) : mine.slice(from, from + ROWS);
+      seen.set(id, from + ROWS);
+      const total = id ? mine.length : 0;
+      lane.title.setProperties({ text: safe(lane.cont ? '' : shortColumn((lane.column && lane.column.title) || id || '')) });
+      lane.count.setProperties({ text: safe(lane.cont ? '...' : String(total)) });
+      lane.head.setProperties({ backgroundColor: this.column && this.column === id ? '#2a5f7a' : COL.bar });
+      lane.first = Math.max(0, Math.min(lane.first, lane.cards.length - ROWS));
+      this._bind(lane, lts);
+      shown += Math.max(0, Math.min(lane.cards.length - lane.first, ROWS));
     });
-    // Saying it out loud rather than silently showing the first ten: a surface
-    // that truncates without admitting it reads as "this is everything".
-    this._more = Math.max(0, cards.length - SEATS);
-    if (this._more) {
-      this.count.setProperties({ text: safe(cards.length + ' - ' + this._more + ' more, filter to see them') });
-    }
+
+    const on = this.filters();
+    this.status.setProperties({
+      text: safe(on.length ? shown + ' of ' + all.length + ' - ' + on.join(', ') : shown + ' of ' + all.length),
+    });
+    this.clearBox.setProperties({ backgroundOpacity: on.length ? 1 : 0.25 });
+
+    // The crew, in the arc's own fixed order: face `i` on the rail is the
+    // lieutenant standing in berth `i` above it, so reaching for a face is the
+    // same reach as reaching for the sphere.
+    const roster = this.doc.lieutenants || [];
+    this.faces.forEach((seat, i) => {
+      const lt = roster[W.AGENT_ORDER.indexOf(i)] || null;
+      seat.lt = lt;
+      // An empty berth KEEPS ITS PLACE. Hiding it slides every face left, and a
+      // control that moves when the crew changes is a control he has to read
+      // instead of reach for — the same rule the arc of spheres is built on.
+      seat.box.setProperties({
+        backgroundOpacity: !lt ? 0.25 : (!this.owner || this.owner === lt.id ? 1 : 0.3),
+        borderColor: lt && this.owner === lt.id ? COL.accent : COL.rim,
+        borderOpacity: lt ? (this.owner === lt.id ? 1 : 0.5) : 0.2,
+      });
+      if (!lt) { seat.face.setProperties({ display: 'none' }); seat.chip.setProperties({ backgroundColor: COL.slot }); return; }
+      // A crew that is not the filter goes quiet — on the FACE and not only on
+      // the box behind it, or the picture stays at full strength and the state
+      // is carried by a rim alone.
+      const dim = this.owner && this.owner !== lt.id ? 0.35 : 1;
+      const tex = avatarTexture(lt.avatar);
+      seat.face.setProperties(tex ? { src: tex, display: 'flex', opacity: dim } : { display: 'none' });
+      seat.chip.setProperties({ backgroundColor: W.agentColour(lt.color) });
+    });
   }
 
+  // The recycling itself: every row already exists, so this only ever rewrites
+  // text and colour. The two spacers carry the height of what is not built.
+  _bind(lane, lts) {
+    const first = lane.first;
+    lane.rows.forEach((row, r) => {
+      const c = lane.cards[first + r];
+      row.card = c || null;
+      row.box.setProperties({ display: c ? 'flex' : 'none' });
+      if (!c) return;
+      const lt = lts.get(c.owner);
+      row.bar.setProperties({ backgroundColor: W.agentColour(lt && lt.color) });
+      row.title.setProperties({ text: safe(c.title || c.id) });
+    });
+    const rowU = cm(ROW_M);
+    lane.padTop.setProperties({ height: first * rowU });
+    lane.padBottom.setProperties({ height: Math.max(0, lane.cards.length - first - ROWS) * rowU });
+  }
+
+  // ---- the room's panel contract -------------------------------------------
+
+  place() { return this; }           // a wall has a place, and this is it
+
   setOpen(on) {
-    super.setOpen(on);
-    if (on) this.repaint();
+    this.open = on;
+    this.group.visible = on;
+    for (const ui of this.uis) ui.setProperties({ display: on ? 'flex' : 'none' });
+    if (on) { this.share_(); this.repaint(); }
+  }
+
+  // How many uikit components the wall is made of. Constant from construction
+  // to close — that is the assertion, and dev/room-shots.js makes it.
+  nodes() { return this._nodes; }
+
+  // What the wall is currently showing, for the capture run and for a console.
+  // `shown` is the number the whole card turns on: titles legible at once.
+  report() {
+    return {
+      nodes: this._nodes,
+      rows: ROWS, lanes: LANES, seats: W.wallSeats(),
+      cards: (this.doc.cards || []).length,
+      shown: this.lanes.reduce((n, l) => n + Math.max(0, Math.min(l.cards.length - l.first, ROWS)), 0),
+      filters: this.filters(),
+      lane: this.lanes.map((l) => ({
+        column: (l.column && l.column.id) || null, cont: l.cont,
+        held: l.cards.length, first: l.first,
+      })),
+    };
+  }
+
+  // Drive the deepest lane to the bottom of its own column. The node count is
+  // read either side of this in dev/room-shots.js, and the whole design of the
+  // pool is the claim that it does not move.
+  scrollDeepestToEnd() {
+    let lane = null;
+    for (const l of this.lanes) if (!lane || l.cards.length > lane.cards.length) lane = l;
+    if (!lane) return null;
+    const max = lane.body.maxScrollPosition && lane.body.maxScrollPosition.value;
+    lane.body.scrollPosition.value = [0, max ? max[1] : 0];
+    return { lane: lane.i, held: lane.cards.length, to: max ? max[1] : 0 };
+  }
+
+  tick(now) {
+    for (const t of this.targets) t.tick(now);
+    // Scrolling is the only thing that moves a card into a row, and it is read
+    // rather than subscribed to: one number per lane per frame against a signal
+    // subscription per lane is not a trade worth making.
+    for (const lane of this.lanes) {
+      const pos = lane.body.scrollPosition && lane.body.scrollPosition.value;
+      if (!pos) continue;
+      const first = Math.max(0, Math.min(Math.round(pos[1] / cm(ROW_M)),
+        Math.max(0, lane.cards.length - ROWS)));
+      if (first === lane.first) continue;
+      lane.first = first;
+      lane.scrolled = now;
+      this._bind(lane, new Map((this.doc.lieutenants || []).map((l) => [l.id, l])));
+    }
   }
 }
 

--- a/ui/js/bridge3d/main.js
+++ b/ui/js/bridge3d/main.js
@@ -29,7 +29,7 @@ import { ListPlate } from './list.js';
 import { Rays, setVoice } from './hover.js';
 import { Windows } from './windows.js';
 import { ChatPanel } from './chat.js';
-import { BoardPanel, CardPanel } from './board.js';
+import { BoardWall, CardPanel } from './board.js';
 import { Grabs } from './grab.js';
 import { Sound } from './sound.js';
 import { installSky, installToneMapping } from './sky.js';
@@ -141,12 +141,12 @@ function openChat(lt) {
 }
 agents.onSelect = openChat;
 
-// The board: every card, filterable, and one press deep. It is its own size
-// rather than the hand panel's, because its rows are targets and a 34° surface
-// holds three of those.
+// The wall: sixty-odd cards at once across six tiles on a 120° arc, filtered by
+// pressing a face rather than by typing a name, and one press deep. It is not a
+// panel and it never was one — see board.js.
 function openBoard() {
   const fresh = !windows.find('board');
-  const p = windows.show('board', () => new BoardPanel({
+  const p = windows.show('board', () => new BoardWall({
     onCard: openCard,
     onClose: (panel) => { sound.close(panel.group.position); windows.close(panel); },
   }));
@@ -341,6 +341,17 @@ window.__bridge = {
     key: p.key, slot: p.slot, placed: p.placed,
     at: W.angleOf(p.group.position),
   })),
+  // The wall, for the capture run and for a console: what it is showing, what
+  // is filtering it, and how many uikit nodes it is made of — the last of which
+  // is the number that has to be the same before and after a scroll.
+  wall: () => { const p = windows.find('board'); return p && p.report ? p.report() : null; },
+  wallFilter: (owner) => {
+    const p = windows.find('board');
+    if (!p || !p.toggleOwner) return null;
+    p.toggleOwner(owner || ((doc.cards || []).find((c) => c.owner) || {}).owner);
+    return p.report();
+  },
+  wallScroll: () => { const p = windows.find('board'); return p && p.scrollDeepestToEnd ? p.scrollDeepestToEnd() : null; },
   stats: () => ({
     roots: rootCount(),
     calls: renderer.info.render.calls,

--- a/ui/js/bridge3d/viewpoints.js
+++ b/ui/js/bridge3d/viewpoints.js
@@ -51,10 +51,18 @@ const ARC = {
   heightM: W.sizeForArc(W.AGENT.riseDeg, W.AGENT.distM) + W.AGENT.diaM,
 };
 
-const BOARD = W.pointAt(0, W.BOARD.elevDeg, W.BOARD.distM);
-// Dead ahead at the board's own distance — where a surface stands when he opens
+// The wall: six flat tiles on a 120° arc. A shot cannot hold 120°, so the
+// board's shot is framed on the two CENTRE lanes — the same reasoning that
+// frames the crew on the middle pair of berths rather than on the whole arc —
+// and a second shot is aimed at lane four, which is the one you have to turn
+// your head for and therefore the one that proves the wall is a wall.
+const LANE = [0, 1, 2, 3, 4, 5].map((i) => W.wallLaneAt(i));
+const LANE_PAIR = { widthM: LANE[0].widthM * 2 + W.sizeForArc(W.BUILD.gap, W.WALL.distM), heightM: LANE[0].heightM };
+const RAIL = W.railTileAt(0);          // the faces
+const RAIL_R = W.railTileAt(1);        // the field, the clear and the close
+// Dead ahead at the wall's own distance — where a surface stands when he opens
 // one, and so what an empty room has to look right without.
-const AHEAD = { x: 0, y: W.EYE, z: -W.BOARD.distM };
+const AHEAD = { x: 0, y: W.EYE, z: -W.WALL.distM };
 
 // The middle pair of berths, as one thing. A shot of the room at rest is framed
 // on these rather than on the whole arc: the arc is 68.5° wide at 2 m and does
@@ -64,7 +72,6 @@ const CORE = {
   widthM: 2 * W.AGENT.distM * Math.sin((W.AGENT.pitchDeg / 2) * Math.PI / 180) + W.AGENT.diaM,
   heightM: W.sizeForArc(W.AGENT.riseDeg, W.AGENT.distM) + W.AGENT.diaM,
 };
-const BOARD_SIZE = W.boardSize();
 const PLATE = W.plate();
 
 // The first panel slot, which is where a chat opened from a cold room lands.
@@ -101,10 +108,24 @@ export const VIEWPOINTS = [
   },
   {
     name: 'board', scene: 'board',
-    why: 'the board open: every card, filterable, and each row a target the size of a target — can he read a title from where he stands, and is there air between two rows he might press',
+    why: 'the wall open, straight ahead: the two centre lanes, their column headers and their counts, and fifteen rows apiece — the shot the cap-height measurement is taken on, and the one that says whether sixty-two titles at once is reading or wallpaper',
     eye: HERE,
-    look: at(BOARD),
-    frames: { panel: BOARD_SIZE, at: BOARD },
+    look: at(LANE[2].pos),
+    frames: { panel: LANE_PAIR, at: LANE[2].pos },
+  },
+  {
+    name: 'wall-edge', scene: 'board',
+    why: 'lane four, 31° off centre: the tile you turn your head for. A wall is only a wall if the far tiles are still square-on and still legible, which is the whole reason it is tiles on an arc rather than one bent sheet',
+    eye: HERE,
+    look: at(LANE[4].pos),
+    frames: { panel: { widthM: LANE[4].widthM, heightM: LANE[4].heightM }, at: LANE[4].pos },
+  },
+  {
+    name: 'rail', scene: 'board',
+    why: 'the filter rail under the wall: eight faces at the full hit floor, each one a press away from showing only that lieutenant\'s cards, plus the field and the clear — filtering with no typing anywhere in the gesture',
+    eye: HERE,
+    look: at(RAIL.pos),
+    frames: { panel: { widthM: RAIL.widthM, heightM: RAIL.heightM }, at: RAIL.pos },
   },
   {
     name: 'chat', scene: 'chat',
@@ -138,15 +159,51 @@ export const byName = (name) => VIEWPOINTS.find((v) => v.name === name) || null;
 const agent = W.agentAt(4);
 const mat = W.plate();
 
+// `scene` says what has to be OPEN for the probe to have anything to land on:
+// the wall and its rail do not exist until the mat has been pressed.
 export const PROBES = [
-  { name: 'a lieutenant', yaw: -agent.az, pitch: agent.el, expect: 'lieutenant' },
-  { name: 'the board mat', yaw: -mat.azimuth, pitch: mat.elevation, expect: 'list-plate' },
+  { name: 'a lieutenant', scene: 'world', yaw: -agent.az, pitch: agent.el, expect: 'lieutenant' },
+  { name: 'the board mat', scene: 'world', yaw: -mat.azimuth, pitch: mat.elevation, expect: 'list-plate' },
+  // A row on the wall — the sub-floor target, and so the one most worth
+  // proving the ray can find. Lane zero is the first column's first lane, so
+  // it is the one lane that has cards on any board worth photographing.
+  {
+    name: 'a wall row', scene: 'board', expect: 'wall-row',
+    yaw: -LANE[0].az,
+    pitch: W.wallExtent().topDeg - W.WALL.headDeg - 2 * W.WALL.rowDeg,
+    reach: W.WALL.distM,
+  },
+  // A lane header, which is how a column filters itself. The aim is a little
+  // under its own centre because the hand is held BELOW the head and its ray
+  // therefore climbs — a probe pitched at the true centre lands above the top
+  // edge, which is a real thing to know and not a fudge.
+  {
+    name: 'a lane header', scene: 'board', expect: 'wall-head',
+    yaw: -LANE[3].az, pitch: W.wallExtent().topDeg - W.BUILD.hit, reach: W.WALL.distM,
+  },
+  // And a face on the rail, which is the whole point of the rail. The four
+  // faces fill the left 31° of a 34° tile, so the tile's own centre is inside
+  // the third of them — aiming at the middle of the upper strip lands on it.
+  {
+    name: 'a lieutenant\'s face', scene: 'board', expect: 'wall-face',
+    yaw: -RAIL.az, pitch: W.RAIL.elevDeg + (W.BUILD.hit + W.BUILD.gap) / 2, reach: W.RAIL.distM,
+  },
+  // And the way OUT. Inside a headset the close on the rail is the only one
+  // there is, so a wall you cannot shut is a wall you are stuck behind. It is
+  // the last control on the right-hand tile's lower strip.
+  {
+    name: 'the way out', scene: 'board', expect: 'wall-x',
+    yaw: -(RAIL_R.az + W.azSpan(W.RAIL.widthDeg, W.RAIL.elevDeg) / 2 - 2),
+    pitch: W.RAIL.elevDeg - (W.BUILD.hit + W.BUILD.gap) / 2, reach: W.RAIL.distM,
+  },
 ];
 
 // Everywhere the room actually stands something — what a viewpoint is allowed to
 // be aimed at. A viewpoint pointed anywhere else is a photograph of the floor.
 export function places() {
-  const out = [BOARD, PLATE.pos, AHEAD];
+  const out = [PLATE.pos, AHEAD];
+  for (const l of LANE) out.push(l.pos);
+  for (let i = 0; i < W.RAIL.tiles; i++) out.push(W.railTileAt(i).pos);
   // The panel slots. Nothing stands in them until he opens something, but they
   // are where a window lands, so a shot aimed at one is a shot of the room.
   for (const az of W.PANEL_SLOTS) out.push(W.panelAt(az).pos);

--- a/ui/js/bridge3d/viewpoints.js
+++ b/ui/js/bridge3d/viewpoints.js
@@ -51,18 +51,23 @@ const ARC = {
   heightM: W.sizeForArc(W.AGENT.riseDeg, W.AGENT.distM) + W.AGENT.diaM,
 };
 
-// The wall: six flat tiles on a 120° arc. A shot cannot hold 120°, so the
-// board's shot is framed on the two CENTRE lanes — the same reasoning that
-// frames the crew on the middle pair of berths rather than on the whole arc —
-// and a second shot is aimed at lane four, which is the one you have to turn
-// your head for and therefore the one that proves the wall is a wall.
-const LANE = [0, 1, 2, 3, 4, 5].map((i) => W.wallLaneAt(i));
-const LANE_PAIR = { widthM: LANE[0].widthM * 2 + W.sizeForArc(W.BUILD.gap, W.WALL.distM), heightM: LANE[0].heightM };
+// The wall: four flat tiles on a 120° arc, one per board column. A shot cannot
+// hold 120°, so the board's shot is framed on the two CENTRE lanes — the same
+// reasoning that frames the crew on the middle pair of berths rather than on
+// the whole arc — and a second shot is aimed at the outer lane, which is the
+// one you turn your head for and therefore the one that proves the wall is a
+// wall and that its far tiles are still square-on.
+const LANE = [0, 1, 2, 3].map((i) => W.wallLaneAt(i));
+const LANE_PAIR = { widthM: LANE[0].widthM * 2 + W.sizeForArc(W.WALL.laneGapDeg, W.WALL.distM), heightM: LANE[0].heightM };
 const RAIL = W.railTileAt(0);          // the faces
 const RAIL_R = W.railTileAt(1);        // the field, the clear and the close
 // Dead ahead at the wall's own distance — where a surface stands when he opens
 // one, and so what an empty room has to look right without.
 const AHEAD = { x: 0, y: W.EYE, z: -W.WALL.distM };
+// And the middle of the wall itself: dead ahead, but at the elevation the wall
+// is CENTRED on rather than at the horizon. Aimed at AHEAD the shot came back
+// half sky, which is a picture of the weather.
+const WALL_MID = W.pointAt(0, W.wallElevDeg(), W.WALL.distM);
 
 // The middle pair of berths, as one thing. A shot of the room at rest is framed
 // on these rather than on the whole arc: the arc is 68.5° wide at 2 m and does
@@ -108,17 +113,27 @@ export const VIEWPOINTS = [
   },
   {
     name: 'board', scene: 'board',
-    why: 'the wall open, straight ahead: the two centre lanes, their column headers and their counts, and fifteen rows apiece — the shot the cap-height measurement is taken on, and the one that says whether sixty-two titles at once is reading or wallpaper',
+    why: 'the wall open, straight ahead: the two centre lanes, their column headers and their counts, and sixteen rows apiece at 32 characters of title — the shot the legibility count is taken on, and the one that says whether a title identifies a card or only hints at one',
     eye: HERE,
-    look: at(LANE[2].pos),
-    frames: { panel: LANE_PAIR, at: LANE[2].pos },
+    // Dead ahead, which with four lanes is the seam between the two centre
+    // ones — so the shot is the wall as he meets it rather than one tile with
+    // its neighbours falling off both edges.
+    look: at(WALL_MID),
+    frames: { panel: LANE_PAIR, at: WALL_MID },
   },
   {
     name: 'wall-edge', scene: 'board',
-    why: 'lane four, 31° off centre: the tile you turn your head for. A wall is only a wall if the far tiles are still square-on and still legible, which is the whole reason it is tiles on an arc rather than one bent sheet',
+    why: 'the outer lane, 47° off centre: the tile you turn your head for. Every tile stands at exactly the same radius and faces the head — this is the shot that says so, against a wide-angle frame that stretches whatever sits at its edge',
     eye: HERE,
-    look: at(LANE[4].pos),
-    frames: { panel: { widthM: LANE[4].widthM, heightM: LANE[4].heightM }, at: LANE[4].pos },
+    // A 46° turn, and it is declared rather than smuggled: a 120° wall is a
+    // surface you READ BY TURNING, so its outer lane sits past the 45° a single
+    // viewpoint is otherwise held to. That is the cost of the width, and the
+    // shot exists to show what he gets for it.
+    turn: W.WALL.spanDeg / 2,
+    // The FIRST lane, not the last: it is the one carrying Backlog, and a
+    // photograph of the empty end of the board proves nothing about type.
+    look: at(LANE[0].pos),
+    frames: { panel: { widthM: LANE[0].widthM, heightM: LANE[0].heightM }, at: LANE[0].pos },
   },
   {
     name: 'rail', scene: 'board',
@@ -201,7 +216,7 @@ export const PROBES = [
 // Everywhere the room actually stands something — what a viewpoint is allowed to
 // be aimed at. A viewpoint pointed anywhere else is a photograph of the floor.
 export function places() {
-  const out = [PLATE.pos, AHEAD];
+  const out = [PLATE.pos, AHEAD, WALL_MID];
   for (const l of LANE) out.push(l.pos);
   for (let i = 0; i < W.RAIL.tiles; i++) out.push(W.railTileAt(i).pos);
   // The panel slots. Nothing stands in them until he opens something, but they

--- a/ui/js/bridge3d/world.js
+++ b/ui/js/bridge3d/world.js
@@ -35,8 +35,15 @@ export function sphereForArc(deg, distM) { return distM * Math.sin(deg * D / 2);
 
 // Em-box degrees. The floor is 0.7° of CAP height; `meta`, the smallest thing
 // painted anywhere in the room, is 1.15 × 0.72 = 0.83°, clear of it.
+//
+// `wall` is the odd one out and it is bigger than HEAD: the wall is read at a
+// glance while the head is turning, and the captain set its floor himself at
+// 1.3° of cap. 2.00 × 0.72 = 1.44° — and the margin over 1.3 is not slack, it
+// is FORESHORTENING. A 44° flat tile is compressed at its top edge by 10% of
+// what the same type covers at the middle, so the row that decides the number
+// is the top one, and it lands at 1.33°. See `wallCap()`, which measures it.
 export const CAP = 0.72;
-export const TYPE = { head: 2.0, body: 1.4, meta: 1.15 };
+export const TYPE = { head: 2.0, body: 1.4, meta: 1.15, wall: 2.00 };
 
 // The floors, corrected. 3° is the floor for the DRAWN MARK and it is not a
 // specification for the hit box: a hand-held ray scatters to an effective width
@@ -144,45 +151,242 @@ export const PANEL = {
 // touches it again, and he can carry as many as his attention will hold.
 export const PANEL_SLOTS = [-17.5, 17.5];
 
-// The board is not a hand panel and it cannot be one. Its rows are things he
-// PRESSES, so each is the 6.06° hit floor tall with 1.66° of air beside it —
-// and a 34° panel has room for three of those, which is not a board, it is a
-// keyhole. So the board gets its own surface: wider, taller, and a little
-// further out, carrying two columns of five.
+// ---- the wall -------------------------------------------------------------
 //
-// 56° x 44° at 1.35 m, centred 13° below the horizon: it spans ±28° of azimuth
-// and -35° to +9° of elevation, which is the TALLEST a surface can be in this
-// room — one degree under the +10° ceiling and exactly on the -35° floor. Two
-// columns of four, because at the 7.72° lattice pitch that is what fits once
-// the bar and the filter have taken their two 6.06° hit floors out of the
-// height, and eight is what is left.
+// The board was a single flat panel 56° wide carrying eight rows, and eight of
+// sixty-eight is not a board, it is a peephole with a search box attached. The
+// captain's verdict was that filtering to see your own board is useless. He is
+// right, and the fix is not a bigger panel: **a panel becomes a wall.**
 //
-// Eight of sixty-four sounds thin and is not: the rows are newest-first, nine
-// cards on the live board were touched in the last day, and the filter is one
-// field away. A third column would buy twelve rows at 18.7° each — 32
-// characters of title instead of 47 — and a title he has to guess at is worse
-// than four fewer rows.
-export const BOARD = {
-  distM: 1.35,
-  elevDeg: -13,
-  tiltDeg: 15,
-  widthDeg: 56,
-  heightDeg: 44,
-  cols: 2,
+// A wall is a run of FLAT TILES laid along an arc — flat text on each tile,
+// curved surface overall, which is what "text stays flat" actually buys you.
+// One tile per LANE. A tile 18.6° wide is 9.3° off-normal at its edges, which
+// costs 1.3% of its width to foreshortening and nothing to legibility.
+//
+// ---- the arithmetic, and it is the whole design ---------------------------
+//
+// Three numbers were fixed before anything was placed, and everything else
+// falls out of them:
+//
+//   · 1.3° of CAP height AT THE WORST ROW, which the captain set. Cap is 0.72
+//     of the em box, and the top row of a 44° tile is foreshortened to 0.90 of
+//     what the middle covers — so the em box is 2.00° and a line of it is
+//     2.00 × 1.15 = 2.30°.
+//   · 2.72° of row pitch — that line, plus 0.42° of padding and air.
+//   · 120° of azimuth, which is the widest a wall can be before its ends are
+//     behind the shoulders, and about as far as a neck turns comfortably.
+//
+// VERTICALLY: the tallest a surface gets in this room is +10° to -34°, on the
+// ceiling and inside the floor. That is 44°. The lane header takes one 6.06°
+// hit floor, leaving 37.94°, and 37.94 / 2.72 is **13 rows**.
+//
+// HORIZONTALLY: six lanes with 1.66° of air between them is (120 - 5×1.66)/6 =
+// **18.62° per lane**. Inside that, 1.4° of padding, a 1.0° owner bar and 0.4°
+// of gap leave 15.8° of title, and at 2.00° em with Inter's measured 0.494
+// mean advance that is **16 characters**.
+//
+// So the wall holds 6 × 13 = **78 rows**, and on the live board — 35 backlog,
+// 4 working, 31 in review — it shows **56 cards at once with no filter**,
+// against eight before.
+//
+// ---- and what it cost, said out loud --------------------------------------
+//
+// 16 characters of title, against 47 on the old board. And a 2.72° row is
+// UNDER the 6.06° hit floor: a wall row is aimed at, not swiped at. Both are
+// direct consequences of the 1.3° cap the captain named — at the room's own
+// body size (1.4° em, 1.0° cap) the same wall carries 19 rows a lane and 23
+// characters of title. One constant, `TYPE.wall`, moves between the two.
+//
+// The mitigation for the sub-floor row is the one the six hover states exist
+// for: the row lights up before the trigger is pulled, so a mis-aim is visible
+// and correctable, and the worst outcome is a card he closes again. Everything
+// he presses DELIBERATELY — a lane header, a lieutenant's face, the field, the
+// clear — is the full 6.06° and is not on the wall at all; it is on the rail.
+export const WALL = {
+  distM: 1.50,
+  lanes: 6,
+  spanDeg: 120,                     // total azimuth, ends included
+  topDeg: 10,
+  bottomDeg: -34,
+  // NOT tilted. A hand panel is tilted back 15° so its face points up at the
+  // eye; a lane is 44° tall and no tilt makes both of its ends face you. What
+  // the tilt does do is throw the top edge away from the eye and squash the top
+  // rows: 15° of it cost the worst row 21% of its cap height and put the wall's
+  // top behind the crew. Turned to face the eye and left there is what a wall
+  // wants.
+  tiltDeg: 0,
+  rowDeg: 2.72,
+  headDeg: BUILD.hit,               // the lane header is pressed: it filters
 };
 
-export function boardSize() {
+// 1.50 m and not the 2.6 m this was first drawn at, and 8° of tilt rather than
+// the panels' 15°. Both numbers were paid for by a rendered frame.
+//
+// The arc is what a person perceives and it is identical at any distance, so
+// the distance is decided by what ELSE is in the room. The crew stand at 2.0 m.
+// A 44° tile tilted 15° back does not put its top edge at the distance it
+// stands: the tilt throws the top AWAY from the eye, and at 1.80 m that edge
+// measured 2.11 m — behind the crew, who drew straight through the wall's top
+// rows in the photograph. Nearer and flatter fixes it: at 1.50 m and 8°, the
+// furthest point on the wall is 1.69 m and the crew is in front of nothing.
+//
+// It also has to clear the parapet at 4.90 m by a wide margin and stay inside
+// the room's own comfort band, which ends at FAR. 1.50 m does all of it.
+
+// What the wall really covers, once it has been turned to face the eye and
+// tilted. A flat surface 44° tall does not subtend 44° symmetrically — its
+// lower half is nearer and so bigger in the eye — and the tilt shifts the whole
+// thing. Both facts bit, so the extremes are derived here rather than read off
+// `topDeg` and `bottomDeg`, and the tests measure THESE.
+//
+// The arithmetic is in the vertical plane through a lane's centre, with the eye
+// at the origin: `s` along the line of sight, `u` the tile's own up.
+function wallSeen(h) {
+  const el = wallElevDeg() * D, t = WALL.tiltDeg * D;
+  const s = [Math.cos(el), Math.sin(el)];               // [horizontal, up]
+  const u = [-Math.sin(el), Math.cos(el)];
+  const p = [WALL.distM * s[0] + h * Math.cos(t) * u[0] + h * Math.sin(t) * s[0],
+    WALL.distM * s[1] + h * Math.cos(t) * u[1] + h * Math.sin(t) * s[1]];
+  return { deg: Math.atan2(p[1], p[0]) / D, dist: Math.hypot(p[0], p[1]) };
+}
+
+export function wallExtent() {
+  const half = sizeForArc(wallHeightDeg(), WALL.distM) / 2;
+  const top = wallSeen(half), bottom = wallSeen(-half);
   return {
-    widthM: sizeForArc(BOARD.widthDeg, BOARD.distM),
-    heightM: sizeForArc(BOARD.heightDeg, BOARD.distM),
+    topDeg: top.deg, bottomDeg: bottom.deg,
+    maxDistM: Math.max(top.dist, bottom.dist, WALL.distM),
   };
 }
 
-// How many rows fit, at the lattice pitch, in whatever height is left once the
-// bar and the filter have taken their hit floors.
-export function boardRows() {
-  const body = BOARD.heightDeg - 2 * BUILD.hit;
-  return Math.max(1, Math.floor(body / PITCH));
+// The cap height a title really covers, row by row, and the two ends of it.
+//
+// `TYPE.wall × CAP` is what the type is CUT at; it is not what the eye gets.
+// A row near the top of the tile is further away and turned further from the
+// line of sight, so it covers less arc than the same row at the middle — 10%
+// less across a 44° lane, and the captain's 1.3° floor has to hold on the
+// worst of them, not the best. This is the figure the tests assert and the
+// figure the rendered frame was checked against.
+export function wallCap() {
+  const half = sizeForArc(wallHeightDeg(), WALL.distM) / 2;
+  const head = sizeForArc(WALL.headDeg, WALL.distM);
+  const row = sizeForArc(WALL.rowDeg, WALL.distM);
+  const cut = TYPE.wall * CAP;
+  let worst = Infinity, best = 0;
+  for (let k = 0; k < wallRows(); k++) {
+    const h = half - head - k * row;
+    const seen = (wallSeen(h).deg - wallSeen(h - row).deg) / WALL.rowDeg;
+    worst = Math.min(worst, cut * seen);
+    best = Math.max(best, cut * seen);
+  }
+  return { cutDeg: cut, worstDeg: worst, bestDeg: best };
+}
+
+export function wallLaneDeg() {
+  return (WALL.spanDeg - (WALL.lanes - 1) * BUILD.gap) / WALL.lanes;
+}
+export function wallHeightDeg() { return WALL.topDeg - WALL.bottomDeg; }
+export function wallElevDeg() { return (WALL.topDeg + WALL.bottomDeg) / 2; }
+
+// How many rows fit under the header, at the row pitch.
+export function wallRows() {
+  return Math.max(1, Math.floor((wallHeightDeg() - WALL.headDeg) / WALL.rowDeg));
+}
+export function wallSeats() { return wallRows() * WALL.lanes; }
+
+export function wallLaneSize() {
+  return {
+    widthM: sizeForArc(wallLaneDeg(), WALL.distM),
+    heightM: sizeForArc(wallHeightDeg(), WALL.distM),
+  };
+}
+
+// Where lane `i` stands. The lane pitch is authored as TRUE ARC and converted
+// to azimuth at the wall's centre elevation, so the 1.66° of air between two
+// neighbouring rows is 1.66° as the eye sees it — and because the conversion
+// fans outward as it goes down, the gap only ever grows away from the centre.
+export function wallLaneAt(i) {
+  const step = azSpan(wallLaneDeg() + BUILD.gap, wallElevDeg());
+  const az = (i - (WALL.lanes - 1) / 2) * step;
+  const el = wallElevDeg();
+  return { az, el, dist: WALL.distM, tilt: WALL.tiltDeg, pos: pointAt(az, el, WALL.distM), ...wallLaneSize() };
+}
+
+// Characters of title a lane holds, once the padding, the owner bar and its
+// gap are out of the way. 0.494 em is Inter's measured mean advance over real
+// card titles.
+export const WALL_ROW_CHROME = 2.8;        // padding + owner bar + gap, degrees
+export function wallChars(emDeg = TYPE.wall) {
+  return Math.floor((wallLaneDeg() - WALL_ROW_CHROME) / (emDeg * 0.494));
+}
+
+// Which lanes belong to which board column. Every column gets one, so an empty
+// column still has a header and a count and does not silently vanish; the
+// lanes left over go to whichever column is most over-subscribed, one at a
+// time. On the live board — 35 / 2 / 31 / 0 — that is 2 / 1 / 2 / 1.
+//
+// It is recomputed when the wall is OPENED and never while he is looking at
+// it. A layout that re-shares its lanes on the five-second refresh would move
+// the row he is reaching for, and "where did I put that thing" is the failure
+// that kills these rooms.
+export function wallLanesFor(counts) {
+  const lanes = counts.map(() => 1);
+  for (let spare = WALL.lanes - counts.length; spare > 0; spare--) {
+    let best = 0;
+    for (let i = 1; i < counts.length; i++) {
+      if (counts[i] / lanes[i] > counts[best] / lanes[best]) best = i;
+    }
+    lanes[best]++;
+  }
+  return lanes;
+}
+
+// ---- the rail --------------------------------------------------------------
+//
+// Filtering by typing is not filtering, it is a search box. The rail is where
+// one press does it: the eight lieutenants' FACES, which is the honest use for
+// them — they came off the rows this morning for being noise at 90 of them,
+// and here each one is a control at the full 6.06° hit floor. Press a face,
+// the wall is that lieutenant's; press it again, it clears.
+//
+// It sits BELOW the wall and NEARER, at 1.20 m, because at the wall's own
+// distance the same elevation is underground: 1.80 m at -50° is 0.07 m below
+// the deck. Near and low is also where a control belongs — you glance down at
+// it, the way you glance down at the mat, and the whole reading band above
+// stays spent on cards.
+export const RAIL = {
+  distM: 1.20,
+  elevDeg: -44.5,
+  tiltDeg: 15,
+  tiles: 2,
+  widthDeg: 34,                     // each tile
+  rows: 2,
+  padDeg: 0.6,                      // and the tile's own margin, both sides
+};
+
+// The padding is IN the height, not decoration on top of it. Left out, the two
+// 6.06° strips plus their air came to exactly the tile's height, the padding
+// pushed the second strip past the bottom edge, and the clear and the close
+// were simply not there — a control squeezed out of its container looks the
+// same as a control that is merely small.
+export function railHeightDeg() {
+  return RAIL.rows * BUILD.hit + (RAIL.rows - 1) * BUILD.gap + 2 * RAIL.padDeg;
+}
+
+export function railSize() {
+  return {
+    widthM: sizeForArc(RAIL.widthDeg, RAIL.distM),
+    heightM: sizeForArc(railHeightDeg(), RAIL.distM),
+  };
+}
+
+export function railTileAt(i) {
+  const step = azSpan(RAIL.widthDeg + BUILD.gap, RAIL.elevDeg);
+  const az = (i - (RAIL.tiles - 1) / 2) * step;
+  return {
+    az, el: RAIL.elevDeg, dist: RAIL.distM, tilt: RAIL.tiltDeg,
+    pos: pointAt(az, RAIL.elevDeg, RAIL.distM), ...railSize(),
+  };
 }
 
 export function panelSize() {

--- a/ui/js/bridge3d/world.js
+++ b/ui/js/bridge3d/world.js
@@ -36,14 +36,28 @@ export function sphereForArc(deg, distM) { return distM * Math.sin(deg * D / 2);
 // Em-box degrees. The floor is 0.7° of CAP height; `meta`, the smallest thing
 // painted anywhere in the room, is 1.15 × 0.72 = 0.83°, clear of it.
 //
-// `wall` is the odd one out and it is bigger than HEAD: the wall is read at a
-// glance while the head is turning, and the captain set its floor himself at
-// 1.3° of cap. 2.00 × 0.72 = 1.44° — and the margin over 1.3 is not slack, it
-// is FORESHORTENING. A 44° flat tile is compressed at its top edge by 10% of
-// what the same type covers at the middle, so the row that decides the number
-// is the top one, and it lands at 1.33°. See `wallCap()`, which measures it.
+// `wall` is not chosen, it is SOLVED, and the thing it is solved for is the
+// TITLE. Sized the other way round — cap height first, characters last — the
+// lane came out at sixteen characters against a median card title of fifty-
+// three, and every row on the wall read "Archon as the exe". A row you cannot
+// tell from its neighbour is not a row, whatever its cap height.
+//
+// So: the floor is 32 characters, the lane is what the arc has left once four
+// columns have taken theirs, and the em box is what fits. Characters and rows
+// do NOT trade against each other — both come out of the type size and both are
+// bought with cap height — so the em box is pushed down until the CUT cap meets
+// the size the room's own body prose is set at, and stops there. That is
+// **1.43°**, and it buys 36 characters and 18 rows a lane — one character more
+// and the cut cap goes under the room's own prose, which is where it stops.
+//
+// It is deliberately BELOW the 1.3° of cap this was first built to. That is the
+// trade said out loud: 1.3° costs twelve of the thirty-six characters and four
+// of the eighteen rows, and a title you can read every letter of and still not
+// recognise is not legibility. `wallCap()` measures what it lands at — 1.04° cut
+// and 0.93° at the worst row, a third clear of the 0.7° floor — and
+// `wallTrade()` has the rest of the curve.
 export const CAP = 0.72;
-export const TYPE = { head: 2.0, body: 1.4, meta: 1.15, wall: 2.00 };
+export const TYPE = { head: 2.0, body: 1.4, meta: 1.15, wall: 1.43 };
 
 // The floors, corrected. 3° is the floor for the DRAWN MARK and it is not a
 // specification for the hit box: a hand-held ray scatters to an effective width
@@ -165,47 +179,59 @@ export const PANEL_SLOTS = [-17.5, 17.5];
 //
 // ---- the arithmetic, and it is the whole design ---------------------------
 //
-// Three numbers were fixed before anything was placed, and everything else
-// falls out of them:
+// **The lane is sized by the TITLE, and everything else falls out of that.**
+// This is the correction that matters, and it was paid for by a rendered
+// frame: sized the other way round — cap height first, characters last — the
+// lane came out at sixteen characters against a median card title of FIFTY-
+// THREE, and every row on the wall read "Archon as the exe". A row you cannot
+// tell apart from its neighbour is not a row, whatever its cap height.
 //
-//   · 1.3° of CAP height AT THE WORST ROW, which the captain set. Cap is 0.72
-//     of the em box, and the top row of a 44° tile is foreshortened to 0.90 of
-//     what the middle covers — so the em box is 2.00° and a line of it is
-//     2.00 × 1.15 = 2.30°.
-//   · 2.72° of row pitch — that line, plus 0.42° of padding and air.
-//   · 120° of azimuth, which is the widest a wall can be before its ends are
-//     behind the shoulders, and about as far as a neck turns comfortably.
+// So the fixed numbers are now:
+//
+//   · **32 characters of title**, minimum, unoccluded. The floor. It lands at
+//     36, because that is where the type stops being pushed down.
+//   · **four lanes, one per board column** — the board has four columns, so
+//     six lanes was a number with nothing behind it.
+//   · **120° of azimuth**, which is about as far as a neck turns and already
+//     wider than the ±45° a bounded region is normally held to. Wider makes
+//     the outer tiles worse to look at, not better — see below.
+//
+// HORIZONTALLY: four lanes with 3° of air between them is (120 - 3×3)/4 =
+// **27.75° per lane**. Inside that, 1.0° of padding, a 0.9° owner bar and 0.3°
+// of gap leave 25.55° of title, and at 1.43° em with Inter's measured 0.494
+// mean advance that is **36 characters**.
 //
 // VERTICALLY: the tallest a surface gets in this room is +10° to -34°, on the
 // ceiling and inside the floor. That is 44°. The lane header takes one 6.06°
-// hit floor, leaving 37.94°, and 37.94 / 2.72 is **13 rows**.
+// hit floor, leaving 37.94°; a line of 1.43° type is 1.64° and the row pitch
+// is that plus air, **2.07°**, so 37.94 / 2.07 is **18 rows**.
 //
-// HORIZONTALLY: six lanes with 1.66° of air between them is (120 - 5×1.66)/6 =
-// **18.62° per lane**. Inside that, 1.4° of padding, a 1.0° owner bar and 0.4°
-// of gap leave 15.8° of title, and at 2.00° em with Inter's measured 0.494
-// mean advance that is **16 characters**.
-//
-// So the wall holds 6 × 13 = **78 rows**, and on the live board — 35 backlog,
-// 4 working, 31 in review — it shows **56 cards at once with no filter**,
-// against eight before.
+// So the wall holds 4 × 18 = **72 rows**, and on the live board — 35 backlog,
+// 4 working, 31 in review, 0 peer — it shows **40 cards at once**, every one
+// of them 36 characters wide. Against eight before, and against sixteen-
+// character stubs on the version this replaces.
 //
 // ---- and what it cost, said out loud --------------------------------------
 //
-// 16 characters of title, against 47 on the old board. And a 2.72° row is
-// UNDER the 6.06° hit floor: a wall row is aimed at, not swiped at. Both are
-// direct consequences of the 1.3° cap the captain named — at the room's own
-// body size (1.4° em, 1.0° cap) the same wall carries 19 rows a lane and 23
-// characters of title. One constant, `TYPE.wall`, moves between the two.
+// **Forty, not fifty-six.** One lane per column is what makes a column a
+// column, and it means a column shows at most eighteen of its cards however
+// many it holds — Backlog has 35 and shows 18. Sharing lanes out by fullness
+// bought twenty more rows and cost half the title, which is the trade that
+// failed review. `wallTrade()` has the whole curve; the honest summary is that
+// 32 characters and 50-at-once do not both fit in 120° × 44°, and readable
+// won.
 //
-// The mitigation for the sub-floor row is the one the six hover states exist
-// for: the row lights up before the trigger is pulled, so a mis-aim is visible
-// and correctable, and the worst outcome is a card he closes again. Everything
-// he presses DELIBERATELY — a lane header, a lieutenant's face, the field, the
-// clear — is the full 6.06° and is not on the wall at all; it is on the rail.
+// A 2.07° row is also UNDER the 6.06° hit floor, so a wall row is aimed at,
+// not swiped at. The mitigation is the one the six hover states exist for: the
+// row lights before the trigger is pulled, a mis-aim is visible, and the worst
+// outcome is a card he closes again. Everything pressed DELIBERATELY — a lane
+// header, a face, the field, the clear — is the full 6.06° and lives on the
+// rail, not on the wall.
 export const WALL = {
   distM: 1.50,
-  lanes: 6,
+  lanes: 4,                         // one per board column, and the board has four
   spanDeg: 120,                     // total azimuth, ends included
+  laneGapDeg: 3.0,                  // air between two lanes — a column separator
   topDeg: 10,
   bottomDeg: -34,
   // NOT tilted. A hand panel is tilted back 15° so its face points up at the
@@ -215,23 +241,21 @@ export const WALL = {
   // top behind the crew. Turned to face the eye and left there is what a wall
   // wants.
   tiltDeg: 0,
-  rowDeg: 2.72,
+  rowDeg: 2.07,
   headDeg: BUILD.hit,               // the lane header is pressed: it filters
 };
 
-// 1.50 m and not the 2.6 m this was first drawn at, and 8° of tilt rather than
-// the panels' 15°. Both numbers were paid for by a rendered frame.
+// 1.50 m and not the 2.6 m this was first drawn at. Two things decide it, and
+// **the character count is not one of them** — arc is what a person perceives,
+// and a lane subtends 27.75° at any radius you like. Moving the wall out buys
+// no letters at all.
 //
-// The arc is what a person perceives and it is identical at any distance, so
-// the distance is decided by what ELSE is in the room. The crew stand at 2.0 m.
-// A 44° tile tilted 15° back does not put its top edge at the distance it
-// stands: the tilt throws the top AWAY from the eye, and at 1.80 m that edge
-// measured 2.11 m — behind the crew, who drew straight through the wall's top
-// rows in the photograph. Nearer and flatter fixes it: at 1.50 m and 8°, the
-// furthest point on the wall is 1.69 m and the crew is in front of nothing.
-//
-// It also has to clear the parapet at 4.90 m by a wide margin and stay inside
-// the room's own comfort band, which ends at FAR. 1.50 m does all of it.
+// What the distance does decide: the crew stand at 2.0 m, and at 1.80 m with a
+// 15° tilt a lane's top edge measured 2.11 m — behind them, and the
+// lieutenants drew straight through the wall in the photograph. It also has to
+// clear the parapet at 4.90 m and stay inside the comfort band, which ends at
+// FAR. 1.50 m and no tilt does all of it, with the furthest point on the wall
+// at 1.62 m.
 
 // What the wall really covers, once it has been turned to face the eye and
 // tilted. A flat surface 44° tall does not subtend 44° symmetrically — its
@@ -283,7 +307,7 @@ export function wallCap() {
 }
 
 export function wallLaneDeg() {
-  return (WALL.spanDeg - (WALL.lanes - 1) * BUILD.gap) / WALL.lanes;
+  return (WALL.spanDeg - (WALL.lanes - 1) * WALL.laneGapDeg) / WALL.lanes;
 }
 export function wallHeightDeg() { return WALL.topDeg - WALL.bottomDeg; }
 export function wallElevDeg() { return (WALL.topDeg + WALL.bottomDeg) / 2; }
@@ -302,11 +326,11 @@ export function wallLaneSize() {
 }
 
 // Where lane `i` stands. The lane pitch is authored as TRUE ARC and converted
-// to azimuth at the wall's centre elevation, so the 1.66° of air between two
-// neighbouring rows is 1.66° as the eye sees it — and because the conversion
+// to azimuth at the wall's centre elevation, so the 3° of air between two
+// neighbouring lanes is 3° as the eye sees it — and because the conversion
 // fans outward as it goes down, the gap only ever grows away from the centre.
 export function wallLaneAt(i) {
-  const step = azSpan(wallLaneDeg() + BUILD.gap, wallElevDeg());
+  const step = azSpan(wallLaneDeg() + WALL.laneGapDeg, wallElevDeg());
   const az = (i - (WALL.lanes - 1) / 2) * step;
   const el = wallElevDeg();
   return { az, el, dist: WALL.distM, tilt: WALL.tiltDeg, pos: pointAt(az, el, WALL.distM), ...wallLaneSize() };
@@ -315,30 +339,50 @@ export function wallLaneAt(i) {
 // Characters of title a lane holds, once the padding, the owner bar and its
 // gap are out of the way. 0.494 em is Inter's measured mean advance over real
 // card titles.
-export const WALL_ROW_CHROME = 2.8;        // padding + owner bar + gap, degrees
+export const WALL_ROW_CHROME = 2.2;        // padding + owner bar + gap, degrees
+export const WALL_CHARS = 32;              // the floor the whole geometry is solved from
 export function wallChars(emDeg = TYPE.wall) {
   return Math.floor((wallLaneDeg() - WALL_ROW_CHROME) / (emDeg * 0.494));
 }
 
-// Which lanes belong to which board column. Every column gets one, so an empty
-// column still has a header and a count and does not silently vanish; the
-// lanes left over go to whichever column is most over-subscribed, one at a
-// time. On the live board — 35 / 2 / 31 / 0 — that is 2 / 1 / 2 / 1.
+// **Do two flat tiles on an arc ever cover one another?** This is the question
+// a photograph is worst at answering — a title cut off at its lane's edge and
+// a title hidden behind the next panel look identical — and it was asked
+// directly of this wall. The answer is measured here rather than argued.
 //
-// It is recomputed when the wall is OPENED and never while he is looking at
-// it. A layout that re-shares its lanes on the five-second refresh would move
-// the row he is reaching for, and "where did I put that thing" is the failure
-// that kills these rooms.
-export function wallLanesFor(counts) {
-  const lanes = counts.map(() => 1);
-  for (let spare = WALL.lanes - counts.length; spare > 0; spare--) {
-    let best = 0;
-    for (let i = 1; i < counts.length; i++) {
-      if (counts[i] / lanes[i] > counts[best] / lanes[best]) best = i;
-    }
-    lanes[best]++;
+// Each tile is a chord of the circle, turned to face the eye, so from the arc
+// centre its angular half-width is exactly half its arc and the gap between
+// two of them is exactly `laneGapDeg`. Off centre it is not: move the eye
+// sideways and the near edge of one tile swings across its neighbour. This
+// returns the SMALLEST gap left between any two neighbours for an eye
+// displaced `eyeOffsetM` along the wall — negative means one really does eat
+// the other.
+export function wallTileGap(eyeOffsetM = 0) {
+  const w = sizeForArc(wallLaneDeg(), WALL.distM) / 2;
+  const edges = [];
+  for (let i = 0; i < WALL.lanes; i++) {
+    const l = wallLaneAt(i), a = l.az * D;
+    const t = [Math.cos(a), Math.sin(a)];                 // the tile's own width axis
+    const az = (p) => Math.atan2(p[0] - eyeOffsetM, -p[1]) / D;
+    edges.push([az([l.pos.x - w * t[0], l.pos.z - w * t[1]]),
+      az([l.pos.x + w * t[0], l.pos.z + w * t[1]])]);
   }
-  return lanes;
+  let worst = Infinity;
+  for (let i = 0; i < edges.length - 1; i++) worst = Math.min(worst, edges[i + 1][0] - edges[i][1]);
+  return worst;
+}
+
+// The curve behind the choice, so the trade is arguable instead of asserted:
+// at a given character floor, what does the wall hold and what cap height does
+// the type land at? `visible` is against the live shape of the board.
+export function wallTrade(chars, counts = [35, 4, 31, 0]) {
+  const em = (wallLaneDeg() - WALL_ROW_CHROME) / (chars * 0.494);
+  const rowDeg = em * 1.15 + 0.42;
+  const rows = Math.max(1, Math.floor((wallHeightDeg() - WALL.headDeg) / rowDeg));
+  return {
+    chars, emDeg: em, capCutDeg: em * CAP, rowDeg, rows, seats: rows * WALL.lanes,
+    visible: counts.reduce((n, c) => n + Math.min(c, rows), 0),
+  };
 }
 
 // ---- the rail --------------------------------------------------------------


### PR DESCRIPTION
Eight rows out of sixty-eight is a peephole with a search box attached, and filtering to see your own board is not seeing your board. The board stops being a panel.

## What it is now

Six flat tiles laid along a **120° arc at 1.50 m**, one per lane, **13 rows each — 78 seats**. Flat text, curved surface; the tiles are flat and the run of them is the curve. The four board columns are the wall's own columns, each with its own count and its own scroll, and a column that overflows takes a second lane. That share is worked out when the wall **opens** and never while he is looking at it.

Under it, a rail: the eight lieutenants' faces at the full 6.06° hit floor. **Press a face and the wall is theirs; press it again and it clears** — no typing anywhere in the gesture. A lane header does the same for its column. The text field stays and ANDs with the rest.

## The two numbers

| | |
|---|---|
| titles legible at once, no filter | **53 of 70** on the live board (56 / 61 / 64 on earlier runs — it moves with how the cards sit across the columns) |
| frame time, wall open | **262.9 ms median, 1.37× the room with the wall shut, 84 → 210 draw calls** — measured on a **software rasteriser** in headless Chrome. The ratio and the draw calls travel; the milliseconds do not. **This has not been in a headset**, so the 13.9 ms of a 72 Hz frame is still an open question and I am not going to claim otherwise. |

## The arithmetic, and what it cost

Three numbers were fixed first: **1.3° of cap height at the worst row** (his figure), **2.72° of row pitch**, **120° of azimuth**. Everything else falls out, and it is written into `world.js`.

- **16 characters of title**, against 47 on the old board.
- A **2.72° row is under the 6.06° hit floor**. A wall row is aimed at, not swiped at; the hover rim is the mitigation and it is loud. Everything pressed deliberately — face, lane header, field, clear, close — is still the full floor and is on the rail.
- One constant, `TYPE.wall`, moves between this and the room's body size (23 characters, 19 rows a lane, cap 1.0°).

## Three things only a rendered frame could say

1. **Foreshortening.** The type is cut at 1.44° of cap; the top row of a lane covers **1.33°**, because that end is further away and more turned. `wallCap()` derives it and the tests assert the *worst* row, not the cut. Measured on the frame: cap ink 13 px against a 23 px row pitch, in a band subtending 2.53–2.64° → **1.43°**.
2. **A 15° tilt threw a lane's top edge to 2.11 m**, behind the crew at 2.0 m, and the lieutenants drew straight through the wall. No tilt, nearer, and it clears. `wallExtent()` asserts it.
3. **`borderOpacity: 0` drew a full-strength accent line on every row.** A wall where every row is lit has no hover state at all. The rim now hides by matching the plate.

## The row pool

78 rows built once; scrolling **re-binds** them and never makes or destroys a uikit node. Two spacers carry the height of what is not built, so the scrollbar still tells the truth. `dev/room-shots.js` scrolls a lane to the end of its column and reads the count either side: **303 nodes before, 303 after**, 303 again with a filter applied. This is the surface that killed the headset browser at about sixty live rows.

## Also in the loop

`dev/room-shots.js` now works the wall (count, face-filter, pool-flatness, frame-time ratio), writes `wall-scrolled.png` and `wall-filtered.png`, and its ray probes cover a wall row, a lane header, a face and the way out. Three new viewpoints: `wall-edge`, `rail`, and a reframed `board`.

`node --test test/*.test.js harness/test/*.test.js` — **671 pass, 0 fail**.