### PR TITLE
fix(server): the move answers without waiting for the worktree release

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3251,13 +3251,20 @@ const server = http.createServer(async (req, res) => {
         const r = moveCard(card, JSON.parse(await readBody(req) || '{}'));
         if (r.error) return sendJson(res, r.code || 400, { error: r.error });
         // The handoff IS the end of the work: the lieutenant has read the diff
-        // and the card left Working, so the worktree goes back. Awaited, so the
-        // move reports the board as it really stands. A worker that has not
-        // reported done keeps its checkout — a card moved out from under a live
-        // or crashed worker is the one case where that directory is still the
-        // only copy of anything.
+        // and the card left Working, so the worktree goes back. A worker that
+        // has not reported done keeps its checkout — a card moved out from under
+        // a live or crashed worker is the one case where that directory is still
+        // the only copy of anything.
+        //
+        // NOT awaited. The release queues behind the per-clone lock, which a
+        // concurrent `card start` holds across `git fetch` + `git worktree add`
+        // — seconds, minutes on a big repo — and the move used to sit there with
+        // it while the card stayed visibly in Working. The move answers as soon
+        // as the card has left; the release lands on the timeline when it lands,
+        // and its own saveBoard/broadcast carries it (including a refusal) to
+        // every screen. Same shape archive already uses.
         if (wasWorking && card.column !== 'working' && (!w || w.done)) {
-          await releaseCardWorktree(card, w, { honorKeep: true });
+          releaseCardWorktree(card, w, { honorKeep: true }); // never throws
         }
         saveBoard(); broadcast();
         return sendJson(res, 200, r);

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -314,7 +314,8 @@ test('card-archived hooks on a handed-off card: BC_WORKTREE is empty, not a rele
     const w = (await s.api('POST', '/api/cards/handed/start', { harness: 'fake' })).body.worker;
     await s.api('POST', '/api/cards/handed/worker/done', { outcome: 'shipped' });
     await s.api('POST', '/api/cards/handed/move', { column: 'review', actor: 'agent' });
-    assert.ok(!fs.existsSync(w.worktree.path), 'the handoff released it');
+    // the move answers before the release lands — it queues behind the per-clone lock
+    await until('the handoff released it', async () => !fs.existsSync(w.worktree.path));
 
     const r = await s.api('POST', '/api/cards/handed/archive', { reason: 'merged', actor: 'user' });
     assert.strictEqual(r.status, 200, JSON.stringify(r.body));

--- a/test/move-dedupe.test.js
+++ b/test/move-dedupe.test.js
@@ -1,0 +1,61 @@
+'use strict';
+// ui/js/api.js — one move per card in flight.
+//
+// The board redraws off SSE, so between the drop and the broadcast the card is
+// still visibly in the column it left. A second drag in that gap used to post a
+// second move; it now rides the answer of the move already going.
+//
+// api.js is DOM-free at import (FileReader is only touched inside a call), so
+// it imports straight into node with a stubbed `fetch` — same shape as
+// selection.test.js.
+const test = require('node:test');
+const assert = require('node:assert');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+let api;
+const calls = [];
+let settle; // resolves the in-flight fetch: every test drives the timing itself
+
+test.before(async () => {
+  globalThis.fetch = (url, opts) => new Promise((resolve, reject) => {
+    calls.push({ url, body: JSON.parse(opts.body) });
+    settle = { resolve, reject };
+  });
+  ({ api } = await import(pathToFileURL(path.join(__dirname, '..', 'ui', 'js', 'api.js')).href));
+});
+const ok = (body) => ({ ok: true, json: async () => body });
+const reset = () => { calls.length = 0; settle = null; };
+
+test('a second move on the same card in flight posts nothing and rides the first answer', async () => {
+  reset();
+  const first = api.moveCard('c1', 'review');
+  const second = api.moveCard('c1', 'review');
+  assert.strictEqual(calls.length, 1, 'the duplicate never reached the server');
+  settle.resolve(ok({ ok: true }));
+  assert.deepStrictEqual(await first, { ok: true });
+  assert.deepStrictEqual(await second, { ok: true }, 'the duplicate got the real move\'s answer');
+});
+
+test('a different card moves in parallel — the guard is per card, not a global mutex', async () => {
+  reset();
+  const a = api.moveCard('c1', 'review');
+  const first = settle;
+  const b = api.moveCard('c2', 'review');
+  assert.strictEqual(calls.length, 2);
+  assert.deepStrictEqual(calls.map((c) => c.body.column), ['review', 'review']);
+  settle.resolve(ok({ ok: true }));
+  first.resolve(ok({ ok: true }));
+  await Promise.all([a, b]);
+});
+
+test('once the move settles the card is movable again — success or failure', async () => {
+  reset();
+  const failing = api.moveCard('c1', 'review');
+  settle.reject(new Error('network'));
+  await assert.rejects(failing, /network/);
+  api.moveCard('c1', 'backlog').catch(() => {});
+  assert.strictEqual(calls.length, 2, 'a failed move does not wedge the card');
+  assert.strictEqual(calls[1].body.column, 'backlog');
+  settle.resolve(ok({ ok: true }));
+});

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -836,16 +836,53 @@ test('the handoff releases the worktree — `worker done` leaves it for the lieu
     assert.ok(fs.existsSync(w.worktree.path),
       'done starts the lieutenant\'s half: verifying the work means reading the diff in there');
 
-    // the handoff out of Working is the end of the work
+    // the handoff out of Working is the end of the work — the move answers as
+    // soon as the card has left, and the release follows on the timeline
     assert.strictEqual((await s.api('POST', '/api/cards/goes/move', { column: 'review', actor: 'agent' })).status, 200);
-    assert.ok(!fs.existsSync(w.worktree.path), 'released at the handoff, before the move even answers');
-    const ev = (await cardEvents(s, 'goes')).find((e) => /worktree released/.test(e.text));
-    assert.ok(ev, 'the timeline says the worktree went');
+    await until('worktree released after the handoff', async () => !fs.existsSync(w.worktree.path));
+    const ev = await until('the timeline says the worktree went',
+      async () => (await cardEvents(s, 'goes')).find((e) => /worktree released/.test(e.text)));
     assert.match(ev.text, rx(w.worktree.path));
-    assert.strictEqual((await s.api('GET', '/api/cards/goes')).body.attributes.worktree, undefined,
-      'the attribute stops pointing at a directory that is gone');
+    await until('the attribute stops pointing at a directory that is gone',
+      async () => (await s.api('GET', '/api/cards/goes')).body.attributes.worktree === undefined);
     // the clone knows too: a stale registration would block the next add
     assert.strictEqual(git(path.join(s.dir, 'projects', 'proj'), 'worktree', 'list').split('\n').filter(Boolean).length, 1);
+  } finally { await teardown(); }
+});
+
+// ...and it does NOT wait for it. The release queues behind the per-clone lock,
+// which a concurrent `card start` holds across `git fetch` + `git worktree add`
+// — seconds, minutes on a big repo. The move used to sit inside that wait with
+// the card still visibly in Working, which reads as a frozen board.
+test('a concurrent start holding the clone lock does not hold up the move', async () => {
+  const { s, teardown } = await boot();
+  try {
+    const proj = path.join(s.dir, 'projects', 'proj');
+    await s.api('POST', '/api/cards', withOwner({
+      title: 'Handed off', id: 'handoff', attributes: { repo: 'proj' },
+    }));
+    const w = (await s.api('POST', '/api/cards/handoff/start', { harness: 'fake' })).body.worker;
+    await s.api('POST', '/api/cards/handoff/worker/done', { outcome: 'shipped' });
+
+    // a fetch that takes its time, so the lock is provably still held when the
+    // move arrives (the fetch fails after it; freshBase falls back to origin/HEAD)
+    git(proj, 'config', 'protocol.ext.allow', 'always');
+    git(proj, 'remote', 'set-url', 'origin', 'ext::sleep 4');
+    await s.api('POST', '/api/cards', withOwner({
+      title: 'Next one', id: 'slowstart', attributes: { repo: 'proj' },
+    }));
+    const starting = s.api('POST', '/api/cards/slowstart/start', { harness: 'fake' });
+    await sleep(300); // the start is inside the fetch by now, holding the lock
+
+    const t0 = Date.now();
+    const mv = await s.api('POST', '/api/cards/handoff/move', { column: 'review', actor: 'agent' });
+    const took = Date.now() - t0;
+    assert.strictEqual(mv.status, 200, JSON.stringify(mv.body));
+    assert.ok(took < 1500, 'the move answered in ' + took + 'ms — it queued behind the lock');
+    assert.strictEqual((await s.api('GET', '/api/cards/handoff')).body.column, 'review');
+
+    assert.strictEqual((await starting).status, 200);
+    await until('the release lands once the lock frees', async () => !fs.existsSync(w.worktree.path));
   } finally { await teardown(); }
 });
 
@@ -893,8 +930,8 @@ test('a dirty worktree survives the handoff, and the timeline says why', async (
     await s.api('POST', '/api/cards/dirty/worker/done', { outcome: 'done, sort of' });
 
     await s.api('POST', '/api/cards/dirty/move', { column: 'review', actor: 'agent' });
-    const ev = (await cardEvents(s, 'dirty')).find((e) => /worktree kept/.test(e.text));
-    assert.ok(ev, 'the refusal is on the timeline');
+    const ev = await until('the refusal is on the timeline',
+      async () => (await cardEvents(s, 'dirty')).find((e) => /worktree kept/.test(e.text)));
     assert.match(ev.text, /uncommitted changes/); // the reason
     assert.match(ev.text, rx(w.worktree.path)); // the path
     assert.strictEqual(ev.level, 2, 'a refused release is not an alarm');
@@ -922,8 +959,8 @@ test('commits on a HEAD no ref holds keep the worktree, exactly like uncommitted
     await s.api('POST', '/api/cards/dangling/worker/done', { outcome: 'committed, no branch' });
 
     await s.api('POST', '/api/cards/dangling/move', { column: 'review', actor: 'agent' });
-    const ev = (await cardEvents(s, 'dangling')).find((e) => /worktree kept/.test(e.text));
-    assert.ok(ev, 'the refusal is on the timeline');
+    const ev = await until('the refusal is on the timeline',
+      async () => (await cardEvents(s, 'dangling')).find((e) => /worktree kept/.test(e.text)));
     assert.match(ev.text, /no branch or tag holds/);
     assert.match(ev.text, rx(sha.slice(0, 8)));
     assert.strictEqual(git(w.worktree.path, 'rev-parse', 'HEAD'), sha, 'the commit is still reachable');
@@ -939,6 +976,7 @@ test('archiving a card whose worktree is already gone is a no-op, not an error',
     const w = (await s.api('POST', '/api/cards/twice/start', { harness: 'fake' })).body.worker;
     await s.api('POST', '/api/cards/twice/worker/done', { outcome: 'shipped' });
     await s.api('POST', '/api/cards/twice/move', { column: 'review', actor: 'agent' });
+    await until('released at the handoff', async () => !(await s.api('GET', '/api/cards/twice')).body.attributes.worktree);
     assert.ok(!fs.existsSync(w.worktree.path));
 
     const r = await s.api('POST', '/api/cards/twice/archive', { reason: 'killed' });
@@ -961,6 +999,7 @@ test('resume and worker send both refuse a worker whose worktree was released', 
     const w = (await s.api('POST', '/api/cards/noback/start', { harness: 'fake' })).body.worker;
     await s.api('POST', '/api/cards/noback/worker/done', { outcome: 'shipped' });
     await s.api('POST', '/api/cards/noback/move', { column: 'review', actor: 'agent' });
+    await until('released at the handoff', async () => !(await s.api('GET', '/api/cards/noback')).body.attributes.worktree);
     assert.ok(!fs.existsSync(w.worktree.path));
 
     // its session is still alive, so send would otherwise reopen the turn in place

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -23,6 +23,15 @@ async function j(method, url, body) {
 // Per page load, thrown away with it — never persisted, never an identity.
 const CLIENT_ID = 'c' + Math.random().toString(36).slice(2) + Date.now().toString(36);
 
+// Moves currently posted, by card id — see api.moveCard. The entry is dropped
+// the moment the request settles, so the next drag on that card is a real move.
+const movesInFlight = new Map();
+function track(id, p) {
+  const done = p.finally(() => movesInFlight.delete(id));
+  movesInFlight.set(id, done);
+  return done;
+}
+
 export const api = {
   clientId: CLIENT_ID,
   createLieutenant: (lt) => j('POST', '/api/lieutenants', Object.assign({ actor: 'user' }, lt)),
@@ -32,8 +41,14 @@ export const api = {
   // A captain move may come back as {ordered: 'start-order'|'rework-order'}
   // instead of an applied move — any→working and review→backlog are orders.
   // `text` rides on the order QueueItem as the captain's comment.
-  moveCard: (id, column, text) => j('POST', '/api/cards/' + encodeURIComponent(id) + '/move',
-    Object.assign({ column, actor: 'user' }, text ? { text } : {})),
+  //
+  // One move per card in flight. The board only redraws when the move's SSE
+  // broadcast arrives, so until then the card sits visibly where it was — and a
+  // second drag in that gap posted a second move. The duplicate rides the answer
+  // of the move already going instead of issuing its own.
+  moveCard: (id, column, text) => movesInFlight.get(id) || track(id,
+    j('POST', '/api/cards/' + encodeURIComponent(id) + '/move',
+      Object.assign({ column, actor: 'user' }, text ? { text } : {}))),
   patchCard: (id, patch) => j('PATCH', '/api/cards/' + encodeURIComponent(id), patch),
   archiveCard: (id, reason) => j('POST', '/api/cards/' + encodeURIComponent(id) + '/archive', { actor: 'user', reason }),
   feedback: (target, text, attachments) => j('POST', '/api/feedback',


### PR DESCRIPTION
Dragging a card out of Working could freeze the board for seconds — minutes on a large repo — because the move handler awaited `releaseCardWorktree`, and the release queues behind the per-clone lock that a concurrent `card start` holds across `git fetch` + `git worktree add`. The card stayed visibly in Working the whole time, and a second drag in that gap posted a duplicate move.

**Option 1 — stop awaiting the release. Taken.** The move answers as soon as the card has left Working; the release fires and lands on the timeline when it lands, refusal included, carried to every screen by its own `saveBoard`/`broadcast` — exactly the shape archive already uses. The window disappears instead of getting decorated. The release itself is untouched: same trigger, same `honorKeep`, same refusals on an unclean worktree.

Option 2 (a pending state) lost because it decorates a wait that does not need to exist — and the first pending state in this UI is a design decision worth making on its own terms, not as a workaround. Option 3 (do nothing) lost because the trigger is not exotic: one lieutenant handing off while another starts a card in the same project is the normal weekday, and the delay scales with repo size.

Double-submit is closed separately, since it is not the release's fault: the board only redraws when the move's SSE broadcast arrives, so `api.moveCard` now keeps one move per card in flight and the duplicate rides the first move's answer. Per card, not a global mutex — bulk still moves a selection.

Tests: a start holding the clone lock for 4s no longer holds up the move (fails at ~3.7s without the fix); the existing release/refusal assertions now wait for the release rather than assuming it landed inside the move; three unit tests for the in-flight guard.
