### PR TITLE
feat(ui): a way out of the workspace screen on a phone

### DIFF
--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -187,3 +187,72 @@ test('an unknown mode still falls back to the kanban', () => {
   setBoardMode('nonsense');
   assert.strictEqual(S.boardMode, 'board');
 });
+
+// ---------- the way out of a screen ----------
+// On a phone the ▦☰🧊 switcher collapses to the active mode's button, and the
+// screens have none — so a screen used to be a dead end you left by reloading.
+// Two exits now, both answering one question: which switcher mode do we go back
+// to? Lifted the same way setBoardMode is, with tapBoardTab along for the ride.
+function loadScreenExits(remembered) {
+  const start = mainSrc.indexOf('const MODE_BTN');
+  const fnAt = mainSrc.indexOf('function tapBoardTab', start);
+  const end = mainSrc.indexOf('\n}\n', fnAt) + 3;
+  assert.ok(start > -1 && fnAt > start && end > fnAt, 'tapBoardTab found in main.js');
+  const localStorage = { getItem: () => remembered, setItem() {} };
+  const document = { getElementById: () => ({ classList: { toggle() {} } }) };
+  const S = {};
+  const renders = [];
+  const make = new Function('document', 'localStorage', 'S', 'forgetFile', 'render',
+    mainSrc.slice(start, end) + '\nreturn { setBoardMode, leaveScreen, tapBoardTab };');
+  return { S, renders, ...make(document, localStorage, S, () => {}, () => renders.push(1)) };
+}
+
+test('the workspace heading row carries a back control', () => {
+  const row = /<div class="ss-headrow">[\s\S]*?<\/div>/.exec(element('settings-screen'))[0];
+  assert.match(row, /id="ss-back"/, 'the ⟵ is in the heading row');
+  assert.ok(row.indexOf('id="ss-back"') < row.indexOf('class="ss-head"'), 'left of the title');
+  assert.match(row, /id="ss-back"[^>]*>⟵</);
+  assert.match(mainSrc, /getElementById\('ss-back'\)\.onclick = leaveScreen/);
+});
+
+test('the ⟵ leaves the screen for the remembered switcher mode', () => {
+  for (const mode of ['table', 'archive', 'board']) {
+    const { S, setBoardMode, leaveScreen } = loadScreenExits(mode);
+    setBoardMode('settings');
+    leaveScreen();
+    assert.strictEqual(S.boardMode, mode);
+  }
+});
+
+test('…and the kanban when nothing is remembered', () => {
+  for (const remembered of [null, 'settings', 'file', 'nonsense']) {
+    const { S, setBoardMode, leaveScreen } = loadScreenExits(remembered);
+    setBoardMode('settings');
+    leaveScreen();
+    assert.strictEqual(S.boardMode, 'board', String(remembered) + ' is not a switcher mode');
+  }
+});
+
+test('the mobile board tab is that same exit while a screen is up', () => {
+  for (const screen of ['settings', 'file']) {
+    const { S, setBoardMode, tapBoardTab } = loadScreenExits('table');
+    setBoardMode(screen);
+    S.view = 'chat';
+    tapBoardTab();
+    assert.strictEqual(S.view, 'board');
+    assert.strictEqual(S.boardMode, 'table', 'tapping ▦ Board left ' + screen);
+  }
+});
+
+test('…and does exactly what it always did while a switcher mode is up', () => {
+  for (const mode of ['board', 'table', 'archive']) {
+    const { S, renders, setBoardMode, tapBoardTab } = loadScreenExits('archive');
+    setBoardMode(mode);
+    S.view = 'chat';
+    const before = renders.length;
+    tapBoardTab();
+    assert.strictEqual(S.view, 'board');
+    assert.strictEqual(S.boardMode, mode, 'the mode is left alone');
+    assert.strictEqual(renders.length, before + 1, 'one repaint, as before');
+  }
+});

--- a/ui/index.html
+++ b/ui/index.html
@@ -162,7 +162,11 @@
            same segmented look as the ▦☰🧊 switcher. data-tab pairs with the
            section's data-sec — that pairing IS the switching logic, so a new
            section is a section element and a button, nothing else. -->
+      <!-- the way out, on every viewport: on a phone the ▦☰🧊 switcher has
+           collapsed to the active mode's button and this screen has none, so
+           without the ⟵ there is no exit. Wears the file screen's crumb look. -->
       <div class="ss-headrow">
+        <button type="button" id="ss-back" class="fs-back" title="back to the board">⟵</button>
         <div class="ss-head">workspace</div>
         <span id="ss-tabs" role="group" aria-label="workspace section">
           <button type="button" data-tab="labels" class="on">labels</button>

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -146,6 +146,24 @@ function setBoardMode(mode) {
   }
   render();
 }
+// The way out of a screen: back to the switcher mode this browser remembers,
+// kanban when it remembers none. Both exits — the workspace ⟵ and the mobile
+// Board tab — ask the question here, so they can never disagree.
+function lastSwitcherMode() {
+  let m = null;
+  try { m = localStorage.getItem('bc-board-mode'); } catch (e) {}
+  return MODE_BTN[m] ? m : 'board';
+}
+function leaveScreen() { setBoardMode(lastSwitcherMode()); }
+// On a phone the board tab IS the main area, so tapping it while that area
+// holds a screen means "give me the board back" — the switcher has collapsed to
+// a button the screens do not have.
+function tapBoardTab() {
+  S.view = 'board';
+  if (SCREENS.includes(S.boardMode)) leaveScreen(); // renders
+  else render();
+}
+document.getElementById('ss-back').onclick = leaveScreen;
 onModeSwitch(setBoardMode);   // the file screen flips the mode through this one owner
 onQuoteSource(fileQuote);     // …and is where every message's file context comes from
 // Mobile collapses the switcher to just the active mode's button; tapping it
@@ -186,7 +204,7 @@ try { setBoardMode(localStorage.getItem('bc-board-mode') || 'board'); } catch (e
 const tabChat = document.getElementById('tab-chat');
 const tabBoard = document.getElementById('tab-board');
 tabChat.onclick = () => { S.view = 'chat'; render(); };
-tabBoard.onclick = () => { S.view = 'board'; render(); };
+tabBoard.onclick = tapBoardTab;
 function renderTabs() {
   document.body.dataset.view = S.view;
   // The board tab IS the main area, so when that area holds a file it says so.


### PR DESCRIPTION
# Description

On a phone the workspace screen was a dead end — the ▦☰🧊 switcher collapses to the active mode's button and the screens have none, so the only exit was reloading the page. There is now a `⟵` in the screen's heading row, and tapping the mobile Board tab while a screen is up returns to the board instead of doing nothing.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` → **748 pass, 0 fail**, run by the lieutenant in the worktree. `test/settings-screen.test.js` covers both exits and that the board tab is unchanged while a switcher mode is up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
