### PR TITLE
A run that is waiting must not read as a run that died

### DIFF
--- a/bin/bc-run.sh
+++ b/bin/bc-run.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# bc-run.sh — the two verbs every bc-card bash node needs. SOURCED, not run:
+#
+#   . /home/ai/repos/bridge-commander/bin/bc-run.sh || { …no env.sh… }
+#
+# It lives in this repo and is sourced by ABSOLUTE PATH, the same contract
+# nm-clerk.sh has, and that is the point. It was briefly written into
+# $ARTIFACTS_DIR by the pipeline's own `setup` node, which is a trap with teeth:
+#
+#   A RESUMED archon run RE-READS the workflow file and SKIPS every node that
+#   already completed.
+#
+# So a run paused on its gate at 12:58, resumed at 12:59 after the workflow file
+# changed, came back into NEW node bodies with an OLD scratch directory — and
+# `setup`, the only writer of the file they wanted, was skipped as
+# already-done. Every node fell into its "setup never finished" guard and the
+# run swallowed the human's decision. A file in the repo cannot be skipped.
+#
+# What still comes from the run's scratch is env.sh — values, not code. That one
+# is safe: `setup` wrote it on the first pass and it is on disk when the run
+# comes back.
+#
+# Requires: ARTIFACTS_DIR, and $ARTIFACTS_DIR/env.sh.
+# Provides: attach, hang, mark.
+
+. "${ARTIFACTS_DIR:-/nonexistent}/env.sh" 2>/dev/null || return 1
+
+# attach <ABSOLUTE-path> <label> — put a file on the card, now rather than at
+# the end of the run. Absolute, always: the board resolves a relative uri with
+# path.resolve against the SERVER's cwd and quietly points the card at a file
+# that does not exist. Idempotent by uri.
+attach() {
+  "$BC" card artifact add "$CARD" --uri "$1" --label "$2" \
+    --workspace "$WORKSPACE" </dev/null >/dev/null 2>&1 \
+    && echo "artifact: $(basename "$1") — $2" \
+    || echo "artifact: $1 kept on disk (the board refused it)"
+}
+
+# hang <file-under-ARTIFACTS_DIR> <label> — copy it where the board can serve
+# it, then attach. Calling it again on a file that grew refreshes the copy
+# without adding a second entry.
+hang() {
+  [ -s "$ARTIFACTS_DIR/$1" ] || return 0
+  mkdir -p "$REPORTS"
+  cp "$ARTIFACTS_DIR/$1" "$REPORTS/$1" 2>/dev/null || return 0
+  attach "$REPORTS/$1" "$2"
+}
+
+# mark <stage> — a row on timings.md and a milestone to the board, at every node
+# boundary. Two problems, one line:
+#   * timings.md used to be written at the END, so a run that died said nothing
+#     about where its time went. It lives under $REPORTS and is appended to as
+#     the run goes, under the artifact hung in setup.
+#   * a `--command` worker emits no milestones of its own, so EVERY run tripped
+#     WORKER STALLED at thirty minutes. `worker signal` is the board's own door
+#     for that, and it resets the stale clock.
+# The gap measured is from the previous mark, so it covers the agent nodes in
+# between — which is where the time actually goes.
+mark() {
+  _t=$(date +%s)
+  _p=$(cat "$ARTIFACTS_DIR/.mark" 2>/dev/null || echo "$_t")
+  printf '%s' "$_t" > "$ARTIFACTS_DIR/.mark"
+  _d=$(( _t - _p ))
+  mkdir -p "$REPORTS"
+  printf '| `%s` | %s | %d |\n' "$1" "$(date -u +%H:%M:%S)" "$_d" >> "$REPORTS/timings.md"
+  "$BC" worker signal "$CARD" "$1 — ${_d}s" --workspace "$WORKSPACE" \
+    </dev/null >/dev/null 2>&1 || true
+  echo "mark: $1 (+${_d}s)"
+}

--- a/bin/nm-clerk.sh
+++ b/bin/nm-clerk.sh
@@ -17,8 +17,23 @@
 # non-zero exit kills the whole run and a crashed run looks exactly like a broken
 # one. So the outcome travels in files:
 #
