### PR TITLE
The board says when its server is running old code

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -26,6 +26,18 @@ The board runs from a checkout on disk; a merged PR is not live until that check
 - Restart the server only if `server/` or `harness/` changed.
 - UI-only changes need just a browser refresh — no restart.
 
+## Is the server running the code on disk?
+
+The server reads its commit once, at boot, and never again — so after a merge it keeps serving
+the old code while every call still succeeds. You do not have to remember: `bc-axi status`
+prints `code=<short>` (`+dirty` when the tree was dirty at boot), and both `bc-axi status` and
+the bare usage screen add one line the moment the checkout has moved past it, naming both
+commits and the restart. Silence means the running server IS the code on disk. `code=unknown`
+means git could not be read — not drift.
+
+This is a report and never a gate: no operation is refused because of drift, and nothing
+restarts the server for you.
+
 ## Updating the tool
 
 Which update path applies depends on how the skill dir was installed — check for `.git`:

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -22,6 +22,7 @@ const SELF_DIR = path.dirname(fs.realpathSync(process.argv[1]));
 const SERVER_JS = process.env.BC_SERVER_JS || path.join(SELF_DIR, '..', 'server', 'server.js');
 const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME, migrateStateDir, resolveStateDir, migrateHomeStateDir, isWorkspace } =
   require(path.join(SELF_DIR, '..', 'server', 'statedir.js'));
+const gitrev = require(path.join(SELF_DIR, '..', 'server', 'gitrev.js'));
 const DEFAULT_PORT = 4780;
 
 function die(msg) { console.error(msg); process.exit(1); }
@@ -188,6 +189,26 @@ function request(method, urlPath, body, timeoutMs) {
 }
 async function serverUp() {
   try { return await request('GET', '/api/status', null, 1500); } catch (e) { return null; }
+}
+
+// ---------- code drift ----------
+// A server keeps serving the code it booted with, so a merge into its checkout
+// leaves it a version behind while every call still succeeds. The server hands
+// us the commit it started from; HEAD right now is a couple of file reads under
+// .git (no git binary, no subprocess) against the checkout the SERVER named.
+// One line, only when they provably differ — silence when they match and
+// silence when either side is unknown.
+//
+// This lives on `status` and the usage screen only. No card operation reads it,
+// nothing here can fail a call, and a down server is simply not asked.
+function driftLineFor(st) {
+  const code = st && st.code;
+  if (!code || !code.root) return null;
+  try { return gitrev.driftLine(code, gitrev.headCommit(code.root)); } catch (e) { return null; }
+}
+async function driftNote() {
+  const st = await serverUp();
+  return st ? driftLineFor(st) : null;
 }
 function readInput(fileArg) {
   const src = fileArg && fileArg !== '-' ? fileArg : 0; // fd 0 = stdin
@@ -1056,8 +1077,12 @@ async function cmdStatus() {
   }
   const st = await serverUp();
   if (!st) { console.log('server: down (workspace ' + WORKSPACE + ', port ' + PORT + ')'); process.exit(1); }
+  const code = st.code || {};
+  const codeTag = code.short ? code.short + (code.dirty ? '+dirty' : '') : 'unknown';
   console.log('server: up  workspace=' + st.workspace + '  cards=' + st.cards + '  lieutenants=' + st.lieutenants +
-    '  pending-queue=' + st.queue_pending + '  url=http://localhost:' + PORT + '/');
+    '  pending-queue=' + st.queue_pending + '  code=' + codeTag + '  url=http://localhost:' + PORT + '/');
+  const drift = driftLineFor(st);
+  if (drift) console.log('⚠ ' + drift);
 }
 
 // ---------- config ----------
