### PR TITLE
feat(ui): the workspace screen gets tabs

### DIFF
--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -63,8 +63,72 @@ test('the workspace row and heading name the workspace, and playbooks are a sect
 test('the workspace row hands off to the screen the way monitoring hands off to the monitor', () => {
   assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
   assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
-  // …and re-reads the playbooks off disk on the way in
-  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?renderPlaybooks\(true\)/);
+  // …landing on labels, every time: the tab is not remembered either
+  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?setWsTab\('labels'\)/);
+});
+
+// ---------- the tab strip ----------
+// The sections stack no longer: one tab per section in the heading row, one
+// section visible. The pairing is data-tab ⇄ data-sec, so the third and fourth
+// section (projects, lieutenants) are markup plus one WS_RENDER entry.
+test('the heading row carries a tab per section', () => {
+  const screen = element('settings-screen');
+  const tabs = element('ss-tabs');
+  const tabNames = [...tabs.matchAll(/data-tab="([^"]+)"/g)].map((m) => m[1]);
+  assert.deepStrictEqual(tabNames, ['labels', 'playbooks'], 'a button per section');
+  const secNames = [...screen.matchAll(/data-sec="([^"]+)"/g)].map((m) => m[1]);
+  assert.deepStrictEqual(secNames, tabNames, 'every tab names a section of the screen');
+  // both sections live inside the screen, and labels is the one that starts up
+  assert.ok(screen.includes('id="ss-labels"') && screen.includes('id="ss-playbooks"'));
+  assert.match(element('ss-labels'), /class="ss-sec on"/, 'labels is the section shown at rest');
+  assert.match(element('ss-playbooks'), /class="ss-sec"/);
+  // the active tab is marked the way the ▦☰🧊 switcher marks its mode: .on
+  const css = fs.readFileSync(ui('app.css'), 'utf8');
+  assert.match(css, /#view-seg button\.on, #ss-tabs button\.on/, 'the tabs reuse the switcher rule');
+  assert.match(css, /\.ss-sec \{[^}]*display: none/, 'a section is hidden unless it is the active one');
+  assert.match(css, /\.ss-sec\.on \{[^}]*display: flex/);
+});
+
+// setWsTab, lifted with WS_RENDER and run against stubs — same spirit as
+// loadSetBoardMode below.
+function loadSetWsTab() {
+  const start = mainSrc.indexOf('const WS_RENDER');
+  const fnAt = mainSrc.indexOf('function setWsTab', start);
+  const end = mainSrc.indexOf('\n}\n', fnAt) + 3;
+  assert.ok(start > -1 && fnAt > start && end > fnAt, 'setWsTab found in main.js');
+  const secs = ['labels', 'playbooks', 'projects'].map((sec) => ({ dataset: { sec }, on: false }));
+  const tabs = ['labels', 'playbooks', 'projects'].map((tab) => ({ dataset: { tab }, on: false }));
+  for (const el of [...secs, ...tabs]) el.classList = { toggle: (c, v) => { el.on = v; } };
+  const document = {
+    querySelectorAll: (q) => (q.includes('data-sec') ? secs : tabs),
+  };
+  const painted = [];
+  const stub = (name) => (reload) => painted.push([name, reload]);
+  const make = new Function('document', 'renderLabelManager', 'renderPlaybooks',
+    mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
+  const api = make(document, stub('labels'), stub('playbooks'));
+  return { secs, tabs, painted, ...api };
+}
+
+test('switching to a tab shows that section and hides every other one', () => {
+  const { setWsTab, secs, tabs, wsTab } = loadSetWsTab();
+  setWsTab('playbooks');
+  assert.strictEqual(wsTab(), 'playbooks');
+  assert.deepStrictEqual(secs.map((s) => s.on), [false, true, false]);
+  assert.deepStrictEqual(tabs.map((t) => t.on), [false, true, false]);
+  setWsTab('labels');
+  assert.deepStrictEqual(secs.map((s) => s.on), [true, false, false]);
+  assert.deepStrictEqual(tabs.map((t) => t.on), [true, false, false]);
+});
+
+test('a section paints when its tab is shown, and only then', () => {
+  const { setWsTab, painted } = loadSetWsTab();
+  setWsTab('labels');
+  assert.deepStrictEqual(painted, [['labels', true]], 'no playbooks fetch on the way into labels');
+  setWsTab('playbooks');
+  assert.deepStrictEqual(painted[1], ['playbooks', true], 'the fetch runs when the tab is shown');
+  // …and the board-event render loop repaints only the active section
+  assert.match(mainSrc, /S\.boardMode === 'settings'\) WS_RENDER\[wsTab\]\(\)/);
 });
 
 // The one rule that keeps this from becoming a second editor: the playbooks

--- a/ui/app.css
+++ b/ui/app.css
@@ -607,8 +607,13 @@ body.resizing { user-select: none; cursor: col-resize; }
 /* workspace screen: the board region's own mode, one section per thing the
    board owns (labels, playbooks) */
 #settings-screen { overflow: auto; padding: 16px; gap: 22px; }
+.ss-headrow { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; flex: none; }
 .ss-head { font-size: 15px; font-weight: 650; color: var(--text); flex: none; }
-.ss-sec { display: flex; flex-direction: column; gap: 8px; max-width: 460px; flex: none; }
+/* one section at a time — the active tab's. #ss-tabs wears the #view-seg look
+   (see the table-view block); tabs sit on top so the screen keeps its width
+   for the content, which on a phone is the whole viewport. */
+.ss-sec { display: none; flex-direction: column; gap: 8px; max-width: 460px; flex: none; }
+.ss-sec.on { display: flex; }
 .ss-title { font-size: 10.5px; font-weight: 650; text-transform: uppercase; letter-spacing: 1px; color: var(--faint); }
 .ss-note { color: var(--faint); font-size: 10.5px; font-family: var(--mono); overflow-wrap: anywhere; }
 /* the list capped itself to fit a dropdown; the screen scrolls as a whole */
@@ -1296,11 +1301,11 @@ a.a-uri { color: var(--accent); }
 }
 
 /* ---------- table view (the card ledger — dual of the kanban) ---------- */