-#   $ARTIFACTS_DIR/nm-outcome     passed | escalated | failed
+#
+#   $ARTIFACTS_DIR/nm-outcome     passed | escalated | refused | failed
 #   $ARTIFACTS_DIR/escalation.md  the whole payload, when a finding is ask-user
+#                                 OR when the gate refused to start at all
+#
+# and the reason it stopped goes to stdout, which is the node's output and the
+# next round's only account of what happened.
+#
+# `refused` and `failed` are the same word to no-mistakes and must not be to us.
+# `failed` is a VERDICT ON THE CHANGE: the gate read the diff and said no, so
+# the next round belongs to the implementer. `refused` is the gate declining to
+# look — repo not initialised, detached HEAD, a missing dependency, no remote —
+# and no amount of rewriting the code fixes it. MNC-17 burned three implement
+# rounds at full model price against a `bridge-commander` that had never been
+# `no-mistakes init`ed: three one-second refusals, three rewrites of code that
+# was never the problem. A refusal is about the ENVIRONMENT, so it escalates to
+# a human like an ask-user finding does, and never bounces to the implementer.
 #
 # and the reason it stopped goes to stdout, which is the node's output and the
 # next round's only account of what happened.
@@ -63,16 +78,40 @@ finish() {
   exit 0
 }
 
+# refuse <reason> [payload] — the gate never looked at the diff. Same exit as
+# an ask-user finding, and the same file, because it needs the same person: it
+# is the environment that is wrong, and the implementer cannot fix it by
+# writing different code.
+refuse() {
+  {
+    echo "# no-mistakes never got as far as reading the change"
+    echo
+    echo "$1"
+    echo
+    echo "This is the ENVIRONMENT, not the diff — repo not initialised, detached"
+    echo "HEAD, a missing dependency, no remote, or the clerk meeting a shape it"
+    echo "does not know. Another implement round cannot fix it, so the run stops"
+    echo "here and asks instead of asking the implementer to rewrite working code."
+    if [ -n "${2:-}" ]; then
+      echo
+      echo '```'
+      printf '%s\n' "$2"
+      echo '```'
+    fi
+  } > "$ART/escalation.md"
+  finish refused "$1"
+}
+
 if [ -n "$RESPOND" ]; then
   case "$RESPOND" in
     fix|approve|skip) ;;
-    *) finish failed "--respond takes fix, approve or skip — not '$RESPOND'" ;;
+    *) refuse "The clerk was called with --respond '$RESPOND', which is not fix, approve or skip." ;;
   esac
   [ -z "$INTENT_FILE" ] \
-    || finish failed "--respond answers a gate that is already open; --intent-file starts a new run. Pick one."
+    || refuse "The clerk was given both --respond and --intent-file; those are two different entry points."
 else
   [ -n "$INTENT_FILE" ] && [ -r "$INTENT_FILE" ] \
-    || finish failed "usage: nm-clerk.sh --intent-file <readable file> [axi run flags...] | --respond <fix|approve|skip> [--findings id,id]"
+    || refuse "The clerk got no readable --intent-file, so the reviewer would have had no acceptance criteria to read the diff against."
 fi
 
 # Pull `<id>\t<action>` out of the TOON tabular block `findings[N]{cols}:`.
@@ -133,8 +172,8 @@ if [ -n "$RESPOND" ]; then
   if [ "$RESPOND" = fix ] && [ -z "$FINDINGS" ]; then
     FINDINGS=$(parse_findings <<<"$("$NM" axi status 2>>"$LOG")" \
       | awk -F'\t' '$2 == "auto-fix" || $2 == "ask-user" { print $1 }' | paste -sd,)
-    [ -n "$FINDINGS" ] || finish failed \
-      "--respond fix with no --findings, and the parked gate offers nothing actionable"
+    [ -n "$FINDINGS" ] || refuse \
+      "A human answered \`fix\`, but the parked gate offers nothing actionable to fix."
   fi
   printf 'clerk: answering the parked gate — %s%s\n' "$RESPOND" "${FINDINGS:+ ($FINDINGS)}"
   if [ "$RESPOND" = fix ] && [ -n "$FINDINGS" ]; then
