### PR TITLE
feat(ui): playbooks join the settings screen, and it becomes the workspace screen

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -61,7 +61,7 @@ const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '.
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
 const { runHooks } = require(path.join(__dirname, 'hooks.js'));
 const { createSampler } = require(path.join(__dirname, 'sysload.js'));
-const { workerBrief, listPlaybooks, resolvePlaybook, parsePlaybook, attrVar, attrCardKey } = require(path.join(__dirname, 'playbooks.js'));
+const { workerBrief, listPlaybooks, resolvePlaybook, playbooksDir, PACKAGED_PLAYBOOKS_DIR, parsePlaybook, attrVar, attrCardKey } = require(path.join(__dirname, 'playbooks.js'));
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
 const gitrev = require(path.join(__dirname, 'gitrev.js'));
@@ -2740,6 +2740,37 @@ function serveStatic(res, rel) {
   res.end(data);
 }
 
+// The one uri the artifact routes accept that is not listed on a card: a
+// playbook. The workspace screen edits them in the same editor a card artifact
+// opens in, which means the same GET, the same version check and the same 409 —
+// a second file API would be a second place to get all of that wrong. So the
+// widening is exactly one shape and nothing else: `<playbooks dir>/<name>.md`,
+// one level deep, no symlink. The directory is DERIVED here, never taken from
+// the client.
+//
+// Returns 'workspace' | 'packaged' | '' — the same two populations
+// resolvePlaybook picks between, and the difference is what may be written.
+// The packaged set is a git checkout of this repo: readable, so the captain can
+// open one and copy it, and never written in place.
+function playbookSource(uri) {
+  if (typeof uri !== 'string' || !uri.startsWith('file://')) return '';
+  const file = uri.slice('file://'.length);
+  // path.resolve is idempotent on a clean absolute path — a `..` segment or a
+  // relative path changes it, so `<dir>/../../board.json` never gets this far.
+  if (path.resolve(file) !== file) return '';
+  if (path.extname(file) !== '.md') return '';
+  const dir = path.dirname(file);
+  const source = dir === playbooksDir(STATE_DIR) ? 'workspace'
+    : dir === PACKAGED_PLAYBOOKS_DIR ? 'packaged' : '';
+  if (!source) return '';
+  // A symlink IN the dir is not a file in the dir: what it points at is what
+  // would be read or written. Refused here rather than followed. (ENOENT is
+  // fine — that is the copy-to-workspace create, and PUT guards the dir itself.)
+  try { if (fs.lstatSync(file).isSymbolicLink()) return ''; }
+  catch (e) { if (e.code !== 'ENOENT') return ''; }
+  return source;
+}
+
 // ---------- server ----------
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, 'http://localhost');
@@ -2824,7 +2855,7 @@ const server = http.createServer(async (req, res) => {
       const uri = url.searchParams.get('uri') || '';
       const raw = url.searchParams.get('raw') === '1' || url.searchParams.get('raw') === 'true';
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
-        c.attributes.artifacts.some((a) => a && a.uri === uri));
+        c.attributes.artifacts.some((a) => a && a.uri === uri)) || !!playbookSource(uri);
       if (!listed) return sendJson(res, 404, { error: 'unknown artifact' });
       // A promoted chat attachment (attachment://id) resolves to its stored file
       // via the sidecar; file:// / bare paths read directly.
