### PR TITLE
The clerk can answer a gate it did not open

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -73,4 +73,10 @@ ALWAYS exits 0, reporting through `$ARTIFACTS_DIR/nm-outcome` and `escalation.md
 runs as a bash node inside an Archon `loop_group` where a non-zero exit kills the whole run.
 The `bc-card` Archon workflow calls it by absolute path (`<this repo>/bin/nm-clerk.sh`), so the
 path is an interface: moving the file breaks a pipeline that lives outside this repo.
+
+`--respond <fix|approve|skip> [--findings id,id]` is the second door: it answers the gate the
+last invocation refused — the no-mistakes run is still open and still parked on it — and then
+drives the rest to an outcome exactly as the first door does. That is what lets a human's
+ruling arrive without anyone finishing the run by hand.
+
 Its tests replay gate payloads recorded from real runs — `node --test test/nm-clerk.test.js`.

--- a/bin/nm-clerk.sh
+++ b/bin/nm-clerk.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # nm-clerk.sh — drive `no-mistakes axi` through its gates with no model in the loop.
 #
-#   nm-clerk.sh --intent-file <file> [extra axi run flags...]
+#   nm-clerk.sh --intent-file <file> [extra axi run flags...]   start a run
+#   nm-clerk.sh --respond <fix|approve|skip> [--findings id,id] answer a parked gate
 #
 # The gate is a mapping, not a judgement: `auto-fix` findings get fixed, a gate
 # with nothing actionable left gets approved, and an `ask-user` finding stops the
 # clerk — that call belongs to a human.
+#
+# `--respond` is that human coming back. It answers the gate the LAST invocation
+# refused — the run is still alive and still parked on it — and then drives the
+# rest exactly as the first entry point does, to the same files. So one card can
+# go run → park → human → outcome without anyone finishing it by hand.
 #
 # ALWAYS EXITS 0. This runs as a bash node inside an Archon `loop_group`, where a
 # non-zero exit kills the whole run and a crashed run looks exactly like a broken
@@ -34,10 +40,16 @@ ART=${ARTIFACTS_DIR:-.}
 LOG=${NM_CLERK_LOG:-/dev/stderr}
 
 INTENT_FILE=
+RESPOND=
+FINDINGS=
 while [ $# -gt 0 ]; do
   case "$1" in
     --intent-file) INTENT_FILE=${2:-}; shift 2 ;;
     --intent-file=*) INTENT_FILE=${1#*=}; shift ;;
+    --respond) RESPOND=${2:-}; shift 2 ;;
+    --respond=*) RESPOND=${1#*=}; shift ;;
+    --findings) FINDINGS=${2:-}; shift 2 ;;
+    --findings=*) FINDINGS=${1#*=}; shift ;;
     *) break ;;
   esac
 done
@@ -51,8 +63,17 @@ finish() {
   exit 0
 }
 
-[ -n "$INTENT_FILE" ] && [ -r "$INTENT_FILE" ] \
-  || finish failed "usage: nm-clerk.sh --intent-file <readable file> [axi run flags...]"
+if [ -n "$RESPOND" ]; then
+  case "$RESPOND" in
+    fix|approve|skip) ;;
+    *) finish failed "--respond takes fix, approve or skip — not '$RESPOND'" ;;
+  esac
+  [ -z "$INTENT_FILE" ] \
+    || finish failed "--respond answers a gate that is already open; --intent-file starts a new run. Pick one."
+else
+  [ -n "$INTENT_FILE" ] && [ -r "$INTENT_FILE" ] \
+    || finish failed "usage: nm-clerk.sh --intent-file <readable file> [axi run flags...] | --respond <fix|approve|skip> [--findings id,id]"
+fi
 
 # Pull `<id>\t<action>` out of the TOON tabular block `findings[N]{cols}:`.
 # The COLUMNS ARE READ FROM THE HEADER, never assumed by position: a reordered
@@ -100,7 +121,20 @@ gate_status() {
 
 fix_rounds=0
 gates=0
-out=$("$NM" axi run --intent "$(cat "$INTENT_FILE")" "$@" 2>>"$LOG")
+
+# The two doors into the same loop. `--respond` skips `axi run` because the run
+# is already open and parked; the human's decision IS the first gate answer, and
+# everything after it is the clerk's ordinary job again.
+if [ -n "$RESPOND" ]; then
+  printf 'clerk: answering the parked gate — %s%s\n' "$RESPOND" "${FINDINGS:+ ($FINDINGS)}"
+  if [ "$RESPOND" = fix ] && [ -n "$FINDINGS" ]; then
+    out=$("$NM" axi respond --action fix --findings "$FINDINGS" 2>>"$LOG")
+  else
+    out=$("$NM" axi respond --action "$RESPOND" 2>>"$LOG")
+  fi
+else
+  out=$("$NM" axi run --intent "$(cat "$INTENT_FILE")" "$@" 2>>"$LOG")
+fi
 
 while :; do
   printf '\n===== gate %d =====\n%s\n' "$((gates + 1))" "$out"

--- a/test/nm-clerk.test.js
+++ b/test/nm-clerk.test.js
@@ -40,8 +40,9 @@ cat "$d/reply-$n" 2>/dev/null || cat "$d/last"
   return bin;
 }
 
-// run(replies) -> { status, stdout, outcome, escalation, calls }
-function run(replies, env = {}) {
+// run(replies, env, argv) -> { status, stdout, outcome, escalation, calls }
+// `argv` defaults to the --intent-file door; the --respond tests pass their own.
+function run(replies, env = {}, argv = null) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nm-clerk-'));
   const bin = fakeNoMistakes(dir, replies);
   const intent = path.join(dir, 'intent.md');
@@ -50,7 +51,7 @@ function run(replies, env = {}) {
   let status = 0;
   let stdout = '';
   try {
-    stdout = execFileSync('bash', [CLERK, '--intent-file', intent], {
+    stdout = execFileSync('bash', [CLERK, ...(argv || ['--intent-file', intent])], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, NM_BIN: bin, ARTIFACTS_DIR: dir, NM_CLERK_LOG: path.join(dir, 'nm.log'), ...env },
@@ -161,6 +162,82 @@ test('an unfamiliar gate status is failed rather than guessed at', () => {
   assert.equal(r.outcome, 'failed');
   assert.match(r.stdout, /unknown gate status: awaiting_something_new/);
   assert.equal(r.calls.length, 1, 'it answered nothing');
+});
+
+// ---------- --respond: the human coming back ----------
+
+test('--respond fix answers the parked gate by id and drives the rest to passed', () => {
+  // What run one actually left behind: a gate parked on two ask-user findings,
+  // and a lieutenant who ruled they are mechanical. From there it is the
+  // clerk's ordinary job again — the fix_review that follows is auto-fix.
+  const r = run(
+    [fixture('gate-fix-review'), fixture('outcome-passed')],
+    {},
+    ['--respond', 'fix', '--findings', 'lint-1,lint-2']
+  );
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'passed');
+  assert.equal(r.escalation, null);
+
+  // No `axi run` — the run was already open. The decision IS the first call.
+  assert.equal(r.calls[0], 'axi respond --action fix --findings lint-1,lint-2');
+  assert.equal(
+    r.calls[1],
+    'axi respond --action fix --findings committed-pycache-artifacts,manual-raises-assertion'
+  );
+  assert.equal(r.calls.filter(c => c.startsWith('axi run')).length, 0);
+});
+
+test('--respond approve needs no findings', () => {
+  const r = run([fixture('outcome-passed')], {}, ['--respond', 'approve']);
+
+  assert.equal(r.outcome, 'passed');
+  assert.equal(r.calls.length, 1);
+  assert.equal(r.calls[0], 'axi respond --action approve');
+});
+
+test('--respond skip is passed through as its own action', () => {
+  const r = run([fixture('outcome-passed')], {}, ['--respond', 'skip']);
+
+  assert.equal(r.outcome, 'passed');
+  assert.equal(r.calls[0], 'axi respond --action skip');
+});
+
+test('--respond re-escalates when the answered gate hands back another ask-user', () => {
+  // The lieutenant's call did not end it: the next gate asks again. The run
+  // must park again rather than approve something nobody ruled on.
+  const r = run([fixture('gate-ask-user')], {}, ['--respond', 'fix', '--findings', 'lint-1']);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'escalated');
+  assert.match(r.escalation, /ask-user finding/);
+  assert.equal(r.calls.length, 1, 'it answered nothing after the human’s own decision');
+});
+
+test('--respond keeps the fix-round cap', () => {
+  const r = run([fixture('gate-fix-review')], {}, ['--respond', 'fix', '--findings', 'lint-1']);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.match(r.stdout, /fix-round cap \(3\) reached at gate fix_review/);
+});
+
+test('an unknown --respond action is failed, not sent', () => {
+  const r = run([fixture('outcome-passed')], {}, ['--respond', 'merge-it']);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.match(r.stdout, /--respond takes fix, approve or skip/);
+  assert.equal(r.calls.length, 0);
+});
+
+test('--respond and --intent-file together is refused rather than half-honoured', () => {
+  const r = run([fixture('outcome-passed')], {}, ['--respond', 'approve', '--intent-file', '/dev/null']);
+
+  assert.equal(r.status, 0);
+  assert.equal(r.outcome, 'failed');
+  assert.equal(r.calls.length, 0);
 });
 
 // ---------- the parser ----------


### PR DESCRIPTION
The pipeline's first real run parked on a lint finding and **ended the run to do it** — `draft`, `describe`, `verify-pr-base` and `report` never happened, and a human finished the PR by hand. The cause is that a parked no-mistakes run has nobody left to answer it: `nm-clerk.sh` writes `escalation.md` and exits, and there is no way back in.

This gives the clerk a second door.

`nm-clerk.sh --respond <fix|approve|skip> [--findings id,id]` answers the gate the last invocation refused. The no-mistakes run is still open and still sitting on that gate, so the decision goes straight to `axi respond` and then the clerk drives everything after it — fix rounds, test, document, lint, push, PR, CI — through the same loop, to the same `nm-outcome` file, under the same round caps, always exiting 0.

That is what lets a human's ruling arrive without anyone finishing the run by hand. The other half of the change — an interactive gate in `bc-card.yaml` that holds the archon run paused and wakes the card's lieutenant — lives in the workspace, which does not track that file.

## Proven against a real parked gate

A scratch repo, a real `no-mistakes axi run` parked at its review gate with one `auto-fix` and one genuine `ask-user` finding, and a human answering it minutes later through the archon gate. The clerk picked the run up mid-flight and drove it on.

The eight new tests replay payloads recorded from real runs, in the style of the existing ones: the happy path, `approve`/`skip` with no findings, a gate that asks again after the answer, the fix-round cap still holding on this path, an unknown action refused before it is sent, and `--respond` with `--intent-file` refused rather than half-honoured.

`node --test test/nm-clerk.test.js` — 16 green.