@@ -1103,7 +1128,7 @@ const commands = {
   line: cmdLine, 'line pass': cmdLinePass,
 };
 if (!commands[cmd]) {
-  die('bc-axi — agent CLI for the bridge-commander board.\n' +
+  const usage = ('bc-axi — agent CLI for the bridge-commander board.\n' +
     'Workspace: nearest .bridge-commander/ from cwd upward, or --workspace DIR. Port: workspace config.json (default 4780), or --port N.\n' +
     'Bind host: config.json "host" (default 127.0.0.1 loopback), or --host H on init/open. Never 0.0.0.0 — there is no app auth.\n' +
     '\nserver & workspace:\n' +
@@ -1114,7 +1139,10 @@ if (!commands[cmd]) {
     '                                         scaffolds AGENTS.md + captain.md + learnings/. Idempotent\n' +
     '  open [--port N] [--host H]             start the workspace server if needed (idempotent), print URL.\n' +
     '                                         Bootstraps .bridge-commander/ in cwd on first run.\n' +
-    '  status                                 up/down, cards, lieutenants, pending queue items\n' +
+    '  status                                 up/down, cards, lieutenants, pending queue items, and the\n' +
+    '                                         commit the server BOOTED from (code=). When the checkout has\n' +
+    '                                         moved past it, one line names both commits and the restart —\n' +
+    '                                         silence means the running server IS the code on disk\n' +
     '  stop                                   stop the workspace server\n' +
     '\nlieutenant:\n' +
     '  lieutenant create --name N [--id id] [--color #rrggbb] [--avatar N] [--prefix ABC] [--charter-file f|-] [--spawn [--harness h]]\n' +
@@ -1243,5 +1271,10 @@ if (!commands[cmd]) {
     '\nconfig:\n' +
     '  config show | config voices "a,b"      TTS voice filter for the UI\n' +
     '\nText/body/charter always via --text-file/--body-file/--charter-file or stdin ("-"), never shell-interpolated.');
+  // The last line of the help screen is the one still on screen when an agent
+  // stops reading: if the running server is behind its checkout, it says so
+  // here. A down server, an unknown commit, or a match all print nothing extra.
+  driftNote().then((n) => die(usage + (n ? '\n\n⚠ ' + n : '')), () => die(usage));
+} else {
+  commands[cmd]().catch((e) => die(e.message));
 }
-commands[cmd]().catch((e) => die(e.message));

--- a/server/gitrev.js
+++ b/server/gitrev.js
@@ -1,0 +1,123 @@
+'use strict';
+// gitrev — which commit is this process actually running? Node built-ins only.
+//
+// A merge changes the files on disk and nothing else: the server keeps serving
+// the code it was started with, every call succeeds against it, and the only
+// symptom is a feature that provably landed refusing to work. So the server
+// records its commit ONCE, at boot, and the CLI compares that record to what
+// the repo says NOW. Drift becomes visible instead of remembered.
+//
+// Git is read here, never required. `headCommit` is plain file reads under
+// .git — no binary, no subprocess, no error when git is missing — which is
+// what lets the comparison sit on a surface an agent hits constantly. The one
+// real git call decides `dirty`, runs once at boot, off any request path, with
+// a short timeout, and answers "unknown" (null) rather than throwing when git
+// is slow, missing, or pointed at something that is not a repo.
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SHA_RE = /^[0-9a-f]{40}$/;
+const DIRTY_TIMEOUT_MS = 2000;
+
+// <dir>/.git is a directory in a clone and a "gitdir: <path>" pointer file in a
+// linked worktree — the board's own workers live in worktrees, so both shapes
+// are the normal case. null when there is no git here at all.
+function gitDir(dir) {
+  if (!dir) return null;
+  const dot = path.join(dir, '.git');
+  let st;
+  try { st = fs.statSync(dot); } catch (e) { return null; }
+  if (st.isDirectory()) return dot;
+  let txt;
+  try { txt = fs.readFileSync(dot, 'utf8'); } catch (e) { return null; }
+  const m = /^gitdir:\s*(.+)$/m.exec(txt);
+  if (!m) return null;
+  const g = m[1].trim();
+  return path.isAbsolute(g) ? g : path.resolve(dir, g);
+}
+
+// A linked worktree keeps its own HEAD but shares the clone's refs, named by a
+// `commondir` pointer beside it.
+function commonDir(g) {
+  let txt;
+  try { txt = fs.readFileSync(path.join(g, 'commondir'), 'utf8').trim(); } catch (e) { return g; }
+  if (!txt) return g;
+  return path.isAbsolute(txt) ? txt : path.resolve(g, txt);
+}
+
+function packedRef(common, ref) {
+  let txt;
+  try { txt = fs.readFileSync(path.join(common, 'packed-refs'), 'utf8'); } catch (e) { return null; }
+  for (const line of txt.split('\n')) {
+    if (!line || line[0] === '#' || line[0] === '^') continue;
+    const sp = line.indexOf(' ');
+    if (sp < 0) continue;
+    if (line.slice(sp + 1).trim() === ref) {
+      const sha = line.slice(0, sp).trim();
+      if (SHA_RE.test(sha)) return sha;
+    }
+  }
+  return null;
+}
+
+// The commit HEAD points at, by file reads alone. null whenever it cannot be
+// answered cheaply and certainly — no repo, unreadable HEAD, unborn branch.
+// A null is "unknown", and every caller here treats unknown as silence.
+function headCommit(dir) {
+  const g = gitDir(dir);
+  if (!g) return null;
+  let head;
+  try { head = fs.readFileSync(path.join(g, 'HEAD'), 'utf8').trim(); } catch (e) { return null; }
+  if (SHA_RE.test(head)) return head; // detached HEAD — the shape a worktree starts in
+  const m = /^ref:\s*(.+)$/.exec(head);
+  if (!m) return null;
+  const ref = m[1].trim();
+  const common = commonDir(g);
+  try {
+    const v = fs.readFileSync(path.join(common, ref), 'utf8').trim();
+    if (SHA_RE.test(v)) return v;
+  } catch (e) {}
+  return packedRef(common, ref);
+}
+
+// The one git subprocess in this file. true/false, or null for "unknown" —
+// git missing, git slow, or not a repo are all answers, never failures.
+function isDirty(dir, timeoutMs) {
+  try {
+    const out = execFileSync('git', ['-C', dir, 'status', '--porcelain'], {
+      encoding: 'utf8',
+      timeout: timeoutMs || DIRTY_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return String(out).trim().length > 0;
+  } catch (e) { return null; }
+}
+
+// Called once, at server boot. `commit: null` means the server cannot say what
+// it is running — which is reported as "unknown" and never as an error.
+function bootRecord(dir, timeoutMs) {
+  const commit = headCommit(dir);
+  return {
+    root: dir,
+    commit,
+    short: short(commit),
+    dirty: commit ? isDirty(dir, timeoutMs) : null,
+  };
+}
+
+function short(sha) { return SHA_RE.test(String(sha || '')) ? String(sha).slice(0, 7) : null; }
+
+// The line, or silence. Silence when the commits match, and silence when either
+// side is unknown — a line that shows up on every call is read as decoration and
+// stops working the day it means something.
+function driftLine(boot, headNow, restart) {
+  if (!boot || !boot.commit || !headNow) return null;
+  if (boot.commit === headNow) return null;
+  return 'server is running OLD code — started from ' + short(boot.commit) +
+    (boot.dirty ? ' (dirty tree)' : '') + ', repo is now ' + short(headNow) +
+    '. Restart it: ' + (restart || 'bc-axi stop && bc-axi open');
+}
+
+module.exports = { gitDir, headCommit, isDirty, bootRecord, driftLine, short };

--- a/server/server.js
+++ b/server/server.js
@@ -64,6 +64,7 @@ const { createSampler } = require(path.join(__dirname, 'sysload.js'));
 const { workerBrief, PROJECT_MODES } = require(path.join(__dirname, 'brief.js'));
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
+const gitrev = require(path.join(__dirname, 'gitrev.js'));
 const { execFile } = require('child_process');
 
 // ---------- args ----------
@@ -200,6 +201,14 @@ const LOOPBACKS = ['127.0.0.1', 'localhost', '::1'];
 const BIND_HOST = opts.host || configHost() || '127.0.0.1';
 // Turn-end hooks (workspace-level and per-worker-spawn) POST here.
 const TURNEND_URL = 'http://127.0.0.1:' + PORT + '/api/turn-end';
+
+// The commit this process is RUNNING, decided once here at boot and never
+// re-read: a merge into the checkout below moves the files, not this record,
+// and /api/status hands the difference to the CLI to announce. Boot is the only
+// place a git subprocess is allowed — no request path ever pays for it.
+// BC_CODE_ROOT is a test-only seam (tests point it at a fabricated checkout).
+const CODE_ROOT = process.env.BC_CODE_ROOT || path.join(__dirname, '..');
+const CODE = gitrev.bootRecord(CODE_ROOT);
 
 // ---------- pidfile: single instance per workspace ----------
 function pidAlive(pid) { try { process.kill(pid, 0); return true; } catch (e) { return e.code === 'EPERM'; } }
@@ -2488,6 +2497,7 @@ const server = http.createServer(async (req, res) => {
         queue_seq: qseq, queue_pending: pending,
         projects: board.projects.length, workers: board.workers.length,
         pid: process.pid,
+        code: CODE, // {root, commit, short, dirty} as of BOOT — the CLI compares it to HEAD now
         sysload: sysload.stats(), // the monitoring refcount probe: {subscribers, sampling}
       });
     }

--- a/test/gitrev.test.js
+++ b/test/gitrev.test.js
@@ -1,0 +1,236 @@
+'use strict';
+// gitrev — the server records the commit it booted from, and the CLI announces
+// when the checkout has moved past it. Three states matter: same commit
+// (silence), drifted (one line), git unavailable (unknown, never an error).
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const gitrev = require('../server/gitrev.js');
+const { startServer, runCli } = require('./helper');
+
+const A = 'a'.repeat(40);
+const B = 'b'.repeat(40);
+
+function tmpdir() { return fs.mkdtempSync(path.join(os.tmpdir(), 'bc-gitrev-')); }
+
+// A checkout fabricated by hand: headCommit never runs git, so the file layout
+// alone is enough — and these tests then need no git binary to pass.
+function fakeRepo(commit, opts = {}) {
+  const dir = tmpdir();
+  const g = path.join(dir, '.git');
+  fs.mkdirSync(path.join(g, 'refs', 'heads'), { recursive: true });
+  if (opts.detached) {
+    fs.writeFileSync(path.join(g, 'HEAD'), commit + '\n');
+  } else {
+    fs.writeFileSync(path.join(g, 'HEAD'), 'ref: refs/heads/main\n');
+    if (opts.packed) fs.writeFileSync(path.join(g, 'packed-refs'), '# pack-refs with: peeled\n' + commit + ' refs/heads/main\n');
+    else fs.writeFileSync(path.join(g, 'refs', 'heads', 'main'), commit + '\n');
+  }
+  return dir;
+}
+function setHead(dir, commit) {
+  fs.writeFileSync(path.join(dir, '.git', 'refs', 'heads', 'main'), commit + '\n');
+}
+
+test('headCommit resolves HEAD through a loose ref, no git binary involved', () => {
+  const dir = fakeRepo(A);
+  try { assert.strictEqual(gitrev.headCommit(dir), A); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('headCommit reads a detached HEAD directly', () => {
+  const dir = fakeRepo(B, { detached: true });
+  try { assert.strictEqual(gitrev.headCommit(dir), B); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('headCommit falls back to packed-refs when the loose ref is gone', () => {
+  const dir = fakeRepo(A, { packed: true });
+  try { assert.strictEqual(gitrev.headCommit(dir), A); } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('headCommit follows a linked worktree: .git pointer file plus commondir', () => {
+  // The shape every bridge-commander WORKER runs in — its .git is a file and
+  // its refs live back in the clone.
+  const clone = fakeRepo(A);
+  const wt = tmpdir();
+  try {
+    const wtGit = path.join(clone, '.git', 'worktrees', 'w1');
+    fs.mkdirSync(wtGit, { recursive: true });
+    fs.writeFileSync(path.join(wtGit, 'HEAD'), 'ref: refs/heads/main\n');
+    fs.writeFileSync(path.join(wtGit, 'commondir'), '../..\n');
+    fs.writeFileSync(path.join(wt, '.git'), 'gitdir: ' + wtGit + '\n');
+    assert.strictEqual(gitrev.headCommit(wt), A);
+  } finally {
+    fs.rmSync(clone, { recursive: true, force: true });
+    fs.rmSync(wt, { recursive: true, force: true });
+  }
+});
+
+test('headCommit answers unknown, not an error, where there is no git at all', () => {
+  const dir = tmpdir();
+  try {
+    assert.strictEqual(gitrev.headCommit(dir), null);
+    assert.strictEqual(gitrev.headCommit('/nonexistent-' + process.pid), null);
+    assert.strictEqual(gitrev.headCommit(null), null);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('bootRecord on a checkout with no git reports unknown and skips the git call', () => {
+  const dir = tmpdir();
+  try {
+    const r = gitrev.bootRecord(dir);
+    assert.strictEqual(r.commit, null);
+    assert.strictEqual(r.short, null);
+    assert.strictEqual(r.dirty, null); // unknown — never a thrown error
+    assert.strictEqual(r.root, dir);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('bootRecord records a dirty working tree as part of the record', () => {
+  const repo = tmpdir();
+  try {
+    execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
+    fs.writeFileSync(path.join(repo, 'a.txt'), 'one\n');
+    execFileSync('git', ['-C', repo, 'add', '.'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    execFileSync('git', ['-C', repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init'],
+      { stdio: ['ignore', 'pipe', 'pipe'] });
+
+    const clean = gitrev.bootRecord(repo);
+    assert.match(clean.commit, /^[0-9a-f]{40}$/);
+    assert.strictEqual(clean.short, clean.commit.slice(0, 7));
+    assert.strictEqual(clean.dirty, false);
+
+    fs.writeFileSync(path.join(repo, 'a.txt'), 'two\n');
+    assert.strictEqual(gitrev.bootRecord(repo).dirty, true);
+  } finally { fs.rmSync(repo, { recursive: true, force: true }); }
+});
+
+test('driftLine is silent on a match and on either side unknown', () => {
+  assert.strictEqual(gitrev.driftLine({ commit: A }, A), null);
+  assert.strictEqual(gitrev.driftLine({ commit: null }, A), null);
+  assert.strictEqual(gitrev.driftLine({ commit: A }, null), null);
+  assert.strictEqual(gitrev.driftLine(null, A), null);
+});
+
+test('driftLine names both commits and the restart command', () => {
+  const line = gitrev.driftLine({ commit: A }, B);
+  assert.match(line, /OLD code/);
+  assert.match(line, new RegExp(A.slice(0, 7)));
+  assert.match(line, new RegExp(B.slice(0, 7)));
+  assert.match(line, /bc-axi stop && bc-axi open/);
+  assert.ok(!line.includes('\n'), 'one line');
+  assert.match(gitrev.driftLine({ commit: A, dirty: true }, B), /dirty tree/);
+});
+
+// ---------- the server's record, and the CLI surfaces that read it ----------
+
+test('the server records its boot commit and /api/status hands it over', async () => {
+  const code = fakeRepo(A);
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    const r = await s.api('GET', '/api/status');
+    assert.strictEqual(r.body.code.commit, A);
+    assert.strictEqual(r.body.code.short, A.slice(0, 7));
+    assert.strictEqual(r.body.code.root, code);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('bc-axi status prints the commit and stays silent while it matches', async () => {
+  const code = fakeRepo(A);
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    const r = await runCli(['status', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /code=aaaaaaa/);
+    assert.ok(!r.stdout.includes('⚠'), 'no drift line while the commits match:\n' + r.stdout);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('bc-axi status announces drift once the checkout moves past the running server', async () => {
+  const code = fakeRepo(A);
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    setHead(code, B); // the merge: files move, the running server does not
+    const r = await runCli(['status', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 0, 'drift is a report, not a failure');
+    assert.match(r.stdout, /⚠ server is running OLD code/);
+    assert.match(r.stdout, /aaaaaaa/);
+    assert.match(r.stdout, /bbbbbbb/);
+    assert.match(r.stdout, /bc-axi stop && bc-axi open/);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('drift reports, never gates: card operations keep working against a stale server', async () => {
+  const code = fakeRepo(A);
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    await s.api('POST', '/api/lieutenants', { name: 'Monica', id: 'monica', prefix: 'MON' });
+    setHead(code, B);
+    const r = await runCli(['card', 'create', '--title', 'still works', '--owner', 'monica',
+      '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.ok(!r.stdout.includes('⚠'), 'card operations carry no drift line: ' + r.stdout);
+    assert.ok(!r.stderr.includes('⚠'), 'card operations carry no drift line: ' + r.stderr);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('the usage screen carries the drift line, and drops it when the commits match', async () => {
+  const code = fakeRepo(A);
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    let r = await runCli(['--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 1); // usage always exits 1
+    assert.match(r.stderr, /agent CLI for the bridge-commander board/);
+    assert.ok(!r.stderr.includes('⚠'), 'silent while the commits match');
+
+    setHead(code, B);
+    r = await runCli(['--workspace', s.dir, '--port', String(s.port)]);
+    assert.match(r.stderr, /⚠ server is running OLD code/);
+    assert.match(r.stderr, /bc-axi stop && bc-axi open/);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('git unavailable: the server reports unknown and nothing else changes', async () => {
+  const code = tmpdir(); // a directory with no .git anywhere
+  const s = await startServer({ env: { BC_CODE_ROOT: code } });
+  try {
+    const st = await s.api('GET', '/api/status');
+    assert.strictEqual(st.body.code.commit, null);
+    assert.strictEqual(st.body.code.dirty, null);
+
+    const r = await runCli(['status', '--workspace', s.dir, '--port', String(s.port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    assert.match(r.stdout, /code=unknown/);
+    assert.ok(!r.stdout.includes('⚠'), 'unknown is not drift:\n' + r.stdout);
+  } finally {
+    await s.stop();
+    fs.rmSync(code, { recursive: true, force: true });
+  }
+});
+
+test('a down server costs the usage screen nothing', async () => {
+  const dir = tmpdir();
+  try {
+    const r = await runCli(['--workspace', dir, '--port', '1']); // nothing listening
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /agent CLI for the bridge-commander board/);
+    assert.ok(!r.stderr.includes('⚠'));
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});


### PR DESCRIPTION
The board server runs whatever code it was started with. Merging changes the files on disk and nothing else — the server keeps serving yesterday's code, the CLI reports success against it, and the only way anyone finds out is a feature that provably landed refusing to work. This makes the drift visible instead of remembered.

## What lands

**`server/gitrev.js`** (new, ~120 lines, no dependency)

- `headCommit(dir)` — the commit HEAD points at, by **plain file reads under `.git`**. No git binary, no subprocess. Handles loose refs, detached HEAD, `packed-refs`, and the `.git`-pointer-file + `commondir` shape every bridge-commander **worker worktree** runs in.
- `bootRecord(dir)` — what the server records at boot: `{root, commit, short, dirty}`. The single `git status --porcelain` call in the whole change lives here, runs **once at boot**, with a 2s timeout, and answers `null` ("unknown") instead of throwing when git is slow, missing, or aimed at something that is not a repo.
- `driftLine(boot, headNow)` — the one line, or `null`.

**Server** — `CODE = gitrev.bootRecord(CODE_ROOT)` at boot, surfaced as `code` on `GET /api/status`. `BC_CODE_ROOT` is a test-only seam, matching the existing `BC_SERVER_JS` precedent.

**CLI** — two surfaces, no new command (`bc-axi status` is the nearest existing status surface):

```
$ bc-axi status
server: up  workspace=/…  cards=82  lieutenants=8  pending-queue=0  code=eb87aae  url=http://localhost:4780/
```

and when the checkout has moved past the running server, on `status` and at the foot of the bare usage screen:

```
⚠ server is running OLD code — started from eb87aae (dirty tree), repo is now a1d470e. Restart it: bc-axi stop && bc-axi open
```

## Against the constraints

| Required | How |
| --- | --- |
| Records the boot commit, dirty included | `bootRecord` at boot, held in memory, never re-read |
| Surfaced on usage + the existing status surface | `bc-axi status` and the bare usage screen; no second command invented |
| Costs nothing on the hot path | HEAD-now is two `fs` reads of the checkout the **server** named — and only on those two surfaces. No card operation reads it; the one git subprocess is at boot |
| Slow/failing git → "unknown", not an error | Every failure path returns `null`; `status` prints `code=unknown` |
| Silence when they match | `driftLine` returns `null` on a match **and** when either side is unknown |
| Tests for same / drifted / git unavailable | All three, plus packed-refs, detached HEAD, worktree layout, dirty tree, down server |

| Forbidden | |
| --- | --- |
| Refusing an operation because of drift | Test asserts `card create` still succeeds against a drifted server, exit 0, no line |
| Auto-restarting | Nothing here restarts anything |
| New dependency / git on every request | Node built-ins only; one git call per **process**, at boot |

## Verification

`node --test --test-concurrency=1 test/*.test.js harness/test/*.test.js` — **707 pass, 0 fail** (691 baseline + 16 new, verified by stashing).

Also run live against the currently-running board, which boots from a checkout **without** this change: `code=unknown`, no drift line, exit 0 — an old server degrades quietly rather than making the CLI shout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
