### PR TITLE
docs: document escalation rulings and post-upgrade init in lieutenant docs

### DIFF
--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -34,8 +34,9 @@ an early ack can lose a delivery forever, an unacked item merely re-offers. When
 
 ## Card hygiene
 
-The card **body is the deliverable**, not a log: rewrite it to current state before every
-handoff so the captain reads the result, not the history. Progress belongs in events
+The card **body is the deliverable**, not a log: rewrite it to current state — what landed and
+where: file, branch, PR — before every handoff, so the captain reads the result, not the
+history. Progress belongs in events
 (`bc-axi event <card> …` — level 2 timeline; level 1 rings the captain, use it sparingly).
 Questions on a card go through its thread (`bc-axi say card:<id>`); you are the interlocutor
 for your cards' threads, always.
@@ -124,6 +125,9 @@ it with no restart.
 refuses and names the templates. Cards created before briefs existed have none — set one
 with `card patch --brief <id>` when you get to them.
 
+A template orders only what a worker can run: the Skill tool refuses a `disable-model-invocation`
+skill to an agent — `/nobloat-pr-description` is one — so that step is yours, at handoff.
+
 ## Starting work
 
 `bc-axi card start <card-id> [--brief-file <f>]` is the ONE way work begins: it provisions
@@ -141,8 +145,7 @@ Workers report through your queue: `worker-signal` items are milestones (note th
 just trust the outcome text; **verified** means the exact end-user path was exercised, not a
 proxy (a notification feature checked via typed events but never a real chat message is not
 verified) — require the done report to name the path it exercised — then rewrite the card body
-to current state (what landed and where: file, branch, PR) and hand off (`card move <id>
-review`) — the card never leaves Working by itself.
+and hand off (`card move <id> review`) — the card never leaves Working by itself.
 The timeline never goes silent: a stalled-but-alive worker isn't just noted — peek its session,
 grasp what it's doing, and POST a level-2 timeline event narrating it, even when the wait is
 legitimate ("waiting on CI, ~15min, normal"). A silent hour on a Working card reads as dead and
@@ -153,9 +156,26 @@ while the worker is absent or dead; the server re-checks). To stop a worker ON P
 (machine pressure, deprioritized work), never kill its session by hand — that reads as a
 crash. Use `bc-axi worker pause <id>` (deliberate stop, no WORKER DIED alarm, record and
 worktree stay resumable), or `worker pause <id> --park` to also shelve the card in one