@@ -2894,9 +2925,10 @@ const server = http.createServer(async (req, res) => {
     // narrow: this is an artifact editor, not remote arbitrary-file write on
     // this machine. The board has no auth of its own (the network boundary is
     // the auth boundary), so every guard below is load-bearing:
-    //   - the uri must ALREADY be listed on a live card — the same allowlist
-    //     the GET uses. Anything else is 403, and there is no flag to turn it
-    //     off;
+    //   - the uri must ALREADY be listed on a live card, or be a WORKSPACE
+    //     playbook (playbookSource) — the GET's allowlist minus the packaged
+    //     playbooks, which are read-only. Anything else is 403, and there is no
+    //     flag to turn it off;
     //   - file:// only, absolute, no `..` (path.resolve is idempotent on a
     //     clean absolute path), and no symlink anywhere along it (realpath must
     //     come back unchanged), so a listed artifact can never be a door to
@@ -2919,9 +2951,17 @@ const server = http.createServer(async (req, res) => {
       const body = JSON.parse(raw || '{}');
       const uri = String(body.uri || '');
       if (typeof body.content !== 'string') return sendJson(res, 400, { error: 'content required' });
+      const pbSource = playbookSource(uri);
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
-        c.attributes.artifacts.some((a) => a && a.uri === uri));
-      if (!listed) return sendJson(res, 403, { error: 'not an artifact of any card — refusing to write' });
+        c.attributes.artifacts.some((a) => a && a.uri === uri)) || pbSource === 'workspace';
+      if (!listed) {
+        // A packaged playbook is readable and never writable: it is a git
+        // checkout of this repo, so the edit is a copy into the workspace.
+        if (pbSource === 'packaged') {
+          return sendJson(res, 403, { error: 'a packaged playbook is never written — copy it to the workspace first' });
+        }
+        return sendJson(res, 403, { error: 'not an artifact of any card — refusing to write' });
+      }
       if (!uri.startsWith('file://')) return sendJson(res, 403, { error: 'only file:// artifacts are writable' });
       const file = uri.slice('file://'.length);
       if (path.resolve(file) !== file) return sendJson(res, 403, { error: 'unsafe artifact path' });
@@ -3331,7 +3371,18 @@ const server = http.createServer(async (req, res) => {
     // (or dropping a new one in) changes the next card started, with no
     // restart, and the dropdown has to say so too.
     if (route === 'GET /api/playbooks') {
-      return sendJson(res, 200, { playbooks: listPlaybooks(STATE_DIR), dir: path.join(STATE_DIR, 'playbooks') });
+      const dir = playbooksDir(STATE_DIR);
+      const ids = listPlaybooks(STATE_DIR);
+      // `playbooks` stays the plain id list the picker and the CLI read.
+      // `items` says WHERE each one comes from — resolvePlaybook already decides
+      // which file wins, so where it landed is the answer, not a second guess at
+      // the same rule. That is what lets the workspace screen open a workspace
+      // playbook for editing and offer to copy a packaged one first.
+      const items = ids.map((id) => {
+        const file = resolvePlaybook(STATE_DIR, id);
+        return { id, file, source: path.dirname(file) === dir ? 'workspace' : 'packaged' };
+      });
+      return sendJson(res, 200, { playbooks: ids, items, dir });
     }
 
     // ----- board-level events (free-form notify) -----

--- a/test/playbook-edit.test.js
+++ b/test/playbook-edit.test.js
@@ -1,0 +1,194 @@
+'use strict';
+// Editing a playbook through the artifact routes — what the workspace screen's
+// playbooks section rides on.
+//
+// A playbook is a file the captain owns, so editing one is the file screen and
+// the same PUT /api/artifact a card artifact is saved with: one editor, one
+// version check, one 409. That means exactly one widening of the write gate,
+// and this file is where its edges live. The gate accepts a `.md` file sitting
+// DIRECTLY in <STATE_DIR>/playbooks and nothing else — not a subdirectory, not
+// another extension, not a symlink out of it, and no directory prefix from the
+// client. The card-artifact path is untouched.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { startServerWithLieutenant, withOwner } = require('./helper');
+
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+const uriOf = (f) => 'file://' + f;
+const get = (s, uri) => s.api('GET', '/api/artifact?uri=' + encodeURIComponent(uri));
+
+// A workspace with one playbook of its own. `bc-axi init` seeds this dir; a
+// server boot does not, so the test does what init would have.
+async function boot(files) {
+  const s = await startServerWithLieutenant();
+  const dir = path.join(s.dir, '.bridge-commander', 'playbooks');
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [name, body] of Object.entries(files || {})) {
+    fs.writeFileSync(path.join(dir, name), body);
+  }
+  return { s, dir };
+}
+
+test('GET /api/playbooks says where each playbook comes from and which file won', async () => {
+  const { s, dir } = await boot({ 'default.md': 'MY default\n' });
+  try {
+    const r = await s.api('GET', '/api/playbooks');
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.body.dir, dir, 'the workspace dir is still in the answer');
+    const by = Object.fromEntries(r.body.items.map((p) => [p.id, p]));
+
+    // overridden in the workspace: the workspace file is the one that wins
+    assert.deepStrictEqual(by.default, {
+      id: 'default', source: 'workspace', file: path.join(dir, 'default.md'),
+    });
+    // not overridden: the packaged file, from the install's own playbooks/
+    assert.strictEqual(by.investigation.source, 'packaged');
+    assert.strictEqual(by.investigation.file,
+      path.join(__dirname, '..', 'playbooks', 'investigation.md'));
+    assert.ok(fs.existsSync(by.investigation.file), 'and it is a real file on disk');
+
+    // the plain id list the picker and the CLI read is unchanged
+    assert.deepStrictEqual(r.body.playbooks, r.body.items.map((p) => p.id));
+    assert.ok(r.body.playbooks.includes('no-mistakes'));
+  } finally { await s.stop(); }
+});
+
+test('a workspace playbook reads and writes through the artifact routes, version check and all', async () => {
+  const { s, dir } = await boot({ 'default.md': 'first draft\n' });
+  try {
+    const uri = uriOf(path.join(dir, 'default.md'));
+    const got = await get(s, uri);
+    assert.strictEqual(got.status, 200, JSON.stringify(got.body));
+    assert.strictEqual(got.body.name, 'default.md');
+    assert.strictEqual(got.body.content, 'first draft\n');
+    assert.strictEqual(got.body.version, sha256('first draft\n'));
+
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'second draft\n', version: got.body.version });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(path.join(dir, 'default.md'), 'utf8'), 'second draft\n');
+
+    // …and a stale version is still refused, carrying what is on disk now
+    const stale = await s.api('PUT', '/api/artifact', { uri, content: 'mine\n', version: got.body.version });
+    assert.strictEqual(stale.status, 409);
+    assert.match(stale.body.error, /changed on disk/);
+    assert.strictEqual(stale.body.content, 'second draft\n');
+    assert.strictEqual(stale.body.version, sha256('second draft\n'));
+    assert.strictEqual(fs.readFileSync(path.join(dir, 'default.md'), 'utf8'), 'second draft\n', 'nothing was written');
+  } finally { await s.stop(); }
+});
+
+test('copy to workspace: a packaged playbook reads, refuses to be written, and copies in', async () => {
+  const { s, dir } = await boot();
+  try {
+    const packaged = (await s.api('GET', '/api/playbooks')).body.items.find((p) => p.id === 'investigation');
+    assert.strictEqual(packaged.source, 'packaged');
+    // it OPENS — that is what read-only means, and what the copy copies
+    const got = await get(s, uriOf(packaged.file));
+    assert.strictEqual(got.status, 200, JSON.stringify(got.body));
+    const content = got.body.content;
+    assert.ok(content.length, 'the packaged playbook has content');
+
+    // …and it is never written in place: the install is a git checkout of this repo
+    const nope = await s.api('PUT', '/api/artifact', { uri: uriOf(packaged.file), content: 'pwned\n', version: got.body.version });
+    assert.strictEqual(nope.status, 403);
+    assert.match(nope.body.error, /packaged playbook/);
+    assert.strictEqual(fs.readFileSync(packaged.file, 'utf8'), content, 'the installed file is untouched');
+
+    // The copy is a create in the workspace: version '' = "expect no file".
+    const target = path.join(dir, 'investigation.md');
+    const put = await s.api('PUT', '/api/artifact', { uri: uriOf(target), content, version: '' });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(target, 'utf8'), content);
+
+    // and now the same id resolves to the workspace copy
+    const after = (await s.api('GET', '/api/playbooks')).body.items.find((p) => p.id === 'investigation');
+    assert.deepStrictEqual(after, { id: 'investigation', source: 'workspace', file: target });
+  } finally { await s.stop(); }
+});
+
+// ---------- what the gate refuses ----------
+// Each of these is its own test on purpose: they are the reasons this is a
+// playbook route and not a workspace file API, and a single collapsed test
+// would let one of them rot green.
+
+async function refused(s, uri, content) {
+  const g = await get(s, uri);
+  assert.strictEqual(g.status, 404, 'GET ' + uri + ' → ' + JSON.stringify(g.body));
+  const p = await s.api('PUT', '/api/artifact', { uri, content: content || 'pwned\n', version: '' });
+  assert.strictEqual(p.status, 403, 'PUT ' + uri + ' → ' + JSON.stringify(p.body));
+}
+
+test('a file outside the playbooks dir is refused', async () => {
+  const { s } = await boot({ 'default.md': 'ok\n' });
+  try {
+    const outside = path.join(s.dir, 'notes.md');
+    fs.writeFileSync(outside, 'private\n');
+    await refused(s, uriOf(outside));
+    assert.strictEqual(fs.readFileSync(outside, 'utf8'), 'private\n');
+  } finally { await s.stop(); }
+});
+
+test('a traversal out of the playbooks dir is refused — the client never supplies a prefix', async () => {
+  const { s, dir } = await boot({ 'default.md': 'ok\n' });
+  try {
+    const board = path.join(s.dir, '.bridge-commander', 'board.json');
+    const before = fs.readFileSync(board, 'utf8');
+    await refused(s, uriOf(path.join(dir, '..', '..', 'board.json')));
+    // the un-normalized spelling too — the string is what arrives, not a path object
+    await refused(s, 'file://' + dir + '/../../board.json');
+    assert.strictEqual(fs.readFileSync(board, 'utf8'), before, 'the board is untouched');
+  } finally { await s.stop(); }
+});
+
+test('a non-.md file in the playbooks dir is refused', async () => {
+  const { s, dir } = await boot({ 'default.md': 'ok\n' });
+  try {
+    const f = path.join(dir, 'notes.txt');
+    fs.writeFileSync(f, 'not a playbook\n');
+    await refused(s, uriOf(f));
+    assert.strictEqual(fs.readFileSync(f, 'utf8'), 'not a playbook\n');
+  } finally { await s.stop(); }
+});
+
+test('a symlink in the playbooks dir pointing outside it is refused, not followed', async () => {
+  const { s, dir } = await boot({ 'default.md': 'ok\n' });
+  try {
+    const secret = path.join(s.dir, 'secret.md');
+    fs.writeFileSync(secret, 'the good stuff\n');
+    fs.symlinkSync(secret, path.join(dir, 'sneaky.md'));
+    await refused(s, uriOf(path.join(dir, 'sneaky.md')));
+    assert.strictEqual(fs.readFileSync(secret, 'utf8'), 'the good stuff\n');
+  } finally { await s.stop(); }
+});
+
+test('a .md in a SUBDIRECTORY of the playbooks dir is refused — directly inside means directly', async () => {
+  const { s, dir } = await boot({ 'default.md': 'ok\n' });
+  try {
+    fs.mkdirSync(path.join(dir, 'sub'));
+    const f = path.join(dir, 'sub', 'nested.md');
+    fs.writeFileSync(f, 'nested\n');
+    await refused(s, uriOf(f));
+    assert.strictEqual(fs.readFileSync(f, 'utf8'), 'nested\n');
+  } finally { await s.stop(); }
+});
+
+test('a card artifact still reads and writes exactly as it did', async () => {
+  const { s } = await boot({ 'default.md': 'ok\n' });
+  try {
+    const file = path.join(s.dir, 'report.md');
+    fs.writeFileSync(file, 'v1\n');
+    const cr = await s.api('POST', '/api/cards', withOwner({ title: 'Deliverable' }));
+    const add = await s.api('POST', '/api/cards/' + cr.body.card.id + '/artifacts', { uri: file, label: 'report' });
+    const uri = add.body.artifact.uri;
+
+    const got = await get(s, uri);
+    assert.strictEqual(got.status, 200);
+    assert.strictEqual(got.body.version, sha256('v1\n'));
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'v2\n', version: got.body.version });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'v2\n');
+  } finally { await s.stop(); }
+});