-#view-seg { display: inline-flex; flex: none; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
-#view-seg button { padding: 5px 10px; font-size: 13px; color: var(--faint); line-height: 1.2; }
-#view-seg button + button { border-left: 1px solid var(--line); }
-#view-seg button:hover { color: var(--accent); }
-#view-seg button.on { color: var(--accent); background: var(--accent-soft); }
+#view-seg, #ss-tabs { display: inline-flex; flex: none; border: 1px solid var(--line); border-radius: 8px; overflow: hidden; }
+#view-seg button, #ss-tabs button { padding: 5px 10px; font-size: 13px; color: var(--faint); line-height: 1.2; }
+#view-seg button + button, #ss-tabs button + button { border-left: 1px solid var(--line); }
+#view-seg button:hover, #ss-tabs button:hover { color: var(--accent); }
+#view-seg button.on, #ss-tabs button.on { color: var(--accent); background: var(--accent-soft); }
 
 #table, #archive, #filepane, #settings-screen { display: none; }
 #board-wrap.table-mode #board, #board-wrap.archive-mode #board, #board-wrap.file-mode #board, #board-wrap.settings-mode #board { display: none; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -158,8 +158,18 @@
          to the browser looking at it. Labels and playbooks today; projects and
          lieutenants move in later. -->
     <div id="settings-screen">
-      <div class="ss-head">workspace</div>
-      <section class="ss-sec" id="ss-labels">
+      <!-- the heading row carries the tabs: one button per section, wearing the
+           same segmented look as the ▦☰🧊 switcher. data-tab pairs with the
+           section's data-sec — that pairing IS the switching logic, so a new
+           section is a section element and a button, nothing else. -->
+      <div class="ss-headrow">
+        <div class="ss-head">workspace</div>
+        <span id="ss-tabs" role="group" aria-label="workspace section">
+          <button type="button" data-tab="labels" class="on">labels</button>
+          <button type="button" data-tab="playbooks">playbooks</button>
+        </span>
+      </div>
+      <section class="ss-sec on" id="ss-labels" data-sec="labels">
         <div class="ss-title">labels</div>
         <div id="lm-list"></div>
         <form id="lm-new">