-step. Steer a live worker with a short line
-typed into its tmux session (the card's `session` attribute); anything long belongs in a rework restart
-with an updated brief. Never do the worker's job yourself.
+step. Steer a live worker with `bc-axi worker send <id> "<line>"`; anything long belongs in a
+rework restart with an updated brief.
+
+### Ruling on an escalated finding
+
+A worker on the `no-mistakes` brief drives its own review gate and signals when a finding comes
+back `ask-user` — the class that challenges what the card asked for. It is parked on that
+finding until your `worker send` reaches it:
+
+| answer | means |
+|---|---|
+| `fix` / `fix id1,id2` | fix everything offered / exactly these |
+| `fix id1 : do X not Y` | fix these, and here is what the finding got wrong |
+| `approve` / `skip` | the findings stand / skip the step |
+| `abort <reason>` | stop; card parked, reason on the timeline, no PR |
+
+Rule on a wrong finding by arguing with it — everything after the colon reaches the fixer, so
+disagreeing is its own answer rather than an approval around it. Every `ask-user` finding gets a
+ruling you typed: **never `--yes`**, which auto-resolves exactly the findings that exist to
+reach you.
 
 ## Merges are watched — never hand-archive merged work
 

--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -126,7 +126,7 @@ refuses and names the templates. Cards created before briefs existed have none �
 with `card patch --brief <id>` when you get to them.
 
 A template orders only what a worker can run: the Skill tool refuses a `disable-model-invocation`
-skill to an agent — `/nobloat-pr-description` is one — so that step is yours, at handoff.
+skill to an agent — `writing-great-skills` is one — so that step is yours, at handoff.
 
 ## Starting work
 

--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -163,14 +163,18 @@ rework restart with an updated brief.
 
 A worker on the `no-mistakes` brief drives its own review gate and signals when a finding comes
 back `ask-user` — the class that challenges what the card asked for. It is parked on that
-finding until your `worker send` reaches it:
+finding until your ruling reaches it by `bc-axi worker send` — a line the worker carries out,
+not flags for a tool:
 
 | answer | means |
 |---|---|
 | `fix` / `fix id1,id2` | fix everything offered / exactly these |
 | `fix id1 : do X not Y` | fix these, and here is what the finding got wrong |
 | `approve` / `skip` | the findings stand / skip the step |
-| `abort <reason>` | stop; card parked, reason on the timeline, no PR |
+| `abort <reason>` | stop the work, reason on the timeline, no PR |
+
+After an `abort` you park the card — `card park <id>`, or `worker pause <id> --park` while the
+worker is still alive — to restore the Working invariant at the top of this file.
 
 Rule on a wrong finding by arguing with it — everything after the colon reaches the fixer, so
 disagreeing is its own answer rather than an approval around it. Every `ask-user` finding gets a

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -46,8 +46,8 @@ Which update path applies depends on how the skill dir was installed — check f
   Update = re-run `npx skills add tonylampada/bridge-commander -g`, then restart the server.
 - **Dev checkout** (`.git` present): update via `git pull`, then follow the deploy section above.
 
-Then re-run `bc-axi init --name <that lieutenant>` **in each workspace**: seeding runs from
-`init` and nowhere else, so until it does, an upgraded workspace has neither the new brief
+Then re-run `bc-axi init --id <the existing lieutenant id>` **in each workspace**: seeding runs
+from `init` and nowhere else, so until it does, an upgraded workspace has neither the new brief
 templates nor the `~/.claude/skills/bridge-commander-worker` symlink — and its templates order a
 skill it does not have. Re-running is idempotent: it copies only the templates that are missing,
 repoints only a symlink of ours (a hand-installed real directory is left alone), and overwrites

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -46,6 +46,15 @@ Which update path applies depends on how the skill dir was installed — check f
   Update = re-run `npx skills add tonylampada/bridge-commander -g`, then restart the server.
 - **Dev checkout** (`.git` present): update via `git pull`, then follow the deploy section above.
 
+Then re-run `bc-axi init --name <that lieutenant>` **in each workspace**: seeding runs from
+`init` and nowhere else, so until it does, an upgraded workspace has neither the new brief
+templates nor the `~/.claude/skills/bridge-commander-worker` symlink — and its templates order a
+skill it does not have. Re-running is idempotent: it copies only the templates that are missing,
+repoints only a symlink of ours (a hand-installed real directory is left alone), and overwrites
+nothing you edited. It does PATCH the session ref of the lieutenant whose id matches `--id` (or
+the slug of `--name`), so run it **from that lieutenant's own tmux session** — from anywhere
+else you repoint them at the wrong address.
+
 ## The stale-UI trap
 
 After a UI deploy the board can LOOK live while running old JS: SSE reconnects and re-renders

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -46,8 +46,8 @@ Which update path applies depends on how the skill dir was installed — check f
   Update = re-run `npx skills add tonylampada/bridge-commander -g`, then restart the server.
 - **Dev checkout** (`.git` present): update via `git pull`, then follow the deploy section above.
 
-Then re-run `bc-axi init --id <the existing lieutenant id>` **in each workspace**: seeding runs
-from `init` and nowhere else, so until it does, an upgraded workspace has neither the new brief
+Then re-run `bc-axi init --name <that lieutenant> --id <their id>` **in each workspace**: seeding
+runs from `init` and nowhere else, so until it does, an upgraded workspace has neither the new brief
 templates nor the `~/.claude/skills/bridge-commander-worker` symlink — and its templates order a
 skill it does not have. Re-running is idempotent: it copies only the templates that are missing,
 repoints only a symlink of ours (a hand-installed real directory is left alone), and overwrites


### PR DESCRIPTION
## Intent

Card MNC-42 (bridge-commander, docs only, no code changes): move three lieutenant facts that lived in ONE workspace's memory/ into the product's own docs, so every workspace stops re-deriving them. The captain added a binding constraint mid-card: apply the writing-great-skills discipline to the edit — single source of truth (extend the sentence that already says it rather than opening a second home), hunt no-ops sentence by sentence, prompt the positive, collapse restatement into leading words. Net line count is a signal, not a target: adding three facts and removing four dead sentences beats a clean +30.

What landed (all in DOCTRINE.md and OPERATIONS.md at the repo root):

1. DOCTRINE.md — new "### Ruling on an escalated finding" at the end of "Supervising workers". OPERATIONS.md already said nm-clerk.sh stops dead on an ask-user finding but never said what the lieutenant then does, which is the actual decision. This adds the answer vocabulary a lieutenant sends with `bc-axi worker send`: fix / fix id1,id2 / "fix id1 : do X not Y" / approve / skip / abort <reason>. Plus the two rules that belong with it: rule on a wrong finding by ARGUING with it (everything after the colon reaches the fixer), and never `--yes`, which auto-resolves exactly the ask-user findings — the ones that exist to reach a human. The `--yes` claim is verified against ~/.claude/skills/no-mistakes/SKILL.md:232-236. The prohibition is kept deliberately (writing-great-skills says keep one only where there is no positive phrasing) and is paired with the positive: "Every ask-user finding gets a ruling you typed".

2. DOCTRINE.md "Briefs" — one added sentence: a template orders only what a worker can run; the Skill tool refuses a `disable-model-invocation` skill to an agent (`/nobloat-pr-description` is one), so that step is the lieutenant's, at handoff. Phrased as what to do, per the card.

3. OPERATIONS.md — extended the existing "Updating the tool" section rather than opening a new one, because that is the moment the fact bites. seedBriefsAndDuties runs from `init` and nowhere else (verified: only caller is cmdInit, cli/bc-axi:423), so upgrading the repo gives an existing workspace neither the new brief templates nor the ~/.claude/skills/bridge-commander-worker symlink — and its templates then order a skill it does not have (observed in our own workspace after upgrading to f10e3f2). Documented with the fix (re-run init per workspace) and its footgun: re-running is idempotent (server/brief.js:128-155 — copies only missing templates, repoints only a symlink of ours, leaves a hand-installed real directory alone, overwrites nothing edited), but cmdInit PATCHes the session ref of the lieutenant whose id matches --id or slug(--name) (cli/bc-axi:367-380), so it must run from that lieutenant's own tmux session or it repoints them at the wrong address.

Pruned in the same commit under the writing-great-skills mandate — each a duplication whose single source of truth is elsewhere in the SAME file, all adjacent to the text being touched:
- "Never do the worker's job yourself" — the "Role: orchestrate, never implement" section already says it, twice over.
- "rewrite the card body to current state (what landed and where: file, branch, PR)" in Supervising workers — "Card hygiene" owns that sentence; the specifics (file, branch, PR) moved INTO the Card hygiene sentence and the restatement is gone, so the meaning still has exactly one home and gained detail.
- "Steer a live worker with a short line typed into its tmux session (the card's `session` attribute)" — stale since `bc-axi worker send <id> "<line>"` exists (cli/bc-axi:863-875) and types with submit verification and retries. Replaced with the verb.

Deliberate non-changes, all of them the card's explicit instruction rather than an oversight:
- Zero code changes. The card forbids them: "if you believe code needs to change (e.g. seeding at boot), signal it and stop; that is a separate card and not yours to open." So the seeding-at-init behaviour is DOCUMENTED, not fixed.
- .github/ untouched — explicitly forbidden by the card.
- The workspace's memory/tools.md (the source these facts came from) lives in a different repo and is not edited here.
- briefs/README.md already states that seeding happens on init and that a workspace file wins over the packaged one, so the OPERATIONS.md entry deliberately covers only what that README does not: the upgrade consequence and the tmux footgun. Restating ownership there would be a second home for one meaning.
- The rest of the source memory (dataman-axi, excalidraw, this-machine notes) is genuinely workspace-specific and stays out of the product docs on purpose.

## What Changed

- DOCTRINE.md gains a "Ruling on an escalated finding" section under Supervising workers: the answer vocabulary a lieutenant sends with `bc-axi worker send` (`fix` / `fix id1,id2` / `fix id1 : do X not Y` / `approve` / `skip` / `abort <reason>`), the follow-up park after an `abort` (`card park <id>` or `worker pause <id> --park`), the rule that a wrong finding is answered by arguing with it, and the prohibition on `--yes`, which auto-resolves the `ask-user` findings that exist to reach a human.
- DOCTRINE.md "Briefs" adds one sentence: a template orders only what a worker can run, since the Skill tool refuses a `disable-model-invocation` skill to an agent, so that step is the lieutenant's at handoff.
- OPERATIONS.md extends the existing "Updating the tool" section with the post-upgrade step: re-run `bc-axi init --name <lieutenant> --id <id>` per workspace, because seeding runs from `init` only — plus the idempotency guarantees and the footgun that init PATCHes the matching lieutenant's session ref, so it must run from that lieutenant's own tmux session.
- Three now-duplicated sentences were pruned in the same pass (the "never do the worker's job yourself" restatement, the card-body rewrite instruction that Card hygiene already owns — its file/branch/PR detail folded into that sentence — and the stale "type into the tmux session" steering advice, replaced by `bc-axi worker send`). Docs only; no code or `.github/` changes, and the full suite still passes 666/666.

## Risk Assessment

✅ Low: Docs-only change to two root markdown files whose every factual claim verifies against the code it cites, and the final round is a one-line correction that makes the runbook command actually executable.

## Testing

Ran the full suite serially (666/666 pass; the parallel-run EADDRINUSE flakiness is the pre-existing test/helper.js freePort race already ruled a no-op, unrelated to this docs change), then demonstrated the change at product level rather than relying on unit tests. Confirmed the diff touches only DOCTRINE.md and OPERATIONS.md. Drove the new \"Ruling on an escalated finding\" section end-to-end through the real `bc-axi` CLI against a live server with the file-backed fake harness: a worker signalled an ask-user escalation, the lieutenant saw it in `drain`, ruled with `worker send \"fix test-1 : …\"` and saw the line land inside the worker session and on the card timeline as a level-2 worker-send event, then exercised the `abort` ruling followed by `worker pause --park`, which moved the card Working→Backlog exactly as the new paragraph promises. Verified the `--yes` prohibition against no-mistakes SKILL.md:232-234, and verified the round-1 fix by calling the Skill tool on `writing-great-skills` (refused for disable-model-invocation, flag still in its frontmatter) while the swapped-out example no longer carries it. Exercised the OPERATIONS.md upgrade paragraph by running seedBriefsAndDuties through all five documented cases and confirming `cmdInit` is its only caller; the tmux session-ref footgun transcript from round 1 still matches the current wording. Captured reviewer-visible visual evidence by rendering the four changed doc regions through the product's own markdown pipeline and screenshotting them, which shows the new answer-vocabulary table rendering correctly. Everything passed, the worktree is clean, and I have no actionable findings.

- Evidence: Changed doc sections rendered through the product&#39;s own markdown pipeline (new answer-vocabulary table renders correctly) (local file: <code>/tmp/no-mistakes-evidence/01KZGHZD8M92AWG3PQ1R8JMBGP/doctrine-rendered.png</code>)
<details>
<summary>Evidence: Rendered HTML source for the above (ui/vendor/marked + DOMPurify + ui/app.css, all local)</summary>

```text
<!doctype html><meta charset="utf-8"><title>MNC-42 — the three lieutenant facts, as a lieutenant reads them</title>
<link rel="stylesheet" href="app.css">
<style>
 body{height:auto;overflow:auto;display:block;padding:28px 22px 60px}
 .wrap{max-width:900px;margin:0 auto}
 h1.page{font:600 20px/1.3 var(--sans);letter-spacing:-.02em;margin-bottom:4px}
 .sub{color:var(--dim);font-size:13px;margin-bottom:24px}
 .panel{background:var(--panel);border:1px solid var(--line2);border-radius:var(--radius);margin:16px 0;box-shadow:var(--shadow);overflow:hidden}
 .panel > .cap{background:var(--panel2);border-bottom:1px solid var(--line2);padding:9px 14px;font:600 12px/1.3 var(--mono);color:var(--accent)}
 .panel > .md{padding:14px 18px 18px}
 .md table th,.md table td{border:1px solid var(--line2);padding:6px 10px;text-align:left}
 .md table th{background:var(--panel2)}
</style>
<div class="wrap">
<h1 class="page">MNC-42 — three lieutenant facts, rendered as a lieutenant reads them</h1>
<div class="sub">DOCTRINE.md and OPERATIONS.md are loaded from the checkout root by the bridge-commander skill (SKILL.md:22, :72). Rendered here through the product’s own markdown pipeline (ui/vendor/marked + DOMPurify, ui/app.css).</div>
<div class="panel"><div class="cap">DOCTRINE.md · Card hygiene (lines 35–37)</div><div class="md" data-src="%23%23%20Card%20hygiene%0A%0AThe%20card%20**body%20is%20the%20deliverable**%2C%20not%20a%20log%3A%20rewrite%20it%20to%20current%20state%20%E2%80%94%20what%20landed%20and%0Awhere%3A%20file%2C%20branch%2C%20PR%20%E2%80%94%20before%20every%20handoff%2C%20so%20the%20captain%20reads%20the%20result%2C%20not%20the%0Ahistory.%20Progress%20belongs%20in%20events%0A(%60bc-axi%20event%20%3Ccard%3E%20%E2%80%A6%60%20%E2%80%94%20level%202%20timeline%3B%20level%201%20rings%20the%20captain%2C%20use%20it%20sparingly).%0AQuestions%20on%20a%20card%20go%20through%20its%20thread%20(%60bc-axi%20say%20card%3A%3Cid%3E%60)%3B%20you%20are%20the%20interlocutor%0Afor%20your%20cards'%20threads%2C%20always."></div></div>
<div class="panel"><div class="cap">DOCTRINE.md · Briefs — the added sentence (lines 128–129)</div><div class="md" data-src="**A%20card%20with%20no%20brief%20does%20not%20start**%2C%20and%20nothing%20picks%20one%20on%20its%20behalf%3A%20%60card%20start%60%0Arefuses%20and%20names%20the%20templates.%20Cards%20created%20before%20briefs%20existed%20have%20none%20%E2%80%94%20set%20one%0Awith%20%60card%20patch%20--brief%20%3Cid%3E%60%20when%20you%20get%20to%20them.%0A%0AA%20template%20orders%20only%20what%20a%20worker%20can%20run%3A%20the%20Skill%20tool%20refuses%20a%20%60disable-model-invocation%60%0Askill%20to%20an%20agent%20%E2%80%94%20%60writing-great-skills%60%20is%20one%20%E2%80%94%20so%20that%20step%20is%20yours%2C%20at%20handoff."></div></div>
<div class="panel"><div class="cap">DOCTRINE.md · Supervising workers → NEW “Ruling on an escalated finding” (lines 155–182)</div><div class="md" data-src="while%20the%20worker%20is%20absent%20or%20dead%3B%20the%20server%20re-checks).%20To%20stop%20a%20worker%20ON%20PURPOSE%0A(machine%20pressure%2C%20deprioritized%20work)%2C%20never%20kill%20its%20session%20by%20hand%20%E2%80%94%20that%20reads%20as%20a%0Acrash.%20Use%20%60bc-axi%20worker%20pause%20%3Cid%3E%60%20(deliberate%20stop%2C%20no%20WORKER%20DIED%20alarm%2C%20record%20and%0Aworktree%20stay%20resumable)%2C%20or%20%60worker%20pause%20%3Cid%3E%20--park%60%20to%20also%20shelve%20the%20card%20in%20one%0Astep.%20Steer%20a%20live%20worker%20with%20%60bc-axi%20worker%20send%20%3Cid%3E%20%22%3Cline%3E%22%60%3B%20anything%20long%20belongs%20in%20a%0Arework%20restart%20with%20an%20updated%20brief.%0A%0A%23%23%23%20Ruling%20on%20an%20escalated%20finding%0A%0AA%20worker%20on%20the%20%60no-mistakes%60%20brief%20drives%20its%20own%20review%20gate%20and%20signals%20when%20a%20finding%20comes%0Aback%20%60ask-user%60%20%E2%80%94%20the%20class%20that%20challenges%20what%20the%20card%20asked%20for.%20It%20is%20parked%20on%20that%0Afinding%20until%20your%20ruling%20reaches%20it%20by%20%60bc-axi%20worker%20send%60%20%E2%80%94%20a%20line%20the%20worker%20carries%20out%2C%0Anot%20flags%20for%20a%20tool%3A%0A%0A%7C%20answer%20%7C%20means%20%7C%0A%7C---%7C---%7C%0A%7C%20%60fix%60%20%2F%20%60fix%20id1%2Cid2%60%20%7C%20fix%20everything%20offered%20%2F%20exactly%20these%20%7C%0A%7C%20%60fix%20id1%20%3A%20do%20X%20not%20Y%60%20%7C%20fix%20these%2C%20and%20here%20is%20what%20the%20finding%20got%20wrong%20%7C%0A%7C%20%60approve%60%20%2F%20%60skip%60%20%7C%20the%20findings%20stand%20%2F%20skip%20the%20step%20%7C%0A%7C%20%60abort%20%3Creason%3E%60%20%7C%20stop%20the%20work%2C%20reason%20on%20the%20timeline%2C%20no%20PR%20%7C%0A%0AAfter%20an%20%60abort%60%20you%20park%20the%20card%20%E2%80%94%20%60card%20park%20%3Cid%3E%60%2C%20or%20%60worker%20pause%20%3Cid%3E%20--park%60%20while%20the%0Aworker%20is%20still%20alive%20%E2%80%94%20to%20restore%20the%20Working%20invariant%20at%20the%20top%20of%20this%20file.%0A%0ARule%20on%20a%20wrong%20finding%20by%20arguing%20with%20it%20%E2%80%94%20everything%20after%20the%20colon%20reaches%20the%20fixer%2C%20so%0Adisagreeing%20is%20its%20own%20answer%20rather%20than%20an%20approval%20around%20it.%20Every%20%60ask-user%60%20finding%20gets%20a%0Aruling%20you%20typed%3A%20**never%20%60--yes%60**%2C%20which%20auto-resolves%20exactly%20the%20findings%20that%20exist%20to%0Areach%20you."></div></div>
<div class="panel"><div class="cap">OPERATIONS.md · Updating the tool — the added paragraph (lines 49–57)</div><div class="md" data-src="%0A%23%23%20Updating%20the%20tool%0A%0AWhich%20update%20path%20applies%20depends%20on%20how%20the%20skill%20dir%20was%20installed%20%E2%80%94%20check%20for%20%60.git%60%3A%0A%0A-%20**skills-CLI%20copy**%20(no%20%60.git%60)%3A%20%60npx%20skills%20add%60%20copied%20the%20folder%2C%20so%20%60git%20pull%60%20won't%20work.%0A%20%20Update%20%3D%20re-run%20%60npx%20skills%20add%20tonylampada%2Fbridge-commander%20-g%60%2C%20then%20restart%20the%20server.%0A-%20**Dev%20checkout**%20(%60.git%60%20present)%3A%20update%20via%20%60git%20pull%60%2C%20then%20follow%20the%20deploy%20section%20above.%0A%0AThen%20re-run%20%60bc-axi%20init%20--name%20%3Cthat%20lieutenant%3E%20--id%20%3Ctheir%20id%3E%60%20**in%20each%20workspace**%3A%20seeding%0Aruns%20from%20%60init%60%20and%20nowhere%20else%2C%20so%20until%20it%20does%2C%20an%20upgraded%20workspace%20has%20neither%20the%20new%20brief%0Atemplates%20nor%20the%20%60~%2F.claude%2Fskills%2Fbridge-commander-worker%60%20symlink%20%E2%80%94%20and%20its%20templates%20order%20a%0Askill%20it%20does%20not%20have.%20Re-running%20is%20idempotent%3A%20it%20copies%20only%20the%20templates%20that%20are%20missing%2C%0Arepoints%20only%20a%20symlink%20of%20ours%20(a%20hand-installed%20real%20directory%20is%20left%20alone)%2C%20and%20overwrites%0Anothing%20you%20edited.%20It%20does%20PATCH%20the%20session%20ref%20of%20the%20lieutenant%20whose%20id%20matches%20%60--id%60%20(or%0Athe%20slug%20of%20%60--name%60)%2C%20so%20run%20it%20**from%20that%20lieutenant's%20own%20tmux%20session**%20%E2%80%94%20from%20anywhere%0Aelse%20you%20repoint%20them%20at%20the%20wrong%20address.%0A"></div></div>
</div>
<script src="marked.umd.js"></script><script src="purify.min.js"></script>
<script>
 marked.use({gfm:true});
 for(const el of document.querySelectorAll(".md[data-src]"))
   el.innerHTML=DOMPurify.sanitize(marked.parse(decodeURIComponent(el.dataset.src)),{USE_PROFILES:{html:true}});
</script>
```
</details>
<details>
<summary>Evidence: E2E CLI transcript — escalation, ruling over `worker send`, abort + park</summary>

<code>[worker] $ bc-axi worker signal fix-1 no-mistakes gate stopped: finding test-1 is ask-user ... Waiting on your ruling; not answering it myself.&#10;signal #7 -&gt; fix-1&#10;&#10;[Ada] $ bc-axi drain&#10;1 pending item(s):&#10;#1 worker milestone — card fix-1 &#34;Rename the export&#34; [working]&#10;&#10;[Ada] $ bc-axi worker send fix-1 fix test-1 : keep the old export name as an alias, the finding read the card wrong — drop nothing&#10;sent -&gt; worker bc-...-lt-ada:w-fix-1 (card fix-1)&#10;&#10;what actually landed inside the worker session (fake-harness send log):&#10;&gt; fix test-1 : keep the old export name as an alias, the finding read the card wrong — drop nothing&#10;&#10;the card timeline the captain reads:&#10;#7 L2 signal — no-mistakes gate stopped: finding test-1 is ask-user ...&#10;#8 L2 worker-send — sent to worker: fix test-1 : keep the old export name as an alias ...&#10;&#10;[Ada] $ bc-axi worker send fix-2 abort the retry is already handled upstream — this card is moot&#10;card fix-2 column before park: working&#10;[Ada] $ bc-axi worker pause fix-2 --park&#10;paused worker ... (deliberate stop); parked fix-2 -&gt; backlog&#10;card fix-2 column after park: backlog &lt;- Working ⇔ live worker, restored</code>

```text

==============================================================================
SETUP — lieutenant Ada puts two cards on the no-mistakes brief and starts their workers
==============================================================================

[Ada] $ bc-axi card start fix-1 --harness fake
    starting a worker for fix-1 (worktree + real session — can take a minute)...
    started worker fake:bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-1
      worktree: /tmp/bc-test-LqHe2K/.bridge-commander/worktrees/fix-1
      branch:   bc/fix-1
      card fix-1 -> working

[Ada] $ bc-axi card start fix-2 --harness fake
    starting a worker for fix-2 (worktree + real session — can take a minute)...
    started worker fake:bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2
      worktree: /tmp/bc-test-LqHe2K/.bridge-commander/worktrees/fix-2
      branch:   bc/fix-2
      card fix-2 -> working

==============================================================================
1. THE ESCALATION — the worker hits an ask-user finding and parks on it (briefs/no-mistakes.md step 3)
==============================================================================

[worker] $ bc-axi worker signal fix-1 no-mistakes gate stopped: finding test-1 is ask-user — "the card said keep the old export name, the review wants it dropped". Waiting on your ruling; not answering it myself.
    signal #7 -> fix-1

[Ada] $ bc-axi drain
    1 pending item(s):
    
    #1  worker milestone — card fix-1 "Rename the export" [working]
        no-mistakes gate stopped: finding test-1 is ask-user — "the card said keep the old export name, the review wants it dropped". Waiting on your ruling; not answering it myself.
        -> note it; act only if it changes your plan
    
    handle EVERY item above, then commit: bc-axi ack 1   (only ack after handling; unacked items re-offer)

==============================================================================
2. THE RULING — Ada answers in the vocabulary DOCTRINE.md now spells out, over `worker send`
==============================================================================

[Ada] $ bc-axi worker send fix-1 fix test-1 : keep the old export name as an alias, the finding read the card wrong — drop nothing
    sent -> worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-1 (card fix-1)

    what actually landed inside the worker session (fake-harness send log):
      > fix test-1 : keep the old export name as an alias, the finding read the card wrong — drop nothing

    the card timeline the captain reads:
    #3 L2 created — created in 📋 Backlog
    #4 L2 started — worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-1 started in /tmp/bc-test-LqHe2K/.bridge-commander/wo
    #7 L2 signal — no-mistakes gate stopped: finding test-1 is ask-user — "the card said keep the old export name, 
    #8 L2 worker-send — sent to worker: fix test-1 : keep the old export name as an alias, the finding read the card wro

==============================================================================
3. THE ABORT RULING — stop the work, then restore the Working invariant
==============================================================================

[Ada] $ bc-axi worker send fix-2 abort the retry is already handled upstream — this card is moot
    sent -> worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2 (card fix-2)

    delivered to the worker: ["abort the retry is already handled upstream — this card is moot"]
    card fix-2 column before park: working

[Ada] $ bc-axi worker pause fix-2 --park
    paused worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2 (card fix-2) — deliberate stop; resume: bc-axi card start fix-2 --resume
    parked fix-2 -> backlog

    card fix-2 column after  park: backlog   <- Working ⇔ live worker, restored

    the card timeline:
    #5 L2 created — created in 📋 Backlog
    #6 L2 started — worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2 started in /tmp/bc-test-LqHe2K/.bridge-commander/wo
    #9 L2 worker-send — sent to worker: abort the retry is already handled upstream — this card is moot
    #10 L2 worker-paused — worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2 paused (deliberate) — resume: card start fix-2 --re
    #11 L2 parked — parked (worker bc-bc-test-lqhe-2b9fdd-lt-ada:w-fix-2, paused): 🔨 Working → 📋 Backlog

==============================================================================
4. THE PROHIBITION — `--yes` is what the doctrine forbids, and here is why
==============================================================================
    /home/ai/.claude/skills/no-mistakes/SKILL.md:232-234
      The one exception is `--yes` (below): it is the user's standing consent to
      drive every gate unattended, so under `--yes` you resolve `ask-user`
      findings automatically instead of stopping to ask.
```
</details>
<details>
<summary>Evidence: E2E demo script (reproducible)</summary>

```text
'use strict';
// End-to-end walk of the new DOCTRINE.md "Ruling on an escalated finding" section,
// driven entirely through the real `bc-axi` CLI against a real server, with the
// file-backed fake harness standing in for a claude-in-tmux worker.
//
//   usage: node ruling-e2e-demo.js <repo-root>
const fs = require('node:fs');
const os = require('node:os');
const path = require('node:path');
const { execFileSync } = require('node:child_process');

const REPO = process.argv[2];
const { startServerWithLieutenant, LT } = require(path.join(REPO, 'test', 'helper.js'));
const { lieutenantSession, workerWindow } = require(path.join(REPO, 'server', 'names.js'));
const CLI = path.join(REPO, 'cli', 'bc-axi');

const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-ruling-'));
const fdir = path.join(root, 'fake');

function git(dir, ...args) {
  return execFileSync('git', ['-C', dir, ...args], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
}
function makeRepo() {
  const repo = path.join(root, 'srcrepo');
  fs.mkdirSync(repo, { recursive: true });
  execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
  fs.writeFileSync(path.join(repo, 'README.md'), 'hello\n');
  git(repo, 'add', '.');
  git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init');
  return repo;
}

let s;
function bc(who, args) {
  const full = [...args, '--workspace', s.dir, '--port', String(s.port)];
  console.log('\n[' + who + '] $ bc-axi ' + args.join(' '));
  const r = require('node:child_process').spawnSync(process.execPath, [CLI, ...full], { encoding: 'utf8' });
  const out = (r.stdout + r.stderr).trim();
  if (out) console.log(out.split('\n').map((l) => '    ' + l).join('\n'));
  return r;
}
function head(t) { console.log('\n' + '='.repeat(78) + '\n' + t + '\n' + '='.repeat(78)); }
function column(id) {
  const b = JSON.parse(fs.readFileSync(path.join(s.dir, '.bridge-commander', 'board.json'), 'utf8'));
  return b.cards.find((c) => c.id === id).column;
}
function delivered(cardId) {
  const key = lieutenantSession(s.dir, LT) + ':' + workerWindow(cardId);
  const f = path.join(fdir, key + '.sends.jsonl');
  if (!fs.existsSync(f)) return [];
  return fs.readFileSync(f, 'utf8').trim().split('\n').map((l) => JSON.parse(l).text);
}
async function timeline(cardId) {
  const c = (await s.api('GET', '/api/cards/' + cardId)).body;
  return c.events.map((e) => '    #' + e.seq + ' L' + e.level + ' ' + e.kind + ' — ' + String(e.text).split('\n')[0].slice(0, 96));
}

(async () => {
  const repo = makeRepo();
  s = await startServerWithLieutenant({
    env: { BC_FAKE_STATE: fdir, BC_WORKTREE_TOOL: 'git', BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0' },
  });
  try {
    await s.api('POST', '/api/projects', { source: repo, name: 'proj' });

    head('SETUP — lieutenant Ada puts two cards on the no-mistakes brief and starts their workers');
    for (const [id, title] of [['fix-1', 'Rename the export'], ['fix-2', 'Add the retry']]) {
      await s.api('POST', '/api/cards', { title, id, owner: LT, brief: 'no-mistakes', attributes: { repo: 'proj' } });
      bc('Ada', ['card', 'start', id, '--harness', 'fake']);
    }

    head('1. THE ESCALATION — the worker hits an ask-user finding and parks on it (briefs/no-mistakes.md step 3)');
    bc('worker', ['worker', 'signal', 'fix-1',
      'no-mistakes gate stopped: finding test-1 is ask-user — "the card said keep the old export name, ' +
      'the review wants it dropped". Waiting on your ruling; not answering it myself.']);
    bc('Ada', ['drain']);

    head('2. THE RULING — Ada answers in the vocabulary DOCTRINE.md now spells out, over `worker send`');
    bc('Ada', ['worker', 'send', 'fix-1',
      'fix test-1 : keep the old export name as an alias, the finding read the card wrong — drop nothing']);
    console.log('\n    what actually landed inside the worker session (fake-harness send log):');
    for (const t of delivered('fix-1')) console.log('      > ' + t);
    console.log('\n    the card timeline the captain reads:');
    console.log((await timeline('fix-1')).join('\n'));

    head('3. THE ABORT RULING — stop the work, then restore the Working invariant');
    bc('Ada', ['worker', 'send', 'fix-2', 'abort the retry is already handled upstream — this card is moot']);
    console.log('\n    delivered to the worker: ' + JSON.stringify(delivered('fix-2')));
    console.log('    card fix-2 column before park: ' + column('fix-2'));
    bc('Ada', ['worker', 'pause', 'fix-2', '--park']);
    console.log('\n    card fix-2 column after  park: ' + column('fix-2') + '   <- Working ⇔ live worker, restored');
    console.log('\n    the card timeline:');
    console.log((await timeline('fix-2')).join('\n'));

    head('4. THE PROHIBITION — `--yes` is what the doctrine forbids, and here is why');
    const skill = path.join(os.homedir(), '.claude', 'skills', 'no-mistakes', 'SKILL.md');
    const txt = fs.readFileSync(skill, 'utf8').split('\n');
    const i = txt.findIndex((l) => l.includes('The one exception is `--yes`'));
    console.log('    ' + skill + ':' + (i + 1) + '-' + (i + 3));
    console.log(txt.slice(i, i + 3).map((l) => '      ' + l).join('\n'));
  } finally {
    await s.stop();
    fs.rmSync(root, { recursive: true, force: true });
  }
})();
```
</details>
<details>
<summary>Evidence: Re-running init is idempotent — all five cases the OPERATIONS.md paragraph claims</summary>

<code>--- 1. fresh workspace: first init seeds templates + the worker-duties symlink&#10;briefs copied : README.md, default.md, investigation.md, no-mistakes.md&#10;skill symlink : .../bridge-commander-worker -&gt; &lt;packaged skill&gt;&#10;&#10;--- 2. lieutenant edits a template, then the tool is upgraded and init re-run&#10;briefs copied : (none — nothing was missing)&#10;my edit kept : true&#10;symlink churn : none — already ours and pointing right&#10;&#10;--- 3. a NEW packaged template appears in an upgrade -&gt; only the missing one is copied&#10;briefs copied : investigation.md&#10;my edit kept : true&#10;&#10;--- 4. a hand-installed REAL skill directory is left alone&#10;skill touched : no&#10;still mine : &#34;mine, installed by hand&#34;&#10;&#10;--- 5. a stale symlink from an older checkout IS repointed&#10;before : /nonexistent/old-checkout/skills/bridge-commander-worker&#10;after : &lt;packaged skill&gt;&#10;== packaged : true</code>

```text
--- 1. fresh workspace: first init seeds templates + the worker-duties symlink
    briefs copied : README.md, default.md, investigation.md, no-mistakes.md
    skill symlink : /tmp/bc-seed-FxzHaE/home/.claude/skills/bridge-commander-worker -> /home/ai/.no-mistakes/worktrees/deeca192624b/01KZGHZD8M92AWG3PQ1R8JMBGP/skills/bridge-commander-worker

--- 2. lieutenant edits a template, then the tool is upgraded and init re-run
    briefs copied : (none — nothing was missing)
    my edit kept  : true
    symlink churn : none — already ours and pointing right

--- 3. a NEW packaged template appears in an upgrade -> only the missing one is copied
    briefs copied : investigation.md
    my edit kept  : true

--- 4. a hand-installed REAL skill directory is left alone
    skill touched : no
    still mine    : "mine, installed by hand"

--- 5. a stale symlink from an older checkout IS repointed
    before        : /nonexistent/old-checkout/skills/bridge-commander-worker
    after         : /home/ai/.no-mistakes/worktrees/deeca192624b/01KZGHZD8M92AWG3PQ1R8JMBGP/skills/bridge-commander-worker
    == packaged   : true
```
</details>
<details>
<summary>Evidence: The DOCTRINE.md briefs example checked against the live skill set</summary>

<code>$ head -5 ~/.claude/skills/writing-great-skills/SKILL.md&#10;name: writing-great-skills&#10;disable-model-invocation: true&#10;&#10;$ Skill(skill=&#34;writing-great-skills&#34;)&#10;-&gt; Skill writing-great-skills cannot be used with Skill tool due to disable-model-invocation.&#10;Ask the user to run /writing-great-skills themselves — it cannot be invoked via the Skill tool.&#10;&#10;### The example swapped OUT in 84c4533 no longer carries the flag:&#10;$ grep -c disable-model-invocation ~/.claude/skills/nobloat-pr-description/SKILL.md&#10;0</code>

```text
### The DOCTRINE.md:128-129 claim, checked against the live skill set

$ sed -n 128,129p DOCTRINE.md
  A template orders only what a worker can run: the Skill tool refuses a `disable-model-invocation`
  skill to an agent — `writing-great-skills` is one — so that step is yours, at handoff.

$ head -5 ~/.claude/skills/writing-great-skills/SKILL.md
  ---
  name: writing-great-skills
  description: Reference for writing and editing skills well — the vocabulary and principles that make a skill predictable.
  disable-model-invocation: true
  ---

$ # the agent actually calls the Skill tool on it:
  Skill(skill="writing-great-skills")
  -> Skill writing-great-skills cannot be used with Skill tool due to disable-model-invocation.
     Ask the user to run /writing-great-skills themselves — it cannot be invoked via the Skill tool.
     Do not replicate this skill's workflow by other means — it is reserved for explicit user invocation.

  -> the example named in DOCTRINE.md still carries the flag, and the tool still refuses it:
     a template that orders this skill orders something the worker cannot run.

### The example that was swapped OUT in 84c4533 no longer carries the flag:
$ grep -c disable-model-invocation ~/.claude/skills/nobloat-pr-description/SKILL.md
  0
$ git log --oneline -1 -- DOCTRINE.md
  84c4533 no-mistakes(test): Swap stale disable-model-invocation skill example in DOCTRINE.md
```
</details>
<details>
<summary>Evidence: The tmux session-ref footgun, reproduced live (round-1 artifact, still matches the current wording)</summary>

```text
### 6. The tmux footgun the docs warn about — re-running init from the WRONG session
$ curl :36429/api/board | lieutenant vance .ref        # after init in session bc-ev-alpha
  {"harness":"claude","session":"bc-ev-alpha","cwd":"/tmp/bc-init-ws-Drpj"}

$ # ...now a well-meaning operator re-runs the upgrade instruction from ANOTHER tmux session:
$ bc-axi init --name Vance --id vance     (typed in session bc-ev-beta)
  ┌─ bridge-commander init
  │  workspace : /tmp/bc-init-ws-Drpj   (existing)
  │  resolved  : existing .bridge-commander/ found from cwd upward
  │  tmux      : bc-ev-beta
  └─ if that workspace is wrong, stop now and re-run with --workspace <dir>
  server already running on port 36429
  founding lieutenant vance already registered — session ref refreshed (bc-ev-beta)
  turn-end hook installed (.claude/settings.local.json -> /api/turn-end)
  statusLine installed (.claude/settings.local.json -> real context window sidecar)
  
  board: http://localhost:36429/

$ curl :36429/api/board | lieutenant vance .ref        # AFTER the second init
  {"harness":"claude","session":"bc-ev-beta","cwd":"/tmp/bc-init-ws-Drpj"}
  -> Vance's address now points at bc-ev-beta. Every wake, feedback line and respawn
     for Vance is typed into a session that is not Vance. Exactly what OPERATIONS.md
     now tells you to avoid: run it from that lieutenant's own tmux session.
  -> note the same run reports no new templates: re-running init is idempotent.
```
</details>
- Outcome: 🔧 2 issues found → auto-fixed ✅ across 2 runs (25m40s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (2) ✅</summary>

- ⚠️ `DOCTRINE.md:173` - The `abort &lt;reason&gt;` row states the effect as &#34;card parked, reason on the timeline, no PR&#34;, but nothing on the worker side can park a card: skills/bridge-commander-worker/SKILL.md:27-40 grants exactly two verbs (`worker signal`, `worker done`) and explicitly tells the worker to leave the column alone; parking is a lieutenant verb (`card park`, `worker pause --park`). A lieutenant who sends `abort &lt;reason&gt;` and trusts this row leaves the card in Working with no live worker — which contradicts the invariant stated at DOCTRINE.md:18 (&#34;A card is in Working iff a live worker exists for it&#34;). Suggest making the lieutenant&#39;s follow-up explicit, e.g. &#34;stop; then `worker pause &lt;id&gt; --park`&#34;.
- ⚠️ `OPERATIONS.md:49` - The upgrade instruction is `bc-axi init --name &lt;that lieutenant&gt;`, and the footgun documented is only the tmux-session one. But cmdInit resolves the target as `opts.id || slugId(opts.name)` and POSTs /api/lieutenants first (cli/bc-axi:367-374) — the ref-refresh PATCH happens only on HTTP 409. If the name typed does not slug-match the registered id (an abbreviation, different casing/spacing, a display name), the re-run silently registers a brand-new lieutenant on the board instead of refreshing the existing one. Worth naming here, or steering the reader to `--id &lt;existing id&gt;` (which `bc-axi lieutenants`/`bc-axi line` can show).
- ℹ️ `DOCTRINE.md:173` - The ruling table is one word wider than the other escalation door documented in the same repo: bin/nm-clerk.sh accepts `--respond &lt;fix|approve|skip&gt; [--findings id,id] [--instructions &#34;…&#34;]` and refuses anything else outright (bin/nm-clerk.sh:116), as OPERATIONS.md:98 records. Rows 1-3 map cleanly onto that interface; `abort` has no counterpart there. The section scopes itself to a worker on the `no-mistakes` brief, so this is not wrong — but a lieutenant answering a clerk-driven escalation (the `bc-card` Archon path) from this vocabulary hits a hard refusal. A half-sentence tying the table to the clerk&#39;s `--respond` flags would make the two doors one fact.

🔧 Fix: Fix abort ruling, init --id, and worker-send framing in docs
1 error still open:
- 🚨 `OPERATIONS.md:49` - The round-1 fix changed the upgrade instruction to `bc-axi init --id &lt;the existing lieutenant id&gt;`, but `--name` is required: cmdInit&#39;s first statement is `if (!opts.name) die(&#39;usage: bc-axi init --name &lt;founding-lieutenant-name&gt; [--id id] ...&#39;)` (cli/bc-axi:331-334), so this command exits on a usage error before it reaches tmux resolution, seeding, or the lieutenant PATCH. Anyone following the runbook after an upgrade gets nothing seeded. The form that keeps the ruling&#39;s intent (target by id, never create a phantom lieutenant) and actually runs is `bc-axi init --name &lt;that lieutenant&gt; --id &lt;their id&gt;` — with `--id` given, the name only matters on a fresh POST, since the already-registered path is a 409 that PATCHes `ref` alone (cli/bc-axi:373-380). Flagging rather than fixing because the exact wording was the card owner&#39;s explicit round-1 instruction.

🔧 Fix: Restore required --name in init upgrade instruction
✅ Re-checked - no issues remain.

</details>

<details>
<summary>🔧 **Test** - 2 issues found → auto-fixed ✅</summary>

- ⚠️ `DOCTRINE.md:129` - DOCTRINE.md:129 names `/nobloat-pr-description` as an example of a `disable-model-invocation` skill a worker cannot run. The general rule is confirmed (calling the Skill tool on such a skill returns &#34;cannot be used with Skill tool due to disable-model-invocation&#34;), but that particular skill no longer carries the flag: ~/.claude/skills/nobloat-pr-description/SKILL.md has no `disable-model-invocation` key and the skill is offered to agents. Its upstream repo has commit eaaf9df &#34;nobloat-pr-description becomes model-invocable&#34; dated 2026-08-08 08:38:47, about a minute after this docs commit (08:37:38) — so the example was true when written and was flipped out from under it. Your call whether to swap in a still-valid example (writing-great-skills, wayfinder, zoom-out and jarbas-review all still carry the flag) or drop the parenthetical.
- ℹ️ `test/helper.js:26` - Running the suite the way test/helper.js documents it (`node --test test/*.test.js`, default parallel concurrency) produced EADDRINUSE failures in events.test.js and prwatch.test.js: helper.js:26 freePort() opens an ephemeral listener, closes it, and returns the number, so two concurrently-booting servers can be handed the same port. Re-running with `--test-concurrency=1` passes 666/666. Pre-existing test-infra flakiness, unrelated to this docs change — noted so a red parallel run is not mistaken for a regression.
- <code>`node --test --test-concurrency=1 test/*.test.js` — full suite, 666 pass / 0 fail</code>
- <code>`node --test test/brief.test.js test/card-brief.test.js test/cli.test.js test/lieutenants.test.js test/pause-park.test.js test/nm-clerk.test.js` — the seeding, init, park and clerk paths the new docs describe (72 pass)</code>
- <code>Captured the real lieutenant launch prompt: booted a server on a temp workspace, POST /api/lieutenants with spawn through the fake harness, read the prompt off the BC_FAKE_STATE marker — confirmed both new DOCTRINE passages present (`/tmp/no-mistakes-evidence/01KZGHZD8M92AWG3PQ1R8JMBGP/capture-prompt.js`)</code>
- <code>Ruling vocabulary end-to-end: `bc-axi card start` on the no-mistakes brief, `bc-axi worker signal` an ask-user park, then `bc-axi worker send` for each of `fix` / `fix nm-3,nm-4` / `fix nm-3 : …` / `approve` / `skip` / `abort &lt;reason&gt;` — all six delivered verbatim into the worker session and onto the card timeline (`ruling-e2e.js`)</code>
- <code>Real `bc-axi init --name Vance --id vance --port &lt;free&gt;` run inside `tmux new-session -d -s bc-ev-alpha` with a sandboxed HOME; re-run from `bc-ev-beta` to reproduce the documented session-ref repoint (verified via GET /api/board before/after)</code>
- <code>`bc-axi init` with no args and with `--name` outside tmux — confirms `--name` is required and the tmux precondition the docs cite</code>
- <code>Idempotency of `seedBriefsAndDuties(stateDir, home)` against a throwaway HOME: hand-edited template checksum unchanged across a re-run, hand-installed real skill directory left intact, only missing templates copied (`upgrade-transcript.sh`)</code>
- <code>`Skill(skill=&#34;writing-great-skills&#34;)` — direct check that the Skill tool refuses a disable-model-invocation skill to an agent</code>
- <code>Source verification of each documented claim: `grep -rn seedBriefsAndDuties` (sole caller cmdInit, cli/bc-axi:423), cli/bc-axi:367-380 (`opts.id || slugId(opts.name)`, PATCH-on-409), server/brief.js:128-155, cli/bc-axi:863-875 (`worker send`), bin/nm-clerk.sh:115-123 (`--instructions` only on fix), ~/.claude/skills/no-mistakes/SKILL.md:232-236 (`--yes`)</code>
- <code>`git diff --stat f10e3f2 a36e969` — confirms only DOCTRINE.md and OPERATIONS.md changed; no code, no .github/</code>

🔧 Fix: Swap stale disable-model-invocation skill example in DOCTRINE.md
✅ Re-checked - no issues remain.
- <code>`node --test --test-concurrency=1 test/*.test.js` — 666/666 pass, 0 fail (serial run avoids the pre-existing freePort race noted in round 1)</code>
- <code>`git diff --stat f10e3f2..HEAD` — confirms the change is DOCTRINE.md + OPERATIONS.md only; zero code, nothing under .github/</code>
- <code>E2E ruling walk via the real CLI against a live server + file-backed fake harness: `bc-axi card start &lt;id&gt; --harness fake` → `bc-axi worker signal` (ask-user escalation) → `bc-axi drain` → `bc-axi worker send &lt;id&gt; &#34;fix test-1 : …&#34;` → `bc-axi worker send &lt;id&gt; &#34;abort …&#34;` → `bc-axi worker pause &lt;id&gt; --park`; asserted the delivered text in the harness send log, the level-2 `worker-send` timeline events, and the Working→Backlog column flip</code>
- <code>`Skill(skill=&#34;writing-great-skills&#34;)` — refused with &#34;cannot be used with Skill tool due to disable-model-invocation&#34;, and `head -5 ~/.claude/skills/writing-great-skills/SKILL.md` shows the flag is live; `grep -c disable-model-invocation ~/.claude/skills/nobloat-pr-description/SKILL.md` → 0, confirming why 84c4533 swapped the example</code>
- <code>`~/.claude/skills/no-mistakes/SKILL.md:232-234` read back verbatim — confirms `--yes` auto-resolves `ask-user` findings, the basis for the doctrine&#39;s prohibition</code>
- <code>`seedBriefsAndDuties` driven through five scenarios in a temp workspace/HOME: first seed, re-run after a hand-edited template (nothing copied, edit intact), a newly-missing packaged template (only that one copied), a hand-installed real skill directory (untouched), and a stale symlink from an older checkout (repointed to the packaged skill)</code>
- <code>`grep -rn seedBriefsAndDuties` — only production caller is `cmdInit` (cli/bc-axi:423), confirming seeding runs from `init` and nowhere else</code>
- <code>`node cli/bc-axi init` / `worker send` / `card park` usage transcripts — confirm the flags and verbs DOCTRINE.md and OPERATIONS.md now name (`init --name &lt;n&gt; --id &lt;id&gt;`, `worker send &lt;id&gt; &#34;&lt;line&gt;&#34;`, `card park &lt;id&gt;`, `worker pause &lt;id&gt; --park`) exist as written</code>
- `Rendered the four changed doc regions through the product's own markdown pipeline (ui/vendor/marked + DOMPurify + ui/app.css) and screenshotted at 1000px width to confirm the new GFM answer-vocabulary table renders`

</details>

<details>
<summary>⚠️ **Document** - 1 warning</summary>

- ⚠️ `README.md:75` - README.md&#39;s brief-template table lists a `codereview` template, but briefs/ ships only default.md, investigation.md and no-mistakes.md, and DOCTRINE.md:113-115 names those three. `codereview` appears nowhere else in the repo. Introduced by the base commit f10e3f2, not by this change, so it is out of this pass&#39;s scope and the fix is ambiguous: either drop the table row or actually ship briefs/codereview.md. A user picking it from the README gets a brief that does not exist.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
