### PR TITLE
feat(ui): labels leave the gear dropdown for a settings screen

### DIFF
--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -1,0 +1,94 @@
+'use strict';
+// The settings screen: labels left the gear dropdown for a board-region mode of
+// their own, beside the chat. Two things are pinned here — where the markup
+// lives (ui/index.html), and the rule that decides which modes are remembered
+// (setBoardMode in ui/js/main.js). main.js binds DOM at import, so the function
+// is lifted out of the source and run against stubs, same spirit as
+// av-dispatch.test.js.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ui = (...p) => path.join(__dirname, '..', 'ui', ...p);
+const html = fs.readFileSync(ui('index.html'), 'utf8');
+const mainSrc = fs.readFileSync(ui('js', 'main.js'), 'utf8');
+
+// the element with this id, from its opening tag to its matching close
+function element(id) {
+  const at = html.indexOf('id="' + id + '"');
+  assert.ok(at > -1, '#' + id + ' is in index.html');
+  const start = html.lastIndexOf('<', at);
+  const tag = /^<(\w+)/.exec(html.slice(start))[1];
+  const re = new RegExp('</?' + tag + '\\b', 'g');
+  re.lastIndex = start;
+  let depth = 0, m;
+  while ((m = re.exec(html))) {
+    depth += m[0][1] === '/' ? -1 : 1;
+    if (depth === 0) return html.slice(start, m.index + m[0].length);
+  }
+  assert.fail('#' + id + ' is never closed');
+}
+
+test('the label manager markup lives in the settings screen, not the gear panel', () => {
+  const panel = element('settings-panel');
+  assert.ok(!panel.includes('id="lm-list"'), 'the gear dropdown no longer holds the label list');
+  assert.ok(!panel.includes('id="lm-new"'), 'nor the new-label form');
+  assert.ok(panel.includes('id="labels-open"'), 'it holds the row that opens the screen instead');
+
+  const screen = element('settings-screen');
+  assert.ok(screen.includes('id="lm-list"'), 'the screen owns the label list');
+  assert.ok(screen.includes('id="lm-new"'), 'and the new-label form');
+  // the screen is a board-region mode: it sits inside the board section
+  assert.ok(element('board-wrap').includes('id="settings-screen"'));
+});
+
+test('the labels row hands off to the screen the way monitoring hands off to the monitor', () => {
+  assert.match(mainSrc, /getElementById\('labels-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
+  assert.match(mainSrc, /getElementById\('labels-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
+});
+
+// setBoardMode, lifted with MODE_BTN and run against stubs
+function loadSetBoardMode() {
+  const start = mainSrc.indexOf('const MODE_BTN');
+  const fnAt = mainSrc.indexOf('function setBoardMode', start);
+  const end = mainSrc.indexOf('\n}\n', fnAt) + 3;
+  assert.ok(start > -1 && fnAt > start && end > fnAt, 'setBoardMode found in main.js');
+  const stored = [];
+  const forgotten = [];
+  const localStorage = { setItem: (k, v) => stored.push([k, v]) };
+  const document = { getElementById: () => ({ classList: { toggle() {} } }) };
+  const S = {};
+  const make = new Function('document', 'localStorage', 'S', 'forgetFile', 'render',
+    mainSrc.slice(start, end) + '\nreturn setBoardMode;');
+  return { S, stored, forgotten, setBoardMode: make(document, localStorage, S, () => forgotten.push(1), () => {}) };
+}
+
+test('the switcher modes are remembered; the screens are not', () => {
+  const { S, stored, setBoardMode } = loadSetBoardMode();
+  for (const mode of ['board', 'table', 'archive']) {
+    setBoardMode(mode);
+    assert.strictEqual(S.boardMode, mode);
+    assert.deepStrictEqual(stored[stored.length - 1], ['bc-board-mode', mode], mode + ' sticks');
+  }
+  const before = stored.length;
+  for (const mode of ['file', 'settings']) {
+    setBoardMode(mode);
+    assert.strictEqual(S.boardMode, mode, mode + ' is a real mode, not coerced to board');
+    assert.strictEqual(stored.length, before, mode + ' is never written to localStorage');
+  }
+});
+
+test('entering the settings screen leaves the file screen', () => {
+  const { forgotten, setBoardMode } = loadSetBoardMode();
+  setBoardMode('file');
+  const before = forgotten.length;
+  setBoardMode('settings');
+  assert.strictEqual(forgotten.length, before + 1, 'forgetFile() ran');
+});
+
+test('an unknown mode still falls back to the kanban', () => {
+  const { S, setBoardMode } = loadSetBoardMode();
+  setBoardMode('nonsense');
+  assert.strictEqual(S.boardMode, 'board');
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -604,6 +604,13 @@ body.resizing { user-select: none; cursor: col-resize; }
 .toast .x { flex: none; color: var(--faint); font-size: 12px; padding: 0 2px; }
 .toast .x:hover { color: var(--danger); }
 
+/* settings screen: the board region's own mode, one section per setting */
+#settings-screen { overflow: auto; padding: 16px; gap: 22px; }
+.ss-sec { display: flex; flex-direction: column; gap: 8px; max-width: 460px; flex: none; }
+.ss-title { font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px; color: var(--faint); }
+/* the list capped itself to fit a dropdown; the screen scrolls as a whole */
+#settings-screen #lm-list { max-height: none; }
+
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
 .lm-row input[type=color], #lm-color { width: 26px; height: 22px; padding: 0; border: 1px solid var(--line); border-radius: 5px; background: none; cursor: pointer; flex: none; }
@@ -1046,8 +1053,8 @@ a.a-uri { color: var(--accent); }
 .mon-rss { flex: none; width: 52px; text-align: right; color: var(--faint); font-family: var(--mono); font-size: 11.5px; }
 .mon-empty { color: var(--faint); font-size: 12px; text-align: center; padding: 10px 0; }
 #mon-containers { color: var(--dim); font-size: 12px; }
-#mon-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
-#mon-open:hover { color: var(--accent); border-color: var(--accent2); }
+#mon-open, #labels-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#mon-open:hover, #labels-open:hover { color: var(--accent); border-color: var(--accent2); }
 
 /* context bar (chat header, switcher rows, Working tiles): used ÷ window from agentStatus.
    Green → yellow → red; red ≈ auto-compact territory (~80%). Rendered only
@@ -1284,9 +1291,9 @@ a.a-uri { color: var(--accent); }
 #view-seg button:hover { color: var(--accent); }
 #view-seg button.on { color: var(--accent); background: var(--accent-soft); }
 
-#table, #archive, #filepane { display: none; }
-#board-wrap.table-mode #board, #board-wrap.archive-mode #board, #board-wrap.file-mode #board { display: none; }
-#board-wrap.table-mode #table, #board-wrap.archive-mode #archive, #board-wrap.file-mode #filepane { display: flex; flex: 1; min-height: 0; flex-direction: column; }
+#table, #archive, #filepane, #settings-screen { display: none; }
+#board-wrap.table-mode #board, #board-wrap.archive-mode #board, #board-wrap.file-mode #board, #board-wrap.settings-mode #board { display: none; }
+#board-wrap.table-mode #table, #board-wrap.archive-mode #archive, #board-wrap.file-mode #filepane, #board-wrap.settings-mode #settings-screen { display: flex; flex: 1; min-height: 0; flex-direction: column; }
 
 .tv-scroll { flex: 1; min-height: 0; overflow: auto; padding: 0 16px 16px; }
 table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 820px; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -94,13 +94,11 @@
   <div class="sp-row">
     <button id="mon-open" title="live machine & per-agent load (samples only while open)">📈 machine load</button>
   </div>
+  <!-- labels outgrew the dropdown: this row hands off to the settings screen -->
   <div class="sp-title">labels</div>
-  <div id="lm-list"></div>
-  <form id="lm-new">
-    <input id="lm-color" type="color" value="#4cc2ff" title="label color">
-    <input id="lm-name" placeholder="new label…" autocomplete="off">
-    <button type="submit">add</button>
-  </form>
+  <div class="sp-row">
+    <button id="labels-open" title="create, rename, recolor and delete board labels">🏷 labels</button>
+  </div>
 </div>
 
 <!-- label picker popover -->
@@ -145,14 +143,28 @@
     <div class="pane-resize" id="chat-resize" title="drag to resize · double-click to reset"></div>
   </section>
 
-  <!-- board: right — one region, four modes (kanban | table | archived | file).
-       The file screen is entered by opening a file, not from the switcher: it
-       takes the board's place with the chat still at its side. -->
+  <!-- board: right — one region, five modes (kanban | table | archived | file |
+       settings). The file and settings screens are not in the switcher (you
+       enter them by opening a file, or from the gear): they take the board's
+       place with the chat still at its side. -->
   <section id="board-wrap">
     <div id="board"><div class="empty">waiting for board…</div></div>
     <div id="table"></div>
     <div id="archive"></div>
     <div id="filepane"></div>
+    <!-- settings screen: one section per setting that outgrew the gear
+         dropdown. Labels today; the rest move in later. -->
+    <div id="settings-screen">
+      <section class="ss-sec" id="ss-labels">
+        <div class="ss-title">labels</div>
+        <div id="lm-list"></div>
+        <form id="lm-new">
+          <input id="lm-color" type="color" value="#4cc2ff" title="label color">
+          <input id="lm-name" placeholder="new label…" autocomplete="off">
+          <button type="submit">add</button>
+        </form>
+      </section>
+    </div>
   </section>
 </main>
 

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -71,7 +71,7 @@ gearBtn.onclick = (e) => {
   e.stopPropagation();
   spEl.hidden = !spEl.hidden;
   gearBtn.classList.toggle('on', !spEl.hidden);
-  if (!spEl.hidden) { S.notifOpen = false; renderLabelManager(); renderNotifSettings(); render(); }
+  if (!spEl.hidden) { S.notifOpen = false; renderNotifSettings(); render(); }
 };
 document.addEventListener('click', (e) => {
   if (!spEl.hidden && !spEl.contains(e.target) && e.target !== gearBtn) {
@@ -85,23 +85,34 @@ document.getElementById('mon-open').onclick = () => {
   gearBtn.classList.remove('on');
   openMonitor();
 };
+// ⚙️ → labels: same handoff, to the settings screen in the board region (so the
+// chat stays at its side). Mobile lives in the board tab, like the file screen.
+document.getElementById('labels-open').onclick = () => {
+  spEl.hidden = true;
+  gearBtn.classList.remove('on');
+  S.view = 'board';
+  setBoardMode('settings');
+};
 
-// ---------- board region mode: kanban ⇄ table ⇄ archived ⇄ file ----------
+// ---------- board region mode: kanban ⇄ table ⇄ archived ⇄ file ⇄ settings ----
 // Board and table are two views over the LIVE cards; 🧊 is the archived
-// snapshots' own read-only mode. The choice sticks per browser.
-// 'file' is the fourth mode and the odd one out: it is not in the switcher (you
-// enter it by opening a file, not by picking it), and it is never remembered —
-// a reload has no file to come back to.
+// snapshots' own read-only mode. Those three are the switcher, and the choice
+// sticks per browser.
+// 'file' and 'settings' are the screens: not in the switcher (you enter them by
+// opening a file, or from the gear), and never remembered — MODE_BTN is the
+// whole rule, so a reload comes back to the last switcher mode.
 const MODE_BTN = { board: 'vs-board', table: 'vs-table', archive: 'vs-arch' };
+const SCREENS = ['file', 'settings'];
 function setBoardMode(mode) {
-  if (!MODE_BTN[mode] && mode !== 'file') mode = 'board';
-  if (mode !== 'file') forgetFile(); // picking a switcher mode leaves the file screen
+  if (!MODE_BTN[mode] && !SCREENS.includes(mode)) mode = 'board';
+  if (mode !== 'file') forgetFile(); // anything else leaves the file screen
   S.boardMode = mode;
-  if (mode !== 'file') try { localStorage.setItem('bc-board-mode', mode); } catch (e) {}
+  if (MODE_BTN[mode]) try { localStorage.setItem('bc-board-mode', mode); } catch (e) {}
   const wrap = document.getElementById('board-wrap');
   wrap.classList.toggle('table-mode', mode === 'table');
   wrap.classList.toggle('archive-mode', mode === 'archive');
   wrap.classList.toggle('file-mode', mode === 'file');
+  wrap.classList.toggle('settings-mode', mode === 'settings');
   for (const [m, id] of Object.entries(MODE_BTN)) {
     document.getElementById(id).classList.toggle('on', m === mode);
   }
@@ -225,6 +236,7 @@ onRender(() => {
   // The file screen owns its own DOM and is never repainted from here: a render
   // under the captain's cursor would eat what he is typing.
   if (S.boardMode === 'file') { /* nothing to repaint */ }
+  else if (S.boardMode === 'settings') renderLabelManager();
   else if (S.boardMode === 'archive') renderArchive();
   else if (S.boardMode === 'table') renderTable();
   else renderBoard();
@@ -234,7 +246,7 @@ onRender(() => {
   renderNotifications();
   renderTabs();
   if (pickerIsOpen()) renderPicker();
-  if (!spEl.hidden) { renderLabelManager(); renderNotifSettings(); }
+  if (!spEl.hidden) renderNotifSettings();
   // fill the [data-ago] spans the panels above left empty (see util.js: time
   // text stays out of the compared markup so it never forces a rebuild)
   refreshAgoLabels();


### PR DESCRIPTION
# Description

The gear dropdown had become a grab-bag — voice, pocket, notifications, monitoring, labels — and label management is the thing that least belongs in a popover. Labels now have a screen of their own in the board region, so the chat pane sits beside them while you edit.

UI only. Label data stays board state; no API or server change.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` — 729 pass, 0 fail. New `test/settings-screen.test.js` fails 3/5 without the change.

By hand on `dev/ui-server.js`: gear → labels opens the screen with the chat beside it; create, rename, recolor, delete and the per-label counts all work; a reload comes back to kanban; on a phone viewport it lands in the board tab and the chat tab still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
