### PR TITLE
An event that wakes the lieutenant, not the captain

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -48,6 +48,7 @@ const opts = {
   title: null, column: null, id: null, type: null, owner: null, lieutenant: null,
   name: null, color: null, avatar: null, prefix: null,
   level: null, kind: null, actor: null, reason: null, note: null, attrs: [], labels: [], json: false,
+  wakeOwner: false,
   worker: null, ttl: null, spawn: false, harness: null,
   mode: null, briefFile: null, resume: false, outcome: null, model: null, effort: null, park: false,
   command: null,
@@ -89,6 +90,7 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--mode') opts.mode = argv[++i];
   else if (a === '--brief-file') opts.briefFile = argv[++i];
   else if (a === '--command') opts.command = argv[++i];
+  else if (a === '--wake-owner') opts.wakeOwner = true;
   else if (a === '--resume') opts.resume = true;
   else if (a === '--park') opts.park = true;
   else if (a === '--outcome') opts.outcome = argv[++i];
@@ -612,13 +614,14 @@ async function cmdPatch() {
 
 async function cmdEvent() {
   const id = positional[0];
-  if (!id) die('usage: bc-axi event <card-id> [--level 1|2] [--kind K] [--text-file f|-]\n  (text from --text-file or stdin; kind is an open token — a kind in the board\'s\n  kinds map sets the default level and emoji; explicit --level wins, else level 2)');
+  if (!id) die('usage: bc-axi event <card-id> [--level 1|2] [--kind K] [--wake-owner] [--text-file f|-]\n  (text from --text-file or stdin; kind is an open token — a kind in the board\'s\n  kinds map sets the default level and emoji; explicit --level wins, else level 2)\n  --wake-owner also queues the event to the card owner\'s drain (wakes the\n  LIEUTENANT, leaves the chat thread alone; --level 1 is what rings the captain)');
   const text = readInput(opts.textFile).trim();
   const body = { text, actor: opts.actor || 'agent' };
   if (opts.level) body.level = opts.level;
   if (opts.kind) body.kind = opts.kind;
+  if (opts.wakeOwner) body.wakeOwner = true;
   const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/events', body);
-  console.log('event #' + r.event.seq + ' L' + r.event.level + ' -> ' + id);
+  console.log('event #' + r.event.seq + ' L' + r.event.level + ' -> ' + id + (opts.wakeOwner ? ' (owner woken)' : ''));
 }
 
 async function cmdNotify() {
@@ -987,6 +990,9 @@ async function cmdDrain() {
     } else if (it.kind === 'card-created') {
       head = 'new card for you — ' + cardBit(it.card);
       hint = 'read it: bc-axi card show ' + it.card;
+    } else if (it.kind === 'card-event') {
+      head = 'CARD EVENT' + (it.eventKind ? ' [' + it.eventKind + ']' : '') + ' — ' + cardBit(it.card);
+      hint = 'an outside process (a workflow, a cron, a CI hook) put this on the timeline and woke you: read the text and act';
     } else if (it.kind === 'card-moved') {
       head = 'captain moved ' + cardBit(it.card) + ': ' + it.from + ' -> ' + it.to;
     }
@@ -1185,8 +1191,11 @@ if (!commands[cmd]) {
     '                                         move (the lieutenant verifies, then hands off). PR URLs in\n' +
     '                                         the outcome auto-populate the card\'s prs attribute\n' +
     '\nevents & chat:\n' +
-    '  event <card-id> [--level 1|2] [--kind K] [--text-file f|-]   append timeline event\n' +
-    '                                         level 1 rings the captain; level 2 = timeline only\n' +
+    '  event <card-id> [--level 1|2] [--kind K] [--wake-owner] [--text-file f|-]   append timeline event\n' +
+    '                                         level 1 rings the captain; level 2 = timeline only.\n' +
+    '                                         --wake-owner also queues a card-event item to the card\n' +
+    '                                         owner\'s drain — the door a workflow, cron or CI hook uses\n' +
+    '                                         to wake a lieutenant without interjecting in the thread\n' +
     '  notify [--kind K] [--text-file f|-]    board-level notification (no card)\n' +
     '  say <lieutenant:ID|card:ID> [--actor a] [--text-file f|-]\n' +
     '                                         post a chat message; a card thread\'s interlocutor is\n' +

--- a/server/server.js
+++ b/server/server.js
@@ -2963,6 +2963,15 @@ const server = http.createServer(async (req, res) => {
         const ev = mkEvent(body, { level: 2 });
         card.events.push(ev);
         card.updated = now();
+        // wakeOwner: the door an outside process (a workflow, a cron, a CI hook)
+        // uses to wake a card's lieutenant. Same pair every server-side wake
+        // already uses — timeline entry AND a queue item — so the escalation is
+        // on the record instead of interjecting in the captain's chat thread.
+        // Orthogonal to level: level 1 rings THE CAPTAIN and always has. Both
+        // flags together does both, deliberately — the caller asked for both.
+        if (body.wakeOwner) {
+          queuePush(card.owner, { kind: 'card-event', card: card.id, eventKind: ev.kind || null, text: ev.text });
+        }
         saveBoard(); broadcast();
         return sendJson(res, 200, { ok: true, event: ev });
       }

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -36,6 +36,42 @@ test('card events: default level 2, explicit level 1, open kind tokens, monotoni
   }
 });
 
+test('wakeOwner queues the event to the card owner without ringing the captain', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Paged' }));
+
+    let r = await s.api('POST', '/api/cards/paged/events',
+      { text: 'the gate needs a decision', kind: 'pipeline', actor: 'archon', wakeOwner: true });
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.body.event.level, 2); // waking the owner is not a captain bell
+
+    // on the timeline
+    const card = (await s.api('GET', '/api/cards/paged')).body;
+    const ev = card.events[card.events.length - 1];
+    assert.strictEqual(ev.kind, 'pipeline');
+    assert.strictEqual(ev.text, 'the gate needs a decision');
+
+    // in the owner's queue, carrying card, event kind and text
+    const items = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items;
+    const item = items.find((i) => i.kind === 'card-event');
+    assert.ok(item, items.map((i) => i.kind).join(','));
+    assert.strictEqual(item.card, 'paged');
+    assert.strictEqual(item.eventKind, 'pipeline');
+    assert.strictEqual(item.text, 'the gate needs a decision');
+
+    // and NOT in the captain's notifications
+    assert.strictEqual((await s.api('GET', '/api/notifications')).body.items.length, 0);
+
+    // without the flag: timeline only, no new queue item
+    await s.api('POST', '/api/cards/paged/events', { text: 'quiet' });
+    const after = (await s.api('GET', '/api/feed?lieutenant=' + LT)).body.items;
+    assert.strictEqual(after.filter((i) => i.kind === 'card-event').length, 1);
+  } finally {
+    await s.stop();
+  }
+});
+
 test('board-level events default to level 1', async () => {
   const s = await startServerWithLieutenant();
   try {


### PR DESCRIPTION
An outside process — a workflow, a cron, a CI hook — could only wake a lieutenant by posting a chat `say` on the card. Wrong door: the transcript is the captain's conversation with the owner, and `worker-said` is the one wake that leaves **no timeline entry**, so a card whose run stopped showed no record of why.

Six server-side wakes already write a card event AND `queuePush` the owner. This makes that pair reachable from the CLI.

## `bc-axi event <card-id> --wake-owner`

- Writes the timeline event exactly as `event` does today.
- Also pushes one `card-event` item into the card owner's queue, carrying the card id, the event kind and the text.
- Never touches the captain's notifications. `--level 1` is the other door and still rings him; the two flags together do both, deliberately — the caller asked for both. Said so in the code.

## Dry run (scratch board, not the captain's)

```
$ bc-axi event MNC-1 --kind pipeline --actor archon --wake-owner --text-file page.md
event #3 L2 -> MNC-1 (owner woken)

=== 1. OWNER'S DRAIN ===
#1  CARD EVENT [pipeline] — card MNC-1 "An event that wakes the lieutenant" [backlog]
    no-mistakes parked on an ask-user finding.
        archon workflow approve run-42 "approve"
    -> an outside process (a workflow, a cron, a CI hook) put this on the timeline and woke you: read the text and act

=== 2. CARD TIMELINE ===
08-06 10:21  L2 pipeline  no-mistakes parked on an ask-user finding. ...  (archon)

=== 3. CAPTAIN'S NOTIFICATIONS ===
{"items":[],"unread":0}

=== 4. CHAT THREAD ===
(empty)
```

## Tests

`node --test test/*.test.js harness/test/*.test.js` — **689 pass, 0 fail**. Existing `event` tests unchanged; one new test in `test/events.test.js` covering all four assertions above plus "no flag → no queue item".

## Downstream

`bc-card.yaml`'s `answer` gate now uses it (committed in the workspace repo, `cd0afdf`) — one call replaces the `say` + `event` pair, message shape kept. `validate workflows bc-card` → ok. One line added to `memory/tools.md`: which door wakes a lieutenant, which one rings the captain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)