@@ -170,7 +180,7 @@
       </section>
       <!-- playbooks: the templates a card start renders. Clicking one opens it
            on the file screen — the same editor a card artifact opens in. -->
-      <section class="ss-sec" id="ss-playbooks">
+      <section class="ss-sec" id="ss-playbooks" data-sec="playbooks">
         <div class="ss-title">playbooks</div>
         <div id="pb-list"></div>
         <div id="pb-dir" class="ss-note"></div>

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -93,9 +93,34 @@ document.getElementById('workspace-open').onclick = () => {
   spEl.hidden = true;
   gearBtn.classList.remove('on');
   S.view = 'board';
-  renderPlaybooks(true); // read the playbooks off disk on the way in
+  setWsTab('labels'); // never remembered: the gear always lands on labels
   setBoardMode('settings');
 };
+
+// ---------- workspace screen tabs ----------
+// One tab per section, one section visible. The tab is a class toggle over
+// [data-sec] plus one variable — nothing is persisted, so entering from the
+// gear always lands on labels, the same way the screen itself is not
+// remembered across a reload.
+// WS_RENDER is what a section paints with: the tab shows it with `true` (read
+// the source afresh on the way in), the render loop repaints it without. A new
+// section is a <section data-sec>, a <button data-tab> and one entry here; the
+// switching below never learns its name.
+const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks };
+let wsTab = 'labels';
+function setWsTab(tab) {
+  wsTab = tab;
+  for (const el of document.querySelectorAll('#settings-screen [data-sec]')) {
+    el.classList.toggle('on', el.dataset.sec === tab);
+  }
+  for (const b of document.querySelectorAll('#ss-tabs button')) {
+    b.classList.toggle('on', b.dataset.tab === tab);
+  }
+  WS_RENDER[tab](true);
+}
+for (const b of document.querySelectorAll('#ss-tabs button')) {
+  b.onclick = () => setWsTab(b.dataset.tab);
+}
 
 // ---------- board region mode: kanban ⇄ table ⇄ archived ⇄ file ⇄ settings ----
 // Board and table are two views over the LIVE cards; 🧊 is the archived
@@ -239,7 +264,7 @@ onRender(() => {
   // The file screen owns its own DOM and is never repainted from here: a render
   // under the captain's cursor would eat what he is typing.
   if (S.boardMode === 'file') { /* nothing to repaint */ }
-  else if (S.boardMode === 'settings') { renderLabelManager(); renderPlaybooks(); }
+  else if (S.boardMode === 'settings') WS_RENDER[wsTab]();
   else if (S.boardMode === 'archive') renderArchive();
   else if (S.boardMode === 'table') renderTable();
   else renderBoard();

--- a/ui/js/pbmanager.js
+++ b/ui/js/pbmanager.js
@@ -22,9 +22,10 @@ let dir = '';      // where a copy lands
 let loading = false;
 
 // Paints from the last answer and fetches when there isn't one. `reload` is
-// what the gear row passes on the way in, so opening the screen always reads
-// disk afresh (a playbook dropped in a second ago is in the list) while the
-// renders that follow — one per board event — cost nothing.
+// what the playbooks tab passes on the way in, so showing the section always
+// reads disk afresh (a playbook dropped in a second ago is in the list) while
+// the renders that follow — one per board event — cost nothing. Nothing runs
+// at all while another tab is up: opening the screen for labels reads no disk.
 export async function renderPlaybooks(reload) {
   if (reload) items = null;
   if (items) return paint();


### PR DESCRIPTION
# Description

Playbooks sat stacked below labels on the workspace screen, and that only gets worse as projects and lieutenants move in. The heading row now carries a tab per section and one section is visible at a time. Opening the screen for labels reads no disk — the playbooks list waits for its own tab.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` → **743 pass, 0 fail**, run by the lieutenant in the worktree. `test/settings-screen.test.js` covers the tab/section pairing, that switching shows exactly one section, and that a section paints only when its tab is shown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