@@ -158,11 +197,11 @@ while :; do
   fi
 
   if grep -q '^error:' <<<"$out"; then
-    finish failed "no-mistakes refused to run: $(sed -n 's/^error:[[:space:]]*//p' <<<"$out" | head -1)"
+    refuse "no-mistakes refused to run: $(sed -n 's/^error:[[:space:]]*//p' <<<"$out" | head -1)" "$out"
   fi
 
   grep -q '^gate:' <<<"$out" \
-    || finish failed "unrecognised no-mistakes output: no gate:, outcome: or error: line"
+    || refuse "Unrecognised no-mistakes output: no gate:, outcome: or error: line." "$out"
 
   gates=$((gates + 1))
   [ "$gates" -gt "$MAX_GATES" ] \
@@ -177,11 +216,11 @@ while :; do
   status=$(gate_status <<<"$out")
   case "$status" in
     awaiting_approval|fix_review) ;;
-    *) finish failed "unknown gate status: ${status:-<none>} — refusing to guess at it" ;;
+    *) refuse "Unknown gate status: ${status:-<none>} — the clerk refuses to guess at a shape it has not seen." "$out" ;;
   esac
 
   rows=$(parse_findings <<<"$out")
-  case "$rows" in PARSE_ERROR*) finish failed "$rows" ;; esac
+  case "$rows" in PARSE_ERROR*) refuse "The clerk could not parse the gate's findings table: $rows" "$out" ;; esac
 
   ask=$(awk -F'\t' '$2 == "ask-user" { print $1 }' <<<"$rows" | paste -sd,)
   if [ -n "$ask" ]; then

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -815,10 +815,10 @@ async function cmdWorkerSend() {
 // WORKER DIED alarm); the record + worktree stay resumable. --park composes
 // card park (Working → Backlog) in the same call.
 //
-// --expect-exit is the pipeline's door, called from INSIDE the session that is
-// about to end (an archon run holding on a gate). Nothing is killed; the stop
-// is recorded so the exit that follows reads as waiting, not dying. --reason
-// replaces the resume hint with the one that actually revives that worker.
+// --expect-exit is called from INSIDE the session that is about to end — an
+// automated `--command` worker holding on an approval gate. Nothing is killed;
+// the stop is recorded so the exit that follows reads as waiting, not dying.
+// --reason replaces the resume hint with the one that revives that worker.
 async function cmdWorkerPause() {
   const id = positional[0];
   if (!id) {
@@ -827,7 +827,7 @@ async function cmdWorkerPause() {
       '  record and worktree survive for card start <card-id> --resume.\n' +
       '  --park also moves the card Working -> Backlog (card park) in the same step.\n' +
       '  --expect-exit records the stop WITHOUT killing anything — for a session that is\n' +
-      '  about to end by itself (a pipeline holding on a gate calling this from inside it).');
+      '  about to end by itself (a --command worker holding on a gate, calling from inside it).');
   }
   const body = { actor: opts.actor || 'agent' };
   if (opts.park) body.park = true;
@@ -1197,7 +1197,7 @@ if (!commands[cmd]) {
     '                                         worktree survive for card start --resume. --park also\n' +
     '                                         moves the card Working -> Backlog (run by the lieutenant).\n' +
     '                                         --expect-exit kills NOTHING — for a session ending by\n' +
-    '                                         itself (a pipeline holding on a gate, calling from inside)\n' +
+    '                                         itself (a --command worker on a gate, calling from inside)\n' +
     '\nworker (run by the worker itself, from its worktree):\n' +
     '  worker signal <card-id> "<milestone>" [--text-file f|-]\n' +
     '                                         real milestone -> level-2 card event + QueueItem to owner\n' +

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -93,6 +93,7 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--wake-owner') opts.wakeOwner = true;
   else if (a === '--resume') opts.resume = true;
   else if (a === '--park') opts.park = true;
+  else if (a === '--expect-exit') opts.expectExit = true;
   else if (a === '--outcome') opts.outcome = argv[++i];
   else if (a === '--uri') opts.uri = argv[++i];
   else if (a === '--file') opts.file = argv[++i];
@@ -813,18 +814,29 @@ async function cmdWorkerSend() {
 // session but records the stop as intentional (worker-paused event, no
 // WORKER DIED alarm); the record + worktree stay resumable. --park composes
 // card park (Working → Backlog) in the same call.
+//
+// --expect-exit is the pipeline's door, called from INSIDE the session that is
+// about to end (an archon run holding on a gate). Nothing is killed; the stop
+// is recorded so the exit that follows reads as waiting, not dying. --reason
+// replaces the resume hint with the one that actually revives that worker.
 async function cmdWorkerPause() {
   const id = positional[0];
   if (!id) {
-    die('usage: bc-axi worker pause <card-id> [--park]\n' +
+    die('usage: bc-axi worker pause <card-id> [--park] [--expect-exit] [--reason "<how to revive>"]\n' +
       '  Kill the worker\'s session as a DELIBERATE stop (no WORKER DIED alarm); the worker\n' +
       '  record and worktree survive for card start <card-id> --resume.\n' +
-      '  --park also moves the card Working -> Backlog (card park) in the same step.');
+      '  --park also moves the card Working -> Backlog (card park) in the same step.\n' +
+      '  --expect-exit records the stop WITHOUT killing anything — for a session that is\n' +
+      '  about to end by itself (a pipeline holding on a gate calling this from inside it).');
   }
   const body = { actor: opts.actor || 'agent' };
   if (opts.park) body.park = true;
+  if (opts.expectExit) body.expectExit = true;
+  if (opts.reason) body.reason = opts.reason;
   const r = await request('POST', '/api/cards/' + encodeURIComponent(id) + '/worker/pause', body, 60000);
-  console.log('paused worker ' + r.session + ' (card ' + id + ') — deliberate stop; resume: bc-axi card start ' + id + ' --resume');
+  console.log('paused worker ' + r.session + ' (card ' + id + ') — deliberate stop'
+    + (opts.expectExit ? ' (session left alone; it is exiting itself)'
+      : '; resume: bc-axi card start ' + id + ' --resume'));
   if (opts.park) {
     if (r.parked) console.log('parked ' + id + ' -> backlog');
     else die('pause landed but park failed: ' + (r.parkError || 'unknown'));
@@ -1179,10 +1191,13 @@ if (!commands[cmd]) {
     '  worker send <card-id> "<instructions>" [--text-file f|-]\n' +
     '                                         hand a LIVE worker new instructions: typed into its\n' +
     '                                         session with verified submission (run by the lieutenant)\n' +
-    '  worker pause <card-id> [--park]        DELIBERATE stop: kill the worker session WITHOUT the\n' +
+    '  worker pause <card-id> [--park] [--expect-exit] [--reason "<how to revive>"]\n' +
+    '                                         DELIBERATE stop: kill the worker session WITHOUT the\n' +
     '                                         WORKER DIED alarm (worker-paused event); record +\n' +
     '                                         worktree survive for card start --resume. --park also\n' +
-    '                                         moves the card Working -> Backlog (run by the lieutenant)\n' +
+    '                                         moves the card Working -> Backlog (run by the lieutenant).\n' +
+    '                                         --expect-exit kills NOTHING — for a session ending by\n' +
+    '                                         itself (a pipeline holding on a gate, calling from inside)\n' +
     '\nworker (run by the worker itself, from its worktree):\n' +
     '  worker signal <card-id> "<milestone>" [--text-file f|-]\n' +
     '                                         real milestone -> level-2 card event + QueueItem to owner\n' +

--- a/server/server.js
+++ b/server/server.js
@@ -2103,14 +2103,13 @@ async function workerSend(card, body) {
 // worktree/branch stay intact, so `card start --resume` revives the worker
 // exactly like a died one. body.park composes the park (Working → Backlog).
 //
-// body.expectExit — the OTHER kind of deliberate stop, and the one a pipeline
-// needs: the session is about to end BY ITSELF and the caller is inside it.
-// A `--command` worker running an interactive archon workflow hits a gate,
-// pauses the run, and its process returns; without a word beforehand that
-// reads as WORKER DIED. Killing here would kill the caller mid-sentence — so
-// the marker is recorded and nothing is killed. body.reason replaces the
-// resume hint, because how you revive a paused pipeline run is not
-// `card start --resume`.
+// body.expectExit — the OTHER kind of deliberate stop, and the one an
+// automated `--command` worker needs: the session is about to end BY ITSELF
+// and the caller is inside it. A command that stops at an approval gate and
+// returns leaves nothing running, and without a word beforehand that reads as
+// WORKER DIED. Killing here would kill the caller mid-sentence, so the marker
+// is recorded and nothing is killed. body.reason replaces the resume hint,
+// because how you revive one of those is not `card start --resume`.
 async function pauseWorker(card, body) {
   const w = findWorker(card.id);
   if (!w) return { error: 'no worker recorded for card ' + card.id + ' — nothing to pause', code: 404 };

--- a/server/server.js
+++ b/server/server.js
@@ -2102,6 +2102,15 @@ async function workerSend(card, body) {
 // own alive() await, closing the mark/kill race) and the registry entry +
 // worktree/branch stay intact, so `card start --resume` revives the worker
 // exactly like a died one. body.park composes the park (Working → Backlog).
+//
+// body.expectExit — the OTHER kind of deliberate stop, and the one a pipeline
+// needs: the session is about to end BY ITSELF and the caller is inside it.
+// A `--command` worker running an interactive archon workflow hits a gate,
+// pauses the run, and its process returns; without a word beforehand that
+// reads as WORKER DIED. Killing here would kill the caller mid-sentence — so
+// the marker is recorded and nothing is killed. body.reason replaces the
+// resume hint, because how you revive a paused pipeline run is not
+// `card start --resume`.
 async function pauseWorker(card, body) {
   const w = findWorker(card.id);
   if (!w) return { error: 'no worker recorded for card ' + card.id + ' — nothing to pause', code: 404 };
@@ -2114,15 +2123,19 @@ async function pauseWorker(card, body) {
   w.paused = now(); // BEFORE the kill: the death must never look like a crash
   delete w.stopNotified;
   delete w.staleNotified;
-  try {
-    await harnessFor(w.ref).kill(w.ref);
-  } catch (e) {
-    delete w.paused; // the session may still be alive — stay honest, let supervision judge
-    return { error: 'pause failed killing session ' + workerName(w.ref) + ': ' + String((e && e.message) || e), code: 502 };
+  if (!(body && body.expectExit)) {
+    try {
+      await harnessFor(w.ref).kill(w.ref);
+    } catch (e) {
+      delete w.paused; // the session may still be alive — stay honest, let supervision judge
+      return { error: 'pause failed killing session ' + workerName(w.ref) + ': ' + String((e && e.message) || e), code: 502 };
+    }
   }
   const actor = String((body && body.actor) || 'agent').slice(0, 60);
+  const reason = String((body && body.reason) || '').trim().slice(0, 500)
+    || 'resume: card start ' + card.id + ' --resume';
   const ev = mkEvent({
-    text: 'worker ' + workerName(w.ref) + ' paused (deliberate) — resume: card start ' + card.id + ' --resume',
+    text: 'worker ' + workerName(w.ref) + ' paused (deliberate) — ' + reason,
     actor,
   }, { kind: 'worker-paused' });
   card.events.push(ev);

--- a/test/nm-clerk.test.js
+++ b/test/nm-clerk.test.js
@@ -131,7 +131,7 @@ test('an ask-user finding parks: escalation.md written, nothing resolved', () =>
   assert.match(r.stdout, /ask-user finding\(s\) at gate awaiting_approval: drag-starting-on-tile-no-longer-selects,tests-assert-helper-not-behavior,tile-prefix-string-heuristic/);
 });
 
-// ---------- failed ----------
+// ---------- failed: a verdict on the change ----------
 
 test('a fixer that keeps producing findings stops at the round cap', () => {
   // The real shape: run 1's fixer committed __pycache__ and the next gate
@@ -146,22 +146,32 @@ test('a fixer that keeps producing findings stops at the round cap', () => {
   assert.equal(r.calls.filter(c => c.includes('--action fix')).length, 3);
 });
 
-test('a precondition error is failed, not a crash', () => {
+// ---------- refused: the gate never read the change ----------
+// The distinction that stops the pipeline asking the wrong agent to fix the
+// wrong thing. `failed` bounces back to the implementer; `refused` escalates,
+// because no rewrite of the code fixes an uninitialised repo.
+
+test('a precondition error is REFUSED, not failed — the environment is wrong, not the diff', () => {
   const r = run(['error: uncommitted changes in the working tree\nhelp[1]: Commit your work before validating\n']);
 
   assert.equal(r.status, 0);
-  assert.equal(r.outcome, 'failed');
+  assert.equal(r.outcome, 'refused');
   assert.match(r.stdout, /refused to run: uncommitted changes in the working tree/);
   assert.equal(r.calls.length, 1);
+  // Same file an ask-user finding writes: it needs the same person.
+  assert.ok(r.escalation, 'a refusal writes escalation.md so the round loop ends and a human is paged');
+  assert.match(r.escalation, /never got as far as reading the change/);
+  assert.match(r.escalation, /uncommitted changes in the working tree/);
 });
 
-test('an unfamiliar gate status is failed rather than guessed at', () => {
+test('an unfamiliar gate status is refused rather than guessed at', () => {
   const r = run([fixture('gate-awaiting-approval').replace('status: awaiting_approval', 'status: awaiting_something_new')]);
 
   assert.equal(r.status, 0);
-  assert.equal(r.outcome, 'failed');
-  assert.match(r.stdout, /unknown gate status: awaiting_something_new/);
+  assert.equal(r.outcome, 'refused');
+  assert.match(r.stdout, /nknown gate status: awaiting_something_new/);
   assert.equal(r.calls.length, 1, 'it answered nothing');
+  assert.ok(r.escalation, 'a shape the clerk does not know is a human question, not another round');
 });
 
 // ---------- --respond: the human coming back ----------
@@ -223,12 +233,12 @@ test('--respond keeps the fix-round cap', () => {
   assert.match(r.stdout, /fix-round cap \(3\) reached at gate fix_review/);
 });
 
-test('an unknown --respond action is failed, not sent', () => {
+test('an unknown --respond action is refused, not sent', () => {
   const r = run([fixture('outcome-passed')], {}, ['--respond', 'merge-it']);
 
   assert.equal(r.status, 0);
-  assert.equal(r.outcome, 'failed');
-  assert.match(r.stdout, /--respond takes fix, approve or skip/);
+  assert.equal(r.outcome, 'refused');
+  assert.match(r.stdout, /not fix, approve or skip/);
   assert.equal(r.calls.length, 0);
 });
 
@@ -236,7 +246,7 @@ test('--respond and --intent-file together is refused rather than half-honoured'
   const r = run([fixture('outcome-passed')], {}, ['--respond', 'approve', '--intent-file', '/dev/null']);
 
   assert.equal(r.status, 0);
-  assert.equal(r.outcome, 'failed');
+  assert.equal(r.outcome, 'refused');
   assert.equal(r.calls.length, 0);
 });
 
@@ -272,7 +282,7 @@ test('a description full of commas and escaped quotes does not shift the columns
   assert.equal(r.outcome, 'escalated');
 });
 
-test('a missing --intent-file is failed, not a usage crash', () => {
+test('a missing --intent-file is refused, not a usage crash', () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'nm-clerk-'));
   let status = 0;
   try {
@@ -285,5 +295,5 @@ test('a missing --intent-file is failed, not a usage crash', () => {
     status = e.status;
   }
   assert.equal(status, 0);
-  assert.equal(fs.readFileSync(path.join(dir, 'nm-outcome'), 'utf8').trim(), 'failed');
+  assert.equal(fs.readFileSync(path.join(dir, 'nm-outcome'), 'utf8').trim(), 'refused');
 });

--- a/test/pause-park.test.js
+++ b/test/pause-park.test.js
@@ -106,6 +106,43 @@ test('worker pause: deliberate stop — session killed, worker-paused event, NO 
   } finally { await teardown(); }
 });
 
+// The pipeline's half of the same lifecycle: an archon run holding on its
+// `answer` gate calls this from INSIDE the session that is about to end. Killing
+// would kill the caller mid-sentence, so --expect-exit records the stop and
+// touches nothing; the exit that follows a moment later reads as waiting.
+test('worker pause --expect-exit: nothing killed, custom reason on the card, and the exit that follows is not a death', async () => {
+  const { s, fdir, teardown } = await boot({ BC_SUPERVISE_INTERVAL_MS: '150' });
+  try {
+    await s.api('POST', '/api/cards', withOwner({ title: 'Gate', id: 'gate', attributes: { repo: 'proj' } }));
+    assert.strictEqual((await s.api('POST', '/api/cards/gate/start', { harness: 'fake' })).status, 200);
+    const session = workerKey(s.dir, 'gate');
+    const marker = path.join(fdir, session + '.json');
+
+    // through the CLI: an unknown flag is silently swallowed as a positional,
+    // so the flag is worth exercising end to end rather than posting the body.
+    const cli = await runCli(['worker', 'pause', 'gate', '--expect-exit',
+      '--reason', 'waiting on the lieutenant — archon workflow approve r-42 "fix"',
+      '--actor', 'archon', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(cli.code, 0, cli.stderr);
+    assert.match(cli.stdout, /exiting itself/);
+    assert.ok(fs.existsSync(marker), 'the caller\'s own session is left alive');
+
+    const ev = (await s.api('GET', '/api/cards/gate')).body.events.find((e) => e.kind === 'worker-paused');
+    assert.ok(ev, 'worker-paused event on the card');
+    assert.match(ev.text, /waiting on the lieutenant/);
+    assert.match(ev.text, /archon workflow approve r-42/);
+    assert.doesNotMatch(ev.text, /card start/, 'the default resume hint is replaced, not appended');
+    assert.ok(boardOnDisk(s).workers.find((x) => x.card === 'gate').paused, 'marked paused');
+
+    // ...and now the run returns and its session really does go.
+    fs.rmSync(marker);
+    await sleep(700);
+    const card = (await s.api('GET', '/api/cards/gate')).body;
+    assert.ok(!card.events.some((e) => e.kind === 'worker-died'), 'a pre-announced exit is not a death');
+    assert.ok(!card.events.some((e) => e.kind === 'worker-stalled'), 'nor a stall');
+  } finally { await teardown(); }
+});
+
 test('worker pause refusals: no worker recorded (404), worker already done (409)', async () => {
   const { s, teardown } = await boot();
   try {


### PR DESCRIPTION
A `--command` worker running an interactive archon workflow pauses at its gate and its process returns. The session goes; supervision sees a ref that stopped answering and rings **WORKER DIED** — for a run that is doing exactly what it was asked to do. Ten runs in flight is ten false alarms an hour, and then nobody reads the alarm that matters.

`worker pause` was already the right door — it records a stop as deliberate so the alarm never fires — but the wrong shape: it **kills** the session, and here the caller *is* the session it would kill.

## What changed

**`worker pause --expect-exit`** records the deliberate stop and kills nothing. It is called from inside the session that is about to end by itself.

**`--reason`** replaces the default `card start --resume` hint. That hint is not just unhelpful for a paused pipeline run, it is dangerous: `card start --resume` would relaunch the workflow from zero. The run id and `archon workflow approve` are what revives it, and the card now says so.

A worker that genuinely dies mid-implement still rings — `--expect-exit` changes nothing about that path.

## The other half

`.bridge-commander/workflows/bc-card.yaml` in `roboflow-commander` (commit `7aa459d`, on `main`) is the caller. Its `answer` node probes for the flag before using it, so an older board makes it stay silent rather than kill itself — but the pair only *works* once this is deployed.

## Test

`test/pause-park.test.js` — drives it through the real CLI (an unknown flag is silently swallowed as a positional, so the flag is worth exercising end to end), asserts the session marker survives, asserts the custom reason replaced the default hint, then removes the marker and runs supervision ticks over it: no `worker-died`, no `worker-stalled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)