### PR TITLE
The no-mistakes clerk, promoted out of the scratchpad

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -64,3 +64,13 @@ retries on its own.
 - `test/install/docker-install-test.sh` verifies the README install procedure end-to-end in a
   pristine Docker container; `--demo` also populates a demo board on port 4790 (the fixture
   behind the README screenshot) and keeps the container running.
+
+## `bin/nm-clerk.sh` — the no-mistakes clerk
+
+Not part of the server. It drives `no-mistakes axi` through its gates with no model in the
+loop — fix the `auto-fix`, approve when only `no-op` remains, stop dead on `ask-user` — and it
+ALWAYS exits 0, reporting through `$ARTIFACTS_DIR/nm-outcome` and `escalation.md`, because it
+runs as a bash node inside an Archon `loop_group` where a non-zero exit kills the whole run.
+The `bc-card` Archon workflow calls it by absolute path (`<this repo>/bin/nm-clerk.sh`), so the
+path is an interface: moving the file breaks a pipeline that lives outside this repo.
+Its tests replay gate payloads recorded from real runs — `node --test test/nm-clerk.test.js`.

--- a/bin/nm-clerk.sh
+++ b/bin/nm-clerk.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# nm-clerk.sh — drive `no-mistakes axi` through its gates with no model in the loop.
+#
+#   nm-clerk.sh --intent-file <file> [extra axi run flags...]
+#
+# The gate is a mapping, not a judgement: `auto-fix` findings get fixed, a gate
+# with nothing actionable left gets approved, and an `ask-user` finding stops the
+# clerk — that call belongs to a human.
+#
+# ALWAYS EXITS 0. This runs as a bash node inside an Archon `loop_group`, where a
+# non-zero exit kills the whole run and a crashed run looks exactly like a broken
+# one. So the outcome travels in files:
+#
+#   $ARTIFACTS_DIR/nm-outcome     passed | escalated | failed
+#   $ARTIFACTS_DIR/escalation.md  the whole payload, when a finding is ask-user
+#
+# and the reason it stopped goes to stdout, which is the node's output and the
+# next round's only account of what happened.
+#
+# Env:
+#   NM_BIN              the no-mistakes binary (default: no-mistakes)
+#   NM_MAX_FIX_ROUNDS   fix rounds before giving up (default: 3). The fixer can
+#                       introduce findings of its own — it has committed
+#                       __pycache__ — so an unbounded fix loop is a real shape.
+#   NM_MAX_GATES        total gates answered before giving up (default: 20)
+#   ARTIFACTS_DIR       where the outcome files go (default: .)
+#   NM_CLERK_LOG        where no-mistakes' stderr goes (default: /dev/stderr)
+set -uo pipefail
+
+NM=${NM_BIN:-no-mistakes}
+MAX_FIX_ROUNDS=${NM_MAX_FIX_ROUNDS:-3}
+MAX_GATES=${NM_MAX_GATES:-20}
+ART=${ARTIFACTS_DIR:-.}
+LOG=${NM_CLERK_LOG:-/dev/stderr}
+
+INTENT_FILE=
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --intent-file) INTENT_FILE=${2:-}; shift 2 ;;
+    --intent-file=*) INTENT_FILE=${1#*=}; shift ;;
+    *) break ;;
+  esac
+done
+
+mkdir -p "$ART"
+
+# finish <outcome> <reason>
+finish() {
+  printf '%s\n' "$1" > "$ART/nm-outcome"
+  printf 'clerk: %s\n' "$2"
+  exit 0
+}
+
+[ -n "$INTENT_FILE" ] && [ -r "$INTENT_FILE" ] \
+  || finish failed "usage: nm-clerk.sh --intent-file <readable file> [axi run flags...]"
+
+# Pull `<id>\t<action>` out of the TOON tabular block `findings[N]{cols}:`.
+# The COLUMNS ARE READ FROM THE HEADER, never assumed by position: a reordered
+# or extended header must not silently shift `action` onto another field.
+# Fields are comma-separated with optional double quotes and backslash escapes;
+# descriptions carry both, so the split has to respect them.
+parse_findings() {
+  awk '
+    function splitrow(line, out,   i, c, f, inq, nf) {
+      delete out; nf = 0; f = ""; inq = 0
+      for (i = 1; i <= length(line); i++) {
+        c = substr(line, i, 1)
+        if (c == "\\" && inq) { i++; f = f substr(line, i, 1); continue }
+        if (c == "\"") { inq = !inq; continue }
+        if (c == "," && !inq) { out[++nf] = f; f = ""; continue }
+        f = f c
+      }
+      out[++nf] = f
+      return nf
+    }
+    /^ *findings\[[0-9]+\]\{/ {
+      hdr = $0; sub(/^[^{]*\{/, "", hdr); sub(/\}.*$/, "", hdr)
+      n = split(hdr, col, ",")
+      idc = 0; ac = 0
+      for (i = 1; i <= n; i++) { if (col[i] == "id") idc = i; if (col[i] == "action") ac = i }
+      if (!idc || !ac) { print "PARSE_ERROR no id/action column in header: " hdr; exit }
+      match($0, /^ */); hdrind = RLENGTH; inblk = 1; next
+    }
+    inblk {
+      match($0, /^ */); ind = RLENGTH
+      line = $0; sub(/^ +/, "", line)
+      if (ind <= hdrind || line == "") { inblk = 0; next }
+      if (splitrow(line, F) < n) { print "PARSE_ERROR short row: " line; exit }
+      print F[idc] "\t" F[ac]
+    }
+  '
+}
+
+# The first `status:` inside the `gate:` block — not the `run:` one above it.
+gate_status() {
+  awk '/^gate:/ { g = 1; next }
+       g && /^[^[:space:]]/ { g = 0 }
+       g && $1 == "status:" { print $2; exit }'
+}
+
+fix_rounds=0
+gates=0
+out=$("$NM" axi run --intent "$(cat "$INTENT_FILE")" "$@" 2>>"$LOG")
+
+while :; do
+  printf '\n===== gate %d =====\n%s\n' "$((gates + 1))" "$out"
+
+  if grep -q '^outcome:' <<<"$out"; then
+    o=$(sed -n 's/^outcome:[[:space:]]*//p' <<<"$out" | head -1)
+    case "$o" in
+      passed|checks-passed) finish passed "no-mistakes finished: $o" ;;
+      *)                    finish failed "no-mistakes finished: $o" ;;
+    esac
+  fi
+
+  if grep -q '^error:' <<<"$out"; then
+    finish failed "no-mistakes refused to run: $(sed -n 's/^error:[[:space:]]*//p' <<<"$out" | head -1)"
+  fi
+
+  grep -q '^gate:' <<<"$out" \
+    || finish failed "unrecognised no-mistakes output: no gate:, outcome: or error: line"
+
+  gates=$((gates + 1))
+  [ "$gates" -gt "$MAX_GATES" ] \
+    && finish failed "gate cap ($MAX_GATES) reached — no-mistakes is not converging"
+
+  # `awaiting_approval` and `fix_review` carry an identically shaped findings
+  # table and mean different things: the first is "rule on these", the second is
+  # "here is what my fixer did, and what it introduced". Both are answered by the
+  # same mapping, but only fix_review can loop, so both are named rather than
+  # defaulted — an unrecognised status is a shape we have not seen, and guessing
+  # at it is how a clerk ships something nobody agreed to.
+  status=$(gate_status <<<"$out")
+  case "$status" in
+    awaiting_approval|fix_review) ;;
+    *) finish failed "unknown gate status: ${status:-<none>} — refusing to guess at it" ;;
+  esac
+
+  rows=$(parse_findings <<<"$out")
+  case "$rows" in PARSE_ERROR*) finish failed "$rows" ;; esac
+
+  ask=$(awk -F'\t' '$2 == "ask-user" { print $1 }' <<<"$rows" | paste -sd,)
+  if [ -n "$ask" ]; then
+    {
+      echo "# no-mistakes parked on an ask-user finding"
+      echo
+      echo "Gate \`$status\` on step \`$(sed -n 's/^ *step:[[:space:]]*//p' <<<"$out" | head -1)\`."
+      echo "Findings the clerk refused to resolve: \`$ask\`."
+      echo
+      echo "An \`ask-user\` finding challenges deliberate intent or touches product"
+      echo "behaviour. Nothing was resolved and nothing was approved."
+      echo
+      echo '```'
+      printf '%s\n' "$out"
+      echo '```'
+    } > "$ART/escalation.md"
+    finish escalated "ask-user finding(s) at gate $status: $ask — parked, nothing resolved"
+  fi
+
+  fix=$(awk -F'\t' '$2 == "auto-fix" { print $1 }' <<<"$rows" | paste -sd,)
+  if [ -n "$fix" ]; then
+    fix_rounds=$((fix_rounds + 1))
+    [ "$fix_rounds" -gt "$MAX_FIX_ROUNDS" ] && finish failed \
+      "fix-round cap ($MAX_FIX_ROUNDS) reached at gate $status; the fixer is still producing findings: $fix"
+    printf 'clerk: fix round %d — %s\n' "$fix_rounds" "$fix"
+    out=$("$NM" axi respond --action fix --findings "$fix" 2>>"$LOG")
+  else
+    printf 'clerk: approve — nothing actionable at gate %s\n' "$status"
+    out=$("$NM" axi respond --action approve 2>>"$LOG")
+  fi
+done