--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -30,11 +30,12 @@ function element(id) {
   assert.fail('#' + id + ' is never closed');
 }
 
-test('the label manager markup lives in the settings screen, not the gear panel', () => {
+test('the label manager markup lives in the workspace screen, not the gear panel', () => {
   const panel = element('settings-panel');
   assert.ok(!panel.includes('id="lm-list"'), 'the gear dropdown no longer holds the label list');
   assert.ok(!panel.includes('id="lm-new"'), 'nor the new-label form');
-  assert.ok(panel.includes('id="labels-open"'), 'it holds the row that opens the screen instead');
+  assert.ok(panel.includes('id="workspace-open"'), 'it holds the row that opens the screen instead');
+  assert.ok(!panel.includes('id="labels-open"'), 'and the row is no longer called labels');
 
   const screen = element('settings-screen');
   assert.ok(screen.includes('id="lm-list"'), 'the screen owns the label list');
@@ -43,9 +44,39 @@ test('the label manager markup lives in the settings screen, not the gear panel'
   assert.ok(element('board-wrap').includes('id="settings-screen"'));
 });
 
-test('the labels row hands off to the screen the way monitoring hands off to the monitor', () => {
-  assert.match(mainSrc, /getElementById\('labels-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
-  assert.match(mainSrc, /getElementById\('labels-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
+// The gear row is THIS BROWSER's list; the screen it opens is the WORKSPACE —
+// the board everyone shares. The row said "labels" while the screen held one
+// section; it holds two now, so the row names the screen instead of its first
+// section, and the screen says what it is.
+test('the workspace row and heading name the workspace, and playbooks are a section of it', () => {
+  const panel = element('settings-panel');
+  assert.match(panel, /<button id="workspace-open"[^>]*>🗂 workspace<\/button>/);
+  const screen = element('settings-screen');
+  assert.match(screen, /class="ss-head">workspace</, 'the screen is headed workspace');
+  assert.ok(screen.includes('id="ss-playbooks"'), 'the screen has a playbooks section');
+  assert.ok(screen.includes('id="pb-list"'), 'with the list the section renders into');
+  assert.ok(screen.includes('id="ss-labels"'), 'and the labels section is still there');
+  assert.match(element('ss-labels'), /class="ss-title">labels</, 'keeping its own section title');
+  assert.match(element('ss-playbooks'), /class="ss-title">playbooks</);
+});
+
+test('the workspace row hands off to the screen the way monitoring hands off to the monitor', () => {
+  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
+  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
+  // …and re-reads the playbooks off disk on the way in
+  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?renderPlaybooks\(true\)/);
+});
+
+// The one rule that keeps this from becoming a second editor: the playbooks
+// section opens files through the artifact routes and the file screen, the same
+// pair a card artifact opens through.
+test('the playbooks section reuses the file screen and the artifact routes', () => {
+  const pb = fs.readFileSync(ui('js', 'pbmanager.js'), 'utf8');
+  assert.match(pb, /import \{ openArtifactFile \} from '\.\/detail\.js'/);
+  assert.match(pb, /api\.saveArtifact\(/, 'copy to workspace goes through the guarded write');
+  assert.ok(!/mountFileEditor|CodeMirror/.test(pb), 'and never mounts an editor of its own');
+  const detail = fs.readFileSync(ui('js', 'detail.js'), 'utf8');
+  assert.match(detail, /export async function openArtifactFile/);
 });
 
 // setBoardMode, lifted with MODE_BTN and run against stubs

--- a/ui/app.css
+++ b/ui/app.css
@@ -604,12 +604,23 @@ body.resizing { user-select: none; cursor: col-resize; }
 .toast .x { flex: none; color: var(--faint); font-size: 12px; padding: 0 2px; }
 .toast .x:hover { color: var(--danger); }
 
-/* settings screen: the board region's own mode, one section per setting */
+/* workspace screen: the board region's own mode, one section per thing the
+   board owns (labels, playbooks) */
 #settings-screen { overflow: auto; padding: 16px; gap: 22px; }
+.ss-head { font-size: 15px; font-weight: 650; color: var(--text); flex: none; }
 .ss-sec { display: flex; flex-direction: column; gap: 8px; max-width: 460px; flex: none; }
 .ss-title { font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px; color: var(--faint); }
+.ss-note { color: var(--faint); font-size: 10.5px; font-family: var(--mono); overflow-wrap: anywhere; }
 /* the list capped itself to fit a dropdown; the screen scrolls as a whole */
 #settings-screen #lm-list { max-height: none; }
+
+/* playbooks: one row per playbook, packaged ones flagged */
+#pb-list { display: flex; flex-direction: column; gap: 4px; }
+.pb-row { display: flex; gap: 8px; align-items: center; }
+.pb-name { flex: 1; min-width: 0; text-align: left; color: var(--text); font-size: 12.5px; padding: 3px 7px;
+  border: 1px solid var(--line); border-radius: 5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pb-name:hover { color: var(--accent); border-color: var(--accent2); }
+.pb-tag { flex: none; color: var(--faint); font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; }
 
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
@@ -1053,8 +1064,8 @@ a.a-uri { color: var(--accent); }
 .mon-rss { flex: none; width: 52px; text-align: right; color: var(--faint); font-family: var(--mono); font-size: 11.5px; }
 .mon-empty { color: var(--faint); font-size: 12px; text-align: center; padding: 10px 0; }
 #mon-containers { color: var(--dim); font-size: 12px; }
-#mon-open, #labels-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
-#mon-open:hover, #labels-open:hover { color: var(--accent); border-color: var(--accent2); }
+#mon-open, #workspace-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#mon-open:hover, #workspace-open:hover { color: var(--accent); border-color: var(--accent2); }
 
 /* context bar (chat header, switcher rows, Working tiles): used ÷ window from agentStatus.
    Green → yellow → red; red ≈ auto-compact territory (~80%). Rendered only

--- a/ui/index.html
+++ b/ui/index.html
@@ -94,10 +94,12 @@
   <div class="sp-row">
     <button id="mon-open" title="live machine & per-agent load (samples only while open)">📈 machine load</button>
   </div>
-  <!-- labels outgrew the dropdown: this row hands off to the settings screen -->
-  <div class="sp-title">labels</div>
+  <!-- everything above this line is about THIS BROWSER. The workspace is not:
+       it is the board itself, shared by everyone on it, so it hands off to a
+       screen of its own. -->
+  <div class="sp-title">workspace</div>
   <div class="sp-row">
-    <button id="labels-open" title="create, rename, recolor and delete board labels">🏷 labels</button>
+    <button id="workspace-open" title="labels and playbooks — the board's own settings">🗂 workspace</button>
   </div>
 </div>
 
@@ -152,9 +154,11 @@
     <div id="table"></div>
     <div id="archive"></div>
     <div id="filepane"></div>
-    <!-- settings screen: one section per setting that outgrew the gear
-         dropdown. Labels today; the rest move in later. -->
+    <!-- the workspace screen: one section per thing the BOARD owns, as opposed
+         to the browser looking at it. Labels and playbooks today; projects and
+         lieutenants move in later. -->
     <div id="settings-screen">
+      <div class="ss-head">workspace</div>
       <section class="ss-sec" id="ss-labels">
         <div class="ss-title">labels</div>
         <div id="lm-list"></div>
@@ -163,6 +167,13 @@
           <input id="lm-name" placeholder="new label…" autocomplete="off">
           <button type="submit">add</button>
         </form>
+      </section>
+      <!-- playbooks: the templates a card start renders. Clicking one opens it
+           on the file screen — the same editor a card artifact opens in. -->
+      <section class="ss-sec" id="ss-playbooks">
+        <div class="ss-title">playbooks</div>
+        <div id="pb-list"></div>
+        <div id="pb-dir" class="ss-note"></div>
       </section>
     </div>
   </section>

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -471,6 +471,32 @@ export async function artifactWritten(ev) {
     ]);
 }
 
+// Open any file the artifact routes will serve on the file screen, through the
+// SAME drafts, versions and 409 handling a card artifact gets — which is what
+// makes the workspace screen's playbooks an editing surface without a second
+// editor, a second file API or a second lost-update story behind them.
+// `opts` adds what the caller knows: `crumb` (where this came from) and
+// `readOnly` — the line a save is refused with, for a file that has to be
+// copied somewhere writable first.
+export async function openArtifactFile(uri, name, opts) {
+  const o = opts || {};
+  const r = await api.artifact(uri);
+  if (!drafts.has(uri)) versions.set(uri, r.version || '');
+  openFile({
+    key: uri,
+    name,
+    markdown: MD_EXT.test(name),
+    content: drafts.has(uri) ? drafts.get(uri) : r.content,
+    saved: r.content, // a restored draft is still unsaved typing
+    crumb: o.crumb,
+    onChange: (text) => drafts.set(uri, text),
+    onSave: o.readOnly
+      ? () => Promise.reject(new Error(o.readOnly))
+      : (text) => saveArtifactText(uri, text, null, null),
+  });
+  return r;
+}
+
 // An artifact entry may carry a content-type hint ({uri, label, type}) — e.g.
 // the auto-attached worker brief is markdown in a `.prompt` file. The hint
 // wins; the extension regex is the fallback.

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -19,6 +19,7 @@ import { closePane, paneOpen } from './pane.js';
 import { openMonitor, closeMonitor, monitorOpen } from './monitor.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
+import { renderPlaybooks } from './pbmanager.js';
 import './resize.js'; // draggable side-panel widths
 import './keepalivesettings.js'; // the pocket switch: hold the audio session open
 
@@ -85,12 +86,14 @@ document.getElementById('mon-open').onclick = () => {
   gearBtn.classList.remove('on');
   openMonitor();
 };
-// ⚙️ → labels: same handoff, to the settings screen in the board region (so the
-// chat stays at its side). Mobile lives in the board tab, like the file screen.
-document.getElementById('labels-open').onclick = () => {
+// ⚙️ → workspace: same handoff, to the workspace screen in the board region (so
+// the chat stays at its side). Mobile lives in the board tab, like the file
+// screen. The dropdown is this browser; the screen is the board everyone shares.
+document.getElementById('workspace-open').onclick = () => {
   spEl.hidden = true;
   gearBtn.classList.remove('on');
   S.view = 'board';
+  renderPlaybooks(true); // read the playbooks off disk on the way in
   setBoardMode('settings');
 };
 
@@ -236,7 +239,7 @@ onRender(() => {
   // The file screen owns its own DOM and is never repainted from here: a render
   // under the captain's cursor would eat what he is typing.
   if (S.boardMode === 'file') { /* nothing to repaint */ }
-  else if (S.boardMode === 'settings') renderLabelManager();
+  else if (S.boardMode === 'settings') { renderLabelManager(); renderPlaybooks(); }
   else if (S.boardMode === 'archive') renderArchive();
   else if (S.boardMode === 'table') renderTable();
   else renderBoard();

--- a/ui/js/pbmanager.js
+++ b/ui/js/pbmanager.js
@@ -1,0 +1,105 @@
+// The workspace screen's playbooks section: every playbook the board can start
+// a card with, and the way to edit one.
+//
+// A playbook is a file, so editing one is the file screen — the same editor,
+// the same 💾, the same 409 as a card artifact (detail.js: openArtifactFile).
+// Nothing here knows how any of that works.
+//
+// Two populations, and the difference is the whole section:
+//   workspace — <STATE_DIR>/playbooks/<id>.md. Yours. Opens and saves.
+//   packaged  — the set that ships with the install. That is a git checkout, so
+//               it is never written: it opens read-only and offers to copy
+//               itself into the workspace, after which it is a workspace one.
+import { api } from './api.js';
+import { openArtifactFile } from './detail.js';
+import { fileNotice } from './filepane.js';
+
+const listEl = document.getElementById('pb-list');
+const dirEl = document.getElementById('pb-dir');
+
+let items = null;  // [{id, source, file}] — last answer from the server
+let dir = '';      // where a copy lands
+let loading = false;
+
+// Paints from the last answer and fetches when there isn't one. `reload` is
+// what the gear row passes on the way in, so opening the screen always reads
+// disk afresh (a playbook dropped in a second ago is in the list) while the
+// renders that follow — one per board event — cost nothing.
+export async function renderPlaybooks(reload) {
+  if (reload) items = null;
+  if (items) return paint();
+  if (loading) return;
+  loading = true;
+  try {
+    const r = await api.playbooks();
+    items = r.items || [];
+    dir = r.dir || '';
+  } catch (e) {
+    listEl.textContent = '⚠ ' + e.message;
+    return;
+  } finally { loading = false; }
+  paint();
+}
+
+function paint() {
+  listEl.textContent = '';
+  for (const p of items) {
+    const row = document.createElement('div');
+    row.className = 'pb-row';
+    const name = document.createElement('button');
+    name.type = 'button';
+    name.className = 'pb-name';
+    name.textContent = p.id;
+    name.title = p.file;
+    name.onclick = () => open(p);
+    row.append(name);
+    if (p.source === 'packaged') {
+      const tag = document.createElement('span');
+      tag.className = 'pb-tag';
+      tag.textContent = 'packaged';
+      tag.title = 'ships with the install — copy it to the workspace to edit it';
+      row.append(tag);
+    }
+    listEl.appendChild(row);
+  }
+  if (!items.length) listEl.textContent = 'no playbooks';
+  dirEl.textContent = dir;
+}
+
+async function open(p) {
+  const packaged = p.source === 'packaged';
+  try {
+    await openArtifactFile('file://' + p.file, p.id + '.md', {
+      readOnly: packaged && 'this playbook ships with the install and is never written — ' +
+        'copy it to the workspace first, then it is yours to edit.',
+    });
+  } catch (e) {
+    listEl.textContent = '⚠ cannot open ' + p.id + ' — ' + e.message;
+    return;
+  }
+  // The read-only case says so where he is about to type, with the one action
+  // that changes it — a screen that only refuses on save teaches him nothing
+  // until after he has written a paragraph.
+  if (packaged) {
+    fileNotice('packaged playbook — read-only', 'warn',
+      [{ label: '⧉ copy to workspace', title: 'write ' + dir + '/' + p.id + '.md and edit that', onClick: () => copy(p) }]);
+  }
+}
+
+// Copy = create the workspace file with the packaged content, through the same
+// guarded write (version '' means "I expect no file", so a file that turned up
+// meanwhile is a 409 and nothing is clobbered). Then reopen: the same id now
+// resolves to the workspace copy, and it is editable.
+async function copy(p) {
+  const target = dir + '/' + p.id + '.md';
+  try {
+    const src = await api.artifact('file://' + p.file);
+    await api.saveArtifact('file://' + target, src.content, '');
+  } catch (e) {
+    return fileNotice('⚠ could not copy — ' + e.message, 'err');
+  }
+  items = null;
+  await renderPlaybooks();
+  await open({ id: p.id, file: target, source: 'workspace' });
+  fileNotice('copied to the workspace — this is yours now', 'ok');
+}


### PR DESCRIPTION
# Description

Playbooks could only be edited by finding the files on disk. They now have a section on the screen labels moved to last PR, editable in place with the same version check and 409 that protect a card artifact. That screen is the board's own settings rather than the browser's, so the gear row and the heading say `workspace`.

One security-relevant change: the artifact routes, which until now served only files listed on a live card, also serve a `.md` sitting directly in a playbooks dir. The directory is derived server-side, subdirectories and symlinks are refused, and the packaged set — a git checkout of this repo — reads but is never written.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` → **740 pass, 0 fail**, run by the lieutenant in the worktree. `test/playbook-edit.test.js` covers the refusals one by one: outside the dir, traversal, non-`.md`, symlink, subdirectory, and a card artifact behaving exactly as before.

By hand in the browser: open the screen, edit and save a workspace playbook, open a packaged one read-only, copy it in, save the copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