--- a/test/fixtures/nm-clerk/gate-ask-user.toon
+++ b/test/fixtures/nm-clerk/gate-ask-user.toon
@@ -1,0 +1,28 @@
+run:
+  id: "01KZ9SDN40H4H13P0Q4FJ0YR2S"
+  branch: fix/tile-b
+  status: running
+  awaiting_agent: parked 0s
+  head: cc3a40cb
+  findings: "3 awaiting, 1 auto-fix"
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,2
+    rebase,completed,0,36
+    review,awaiting_approval,4,52524
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  risk: high
+  note: "Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed."
+  findings[4]{id,severity,file,action,description}:
+    drag-starting-on-tile-no-longer-selects,error,selection.py,ask-user,"Removed required behavior. The intent states: \"no existing behaviour may be removed. A rubber-band drag that STARTS on a tile must still select everything its rectangle covers, exactly as it did before.\" The new hunk `if not should_start_selection_drag(target): return set(SELECTION)` short-circuits at mousedown, so `items_in_rect` is never consulted for any target beginning with \"tile-\". Before this change, `handle_mousedown(\"tile-7\", {\"c\"})` returned `{\"c\"}`; now it returns the untouched prior selection. Repro: SELECTION={\"a\"}; drag starting on tile-7 covering tile-9 -> expected {\"a\"?/\"tile-9… (truncated, 827 chars total)"
+    tests-assert-helper-not-behavior,error,test_selection.py,ask-user,"The intent states: \"the reported behaviour itself must be fixed and asserted - clicking a tile keeps the selection you were building. Exposing a helper that says a drag should not start is not the same thing.\" Both added tests (`test_drag_does_not_start_on_a_tile`, `test_drag_starts_on_empty_canvas`) assert only `should_start_selection_drag(...)`. No test calls `handle_mousedown` with a tile target, so the user-visible claim (selection survives a tile click) is unasserted, and the regression in finding 1 (drag starting on a tile still selects its rectangle) has no test guarding it either."
+    tile-prefix-string-heuristic,warning,selection.py,ask-user,"Tile identification is a `str(target).startswith(\"tile-\")` prefix match. Any non-tile element whose identifier happens to start with \"tile-\" (e.g. a container id \"tile-grid-background\" or \"tile-panel\") is treated as a tile and suppresses the gesture, while a tile identified any other way (numeric id, DOM node object, child element inside a tile) is not matched and still wipes the selection. `str()` on a non-string target also silently stringifies arbitrary objects, so the check can pass or fail on repr formatting rather than on what was actually clicked."
+    tests-share-mutable-global,info,test_selection.py,auto-fix,"`SELECTION` is module-level mutable state and only `test_rubber_band_over_empty_space_selects_what_it_covers` clears it, inline. The new code path returns that global directly, so any test of the tile-click behavior depends on prior test ordering. A `setUp` that calls `SELECTION.clear()` removes the ordering dependency before more tests are added."
+help[6]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.","When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/test/fixtures/nm-clerk/gate-awaiting-approval.toon
+++ b/test/fixtures/nm-clerk/gate-awaiting-approval.toon
@@ -1,0 +1,26 @@
+run:
+  id: "01KZ9S3G69VR6KNMR2QZ3WP1SJ"
+  branch: feat/bulk-discount
+  status: running
+  awaiting_agent: parked 0s
+  head: cdb2de47
+  findings: 2 auto-fix
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,3
+    rebase,completed,0,32
+    review,awaiting_approval,2,29554
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: awaiting_approval
+  risk: medium
+  note: "Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed."
+  findings[2]{id,severity,file,action,description}:
+    missing-import-average-discount,error,test_calc.py,auto-fix,"test_average_discount calls average_discount but test_calc.py:1 only imports discount, so the test raises NameError instead of exercising the new helper. Change the import to `from calc import discount, average_discount`."
+    empty-prices-zero-division,warning,calc.py,auto-fix,"average_discount([], pct) raises ZeroDivisionError on `total / len(prices)`. Guard the empty case (return 0 or raise a descriptive ValueError) since callers pricing a basket may legitimately pass an empty list."
+help[6]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.","When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/test/fixtures/nm-clerk/gate-fix-review.toon
+++ b/test/fixtures/nm-clerk/gate-fix-review.toon
@@ -1,0 +1,26 @@
+run:
+  id: "01KZ9S3G69VR6KNMR2QZ3WP1SJ"
+  branch: feat/bulk-discount
+  status: running
+  awaiting_agent: parked 0s
+  head: b083e47c
+  findings: 2 auto-fix
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,3
+    rebase,completed,0,32
+    review,fix_review,2,105479
+    test,pending,0,0
+    document,pending,0,0
+    lint,pending,0,0
+    push,pending,0,0
+    pr,pending,0,0
+    ci,pending,0,0
+gate:
+  step: review
+  status: fix_review
+  risk: low
+  note: "Review auto-fix is disabled by default (`auto_fix.review: 0`; a repo or global `auto_fix.review > 0` override re-enables it), so blocking and ask-user review findings park for your decision rather than being silently self-fixed."
+  findings[2]{id,severity,file,action,description}:
+    committed-pycache-artifacts,warning,__pycache__/calc.cpython-312.pyc,auto-fix,"Commit b083e47 added compiled bytecode (__pycache__/calc.cpython-312.pyc and __pycache__/test_calc.cpython-312.pyc) to the repo, and there is no .gitignore. These are build artifacts that churn on every interpreter/version change and will produce spurious binary diffs. Run `git rm -r --cached __pycache__` and add a .gitignore containing `__pycache__/` and `*.pyc`."
+    manual-raises-assertion,info,test_calc.py,auto-fix,"test_average_discount_empty hand-rolls exception assertion with try/except/return plus a trailing raise AssertionError. `with pytest.raises(ValueError): average_discount([], 10)` expresses the same check in one line and fails with a clearer message."
+help[6]: Run `no-mistakes axi respond --action approve` to accept this step and continue,Run `no-mistakes axi respond --action fix --findings <ids>` to have the pipeline fix the selected findings (do not edit files yourself),Run `no-mistakes axi respond --action skip` to skip this step,Run `no-mistakes axi logs --step review --full` to read the full step log,"A long-running call is working, not stalled - background it if your harness needs to, but the run never advances past a gate on its own. Read every return; on a `gate:`, respond; loop until an `outcome:`.","When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/test/fixtures/nm-clerk/outcome-passed.toon
+++ b/test/fixtures/nm-clerk/outcome-passed.toon
@@ -1,0 +1,21 @@
+run:
+  id: "01KZ9S3G69VR6KNMR2QZ3WP1SJ"
+  branch: feat/bulk-discount
+  status: completed
+  head: "0138684c"
+  findings: 1 auto-fix
+  steps[9]{step,status,findings,duration_ms}:
+    intent,completed,0,3
+    rebase,completed,0,32
+    review,completed,1,170503
+    test,completed,0,88110
+    document,completed,0,66357
+    lint,completed,0,5
+    push,skipped,0,0
+    pr,skipped,0,0
+    ci,skipped,0,0
+outcome: passed
+fixes[2]{step,summary}:
+  review,fix average_discount empty input and test import
+  review,"untrack __pycache__, add .gitignore, use pytest.raises"
+help[3]: "Summarize this pipeline run for the user in a concise, easily readable format: what was validated and what was found.",The pipeline fixed findings the original change missed (see `fixes`) - acknowledge the misses and list each fix so the user can review them.,"When you make an additional fix after a gate round has already produced fix commits, commit it on top of the existing branch and run `no-mistakes axi run --intent \"...\"` with the original user intent. Never abort-and-restart, reset the branch, or open a new branch in a way that drops prior gate-fix commits. A fresh run re-validates the branch's current state, so already-resolved findings do not re-surface."

--- a/test/nm-clerk.test.js
+++ b/test/nm-clerk.test.js
@@ -1,0 +1,212 @@
+'use strict';
+// bin/nm-clerk.sh — the bash driver that answers no-mistakes' gates without a
+// model. It shells out to `no-mistakes axi`, which takes minutes and needs a
+// real repo, so every test here replaces that binary (NM_BIN) with a fake that
+// replays payloads RECORDED FROM REAL RUNS (test/fixtures/nm-clerk/*.toon) and
+// logs the argv it was handed.
+//
+// What is asserted: the three outcomes the pipeline routes on, read from
+// $ARTIFACTS_DIR/nm-outcome, and an exit status that is ALWAYS 0 — a non-zero
+// exit inside an Archon loop_group kills the whole run.
+const test = require('node:test');
+const assert = require('node:assert');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const CLERK = path.join(__dirname, '..', 'bin', 'nm-clerk.sh');
+const FIXTURES = path.join(__dirname, 'fixtures', 'nm-clerk');
+
+const fixture = name => fs.readFileSync(path.join(FIXTURES, `${name}.toon`), 'utf8');
+
+// A fake `no-mistakes` that prints replies[n] on its nth call (the last reply
+// repeats forever, which is how the runaway-fixer case is built) and appends
+// its arguments to calls.log, one invocation per line.
+function fakeNoMistakes(dir, replies) {
+  const stateDir = path.join(dir, 'fake');
+  fs.mkdirSync(stateDir, { recursive: true });
+  replies.forEach((r, i) => fs.writeFileSync(path.join(stateDir, `reply-${i + 1}`), r));
+  fs.writeFileSync(path.join(stateDir, 'last'), replies[replies.length - 1]);
+  const bin = path.join(dir, 'no-mistakes');
+  fs.writeFileSync(bin, `#!/usr/bin/env bash
+d=${JSON.stringify(stateDir)}
+n=$(( $(cat "$d/n" 2>/dev/null || echo 0) + 1 ))
+echo "$n" > "$d/n"
+args="$*"; printf '%s\\n' "\${args//$'\\n'/ }" >> "$d/calls.log"   # one line per invocation
+cat "$d/reply-$n" 2>/dev/null || cat "$d/last"
+`);
+  fs.chmodSync(bin, 0o755);
+  return bin;
+}
+
+// run(replies) -> { status, stdout, outcome, escalation, calls }
+function run(replies, env = {}) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nm-clerk-'));
+  const bin = fakeNoMistakes(dir, replies);
+  const intent = path.join(dir, 'intent.md');
+  fs.writeFileSync(intent, 'REQUIRED: the tile click keeps the selection.\nFORBIDDEN: removing the drag.\n');
+
+  let status = 0;
+  let stdout = '';
+  try {
+    stdout = execFileSync('bash', [CLERK, '--intent-file', intent], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, NM_BIN: bin, ARTIFACTS_DIR: dir, NM_CLERK_LOG: path.join(dir, 'nm.log'), ...env },
+    });
+  } catch (e) {
+    status = e.status;
+    stdout = e.stdout || '';
+  }
+  const read = f => (fs.existsSync(path.join(dir, f)) ? fs.readFileSync(path.join(dir, f), 'utf8') : null);
+  return {
+    status,
+    stdout,
+    outcome: (read('nm-outcome') || '').trim(),
+    escalation: read('escalation.md'),
+    calls: (read('fake/calls.log') || '').trim().split('\n').filter(Boolean),
+  };
+}
+
+// ---------- passed ----------
+
+test('drives a real run through awaiting_approval and fix_review to passed', () => {
+  const r = run([
+    fixture('gate-awaiting-approval'),
+    fixture('gate-fix-review'),
+    fixture('outcome-passed'),
+  ]);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'passed');
+  assert.equal(r.escalation, null, 'nothing was escalated');
+
+  // The intent reached `axi run`, and each gate was answered by finding id.
+  assert.match(r.calls[0], /^axi run --intent REQUIRED: the tile click keeps the selection\./);
+  assert.equal(
+    r.calls[1],
+    'axi respond --action fix --findings missing-import-average-discount,empty-prices-zero-division'
+  );
+  assert.equal(
+    r.calls[2],
+    'axi respond --action fix --findings committed-pycache-artifacts,manual-raises-assertion'
+  );
+});
+
+test('approves a gate whose findings are all no-op', () => {
+  const noop = fixture('gate-awaiting-approval').replace(/,auto-fix,/g, ',no-op,');
+  const r = run([noop, fixture('outcome-passed')]);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'passed');
+  assert.equal(r.calls[1], 'axi respond --action approve');
+  assert.match(r.stdout, /approve — nothing actionable at gate awaiting_approval/);
+});
+
+// ---------- escalated ----------
+
+test('an ask-user finding parks: escalation.md written, nothing resolved', () => {
+  const r = run([fixture('gate-ask-user'), fixture('outcome-passed')]);
+
+  assert.equal(r.status, 0, 'a bash node that exits non-zero kills the loop_group');
+  assert.equal(r.outcome, 'escalated');
+
+  // Exactly one call: the run. It never answered the gate.
+  assert.equal(r.calls.length, 1);
+  assert.match(r.calls[0], /^axi run /);
+
+  // The whole payload is on the file, all four findings included.
+  assert.match(r.escalation, /ask-user finding/);
+  for (const id of [
+    'drag-starting-on-tile-no-longer-selects',
+    'tests-assert-helper-not-behavior',
+    'tile-prefix-string-heuristic',
+    'tests-share-mutable-global',
+  ]) {
+    assert.ok(r.escalation.includes(id), `escalation.md is missing ${id}`);
+  }
+  // And the ask-user ids — not the auto-fix one — are named as the reason.
+  assert.match(r.stdout, /ask-user finding\(s\) at gate awaiting_approval: drag-starting-on-tile-no-longer-selects,tests-assert-helper-not-behavior,tile-prefix-string-heuristic/);
+});
+
+// ---------- failed ----------
+
+test('a fixer that keeps producing findings stops at the round cap', () => {
+  // The real shape: run 1's fixer committed __pycache__ and the next gate
+  // flagged its own artifact. This fixture repeats forever.
+  const r = run([fixture('gate-awaiting-approval'), fixture('gate-fix-review')]);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.match(r.stdout, /fix-round cap \(3\) reached at gate fix_review/);
+  // 1 run + 3 fixes, and then it stopped rather than sending a fourth.
+  assert.equal(r.calls.length, 4);
+  assert.equal(r.calls.filter(c => c.includes('--action fix')).length, 3);
+});
+
+test('a precondition error is failed, not a crash', () => {
+  const r = run(['error: uncommitted changes in the working tree\nhelp[1]: Commit your work before validating\n']);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.match(r.stdout, /refused to run: uncommitted changes in the working tree/);
+  assert.equal(r.calls.length, 1);
+});
+
+test('an unfamiliar gate status is failed rather than guessed at', () => {
+  const r = run([fixture('gate-awaiting-approval').replace('status: awaiting_approval', 'status: awaiting_something_new')]);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.match(r.stdout, /unknown gate status: awaiting_something_new/);
+  assert.equal(r.calls.length, 1, 'it answered nothing');
+});
+
+// ---------- the parser ----------
+
+test('columns are read from the header, not counted from the left', () => {
+  // Same gate with the findings table transposed: action first, id last.
+  const src = fixture('gate-awaiting-approval');
+  const reordered = src
+    .replace('findings[2]{id,severity,file,action,description}:', 'findings[2]{action,file,severity,description,id}:')
+    .replace(
+      /^ {4}missing-import-average-discount,error,test_calc\.py,auto-fix,(".*")$/m,
+      '    auto-fix,test_calc.py,error,$1,missing-import-average-discount'
+    )
+    .replace(
+      /^ {4}empty-prices-zero-division,warning,calc\.py,auto-fix,(".*")$/m,
+      '    auto-fix,calc.py,warning,$1,empty-prices-zero-division'
+    );
+  assert.notEqual(reordered, src, 'the fixture rewrite matched nothing');
+
+  const r = run([reordered, fixture('outcome-passed')]);
+  assert.equal(r.outcome, 'passed');
+  assert.equal(
+    r.calls[1],
+    'axi respond --action fix --findings missing-import-average-discount,empty-prices-zero-division'
+  );
+});
+
+test('a description full of commas and escaped quotes does not shift the columns', () => {
+  // gate-ask-user's descriptions carry both. If the split were naive, the
+  // ask-user rows would parse as something else and the clerk would answer.
+  const r = run([fixture('gate-ask-user')]);
+  assert.equal(r.outcome, 'escalated');
+});
+
+test('a missing --intent-file is failed, not a usage crash', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nm-clerk-'));
+  let status = 0;
+  try {
+    execFileSync('bash', [CLERK], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ARTIFACTS_DIR: dir },
+    });
+  } catch (e) {
+    status = e.status;
+  }
+  assert.equal(status, 0);
+  assert.equal(fs.readFileSync(path.join(dir, 'nm-outcome'), 'utf8').trim(), 'failed');
+});


### PR DESCRIPTION
`no-mistakes` never advances past a gate on its own — someone has to read each
`gate:` and answer it. That someone has been an agent, and MNC-7 proved it does
not have to be: the gate is a mapping, and 60 lines of bash drove a real run from
`axi run` to `outcome: passed` with no model in the loop.

This lands that driver as `bin/nm-clerk.sh` so the `bc-card` Archon pipeline can
call it, with the three things the scratch version could not do.

**It always exits 0.** It runs as a bash node inside an Archon `loop_group`,
where a non-zero exit kills the entire run — and a crashed run is
indistinguishable from a broken one in the logs. The outcome travels in files
instead: `$ARTIFACTS_DIR/nm-outcome` is `passed`, `escalated` or `failed`, and
an `ask-user` finding writes the whole payload to `escalation.md` for a human.

**It caps its own fix rounds.** `no-mistakes` has no cap and its fixer can
introduce findings of its own: MNC-7's first run watched it commit `__pycache__`
and the next gate flag the artifact it had just made. Three rounds, then it stops
and says why.

**It names `fix_review` rather than defaulting into it.** Same findings table as
`awaiting_approval`, different meaning — "rule on these" versus "here is what my
fixer did, and what it introduced" — and only one of the two can loop. An
unrecognised status is a shape we have not seen, and a clerk that guesses at one
is how something nobody agreed to ships.

Columns come from the TOON header, never from position, and the field split
respects quotes and backslash escapes because real descriptions carry both.

The tests replay gate payloads captured from actual `no-mistakes` runs
(`test/fixtures/nm-clerk/`) and assert the outcome file: driven through
`awaiting_approval` and `fix_review` to `passed`, `escalated` on the
four-finding `ask-user` gate, `failed` at the round cap, on a precondition
error, and on a status the parser does not recognise.

`bin/` is new here and its path is an interface — the `bc-card` workflow lives
outside this repo and calls the script absolutely — so OPERATIONS.md says so.

`node --test test/*.test.js harness/test/*.test.js` — 681 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)