### PR TITLE
feat(ui): the playbooks tab says what a playbook may contain

### DIFF
--- a/server/playbooks.js
+++ b/server/playbooks.js
@@ -220,6 +220,38 @@ function briefVars(b) {
   return vars;
 }
 
+// ---------- the reference the workspace screen shows ----------
+//
+// Editing a playbook takes two vocabularies — the placeholders briefVars()
+// fills and the keys FM_KEYS accepts — and neither is readable from the UI.
+// They live HERE, beside the code that implements them, and go out on
+// GET /api/playbooks. A test pins PLACEHOLDERS to briefVars()'s own keys and
+// FRONTMATTER to FM_KEYS, so adding either without a line here goes red.
+const PLACEHOLDERS = [
+  { name: 'CARD_ID', desc: "the card's id, e.g. MNC-42" },
+  { name: 'CARD_TITLE', desc: "the card's title" },
+  { name: 'TASK', desc: 'the card body; the title when the body is empty' },
+  { name: 'THREAD', desc: "the card's conversation so far, quoted; empty when there is none" },
+  { name: 'PROJECT', desc: "the registered project named by the card's repo attribute" },
+  { name: 'PROJECT_PATH', desc: "the project clone. Not the worker's to touch" },
+  { name: 'WORKTREE', desc: "the worker's own checkout, made at start" },
+  { name: 'BRANCH', desc: "the branch this card's work belongs on" },
+  { name: 'WORKSPACE', desc: "this workspace's root" },
+  { name: 'CLI', desc: 'the full bc-axi --workspace <dir> invocation, to paste in front of any verb' },
+  { name: 'REPORT_FILE', desc: 'where a durable report goes: <state dir>/reports/<CARD_ID>.md' },
+  { name: 'ATTR_<NAME>', desc: 'any card attribute, uppercased: --attr repo=x fills {{ATTR_REPO}}. '
+    + 'Structured attributes (artifacts, prs) have no text form and stay literal' },
+];
+
+const FRONTMATTER = [
+  { key: 'harness', desc: "which agent runs the card (claude, codex); the workspace's own by default" },
+  { key: 'model', desc: 'the model that harness starts on' },
+  { key: 'requires', desc: 'attributes a card must carry, [a, b]. A card missing one is refused '
+    + 'before any worktree exists' },
+  { key: 'branch', desc: 'false for a playbook that ships no code: no branch, no PR' },
+  { key: 'keep_worktree', desc: "true keeps the worker's checkout after the card leaves Working" },
+];
+
 // render(template, vars) — {{NAME}} → its value. An unknown name is left
 // EXACTLY as written: a typo has to be visible in the brief, never silently
 // empty.
@@ -282,4 +314,5 @@ function seedPlaybooksAndDuties(stateDir, home) {
 module.exports = {
   PACKAGED_PLAYBOOKS_DIR, PACKAGED_SKILL_DIR, playbooksDir, listPlaybooks, resolvePlaybook,
   parsePlaybook, attrVar, attrCardKey, briefVars, render, workerBrief, seedPlaybooksAndDuties,
+  FM_KEYS, PLACEHOLDERS, FRONTMATTER,
 };

--- a/server/server.js
+++ b/server/server.js
@@ -61,7 +61,7 @@ const { isHarnessRef, harnessFor, getHarness } = require(path.join(__dirname, '.
 const { createWorktree, releaseWorktree } = require(path.join(__dirname, 'worktrees.js'));
 const { runHooks } = require(path.join(__dirname, 'hooks.js'));
 const { createSampler } = require(path.join(__dirname, 'sysload.js'));
-const { workerBrief, listPlaybooks, resolvePlaybook, playbooksDir, PACKAGED_PLAYBOOKS_DIR, parsePlaybook, attrVar, attrCardKey } = require(path.join(__dirname, 'playbooks.js'));
+const { workerBrief, listPlaybooks, resolvePlaybook, playbooksDir, PACKAGED_PLAYBOOKS_DIR, parsePlaybook, attrVar, attrCardKey, PLACEHOLDERS, FRONTMATTER } = require(path.join(__dirname, 'playbooks.js'));
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
 const gitrev = require(path.join(__dirname, 'gitrev.js'));
@@ -3382,7 +3382,10 @@ const server = http.createServer(async (req, res) => {
         const file = resolvePlaybook(STATE_DIR, id);
         return { id, file, source: path.dirname(file) === dir ? 'workspace' : 'packaged' };
       });
-      return sendJson(res, 200, { playbooks: ids, items, dir });
+      // `reference` is the two vocabularies a playbook is written in, straight
+      // off playbooks.js — the screen renders it, never restates it.
+      return sendJson(res, 200, { playbooks: ids, items, dir,
+        reference: { placeholders: PLACEHOLDERS, frontmatter: FRONTMATTER } });
     }
 
     // ----- board-level events (free-form notify) -----

--- a/test/playbook-edit.test.js
+++ b/test/playbook-edit.test.js
@@ -56,6 +56,22 @@ test('GET /api/playbooks says where each playbook comes from and which file won'
   } finally { await s.stop(); }
 });
 
+// Writing a playbook takes two vocabularies — the placeholders and the five
+// frontmatter keys — and the screen can only show them if the answer carries
+// them. They come from server/playbooks.js, which is where the test that keeps
+// them honest lives (playbooks.test.js).
+test('GET /api/playbooks carries the reference the playbooks screen renders', async () => {
+  const { s } = await boot({});
+  try {
+    const { placeholders, frontmatter } = (await s.api('GET', '/api/playbooks')).body.reference;
+    assert.ok(placeholders.length && frontmatter.length, 'both lists are there');
+    assert.ok(placeholders.some((p) => p.name === 'CARD_ID'));
+    assert.ok(frontmatter.some((f) => f.key === 'harness'));
+    for (const p of placeholders) assert.ok(p.name && p.desc.trim(), p.name + ' is described');
+    for (const f of frontmatter) assert.ok(f.key && f.desc.trim(), f.key + ' is described');
+  } finally { await s.stop(); }
+});
+
 test('a workspace playbook reads and writes through the artifact routes, version check and all', async () => {
   const { s, dir } = await boot({ 'default.md': 'first draft\n' });
   try {

--- a/test/playbooks.test.js
+++ b/test/playbooks.test.js
@@ -10,7 +10,7 @@ const os = require('node:os');
 const path = require('node:path');
 const {
   workerBrief, render, listPlaybooks, resolvePlaybook, playbooksDir, seedPlaybooksAndDuties, parsePlaybook,
-  PACKAGED_PLAYBOOKS_DIR, PACKAGED_SKILL_DIR,
+  briefVars, PACKAGED_PLAYBOOKS_DIR, PACKAGED_SKILL_DIR, FM_KEYS, PLACEHOLDERS, FRONTMATTER,
 } = require('../server/playbooks.js');
 
 function tmpState(files) {
@@ -299,4 +299,29 @@ test('init SYMLINKS the worker-duties skill, repoints a stale link, and leaves a
 
   fs.rmSync(dir, { recursive: true, force: true });
   fs.rmSync(home, { recursive: true, force: true });
+});
+
+// ---------- the reference the workspace screen shows ----------
+//
+// Two lists documenting the two vocabularies, and the whole point of them is
+// that they cannot drift: they are checked against the code that implements
+// them, so a new placeholder or a new frontmatter key without a line of prose
+// is a red suite, not a stale panel.
+
+test('the documented placeholders are exactly the ones briefVars fills, plus ATTR_<NAME>', () => {
+  const sample = {
+    card: { id: 'MON-9', title: 'Demo card', body: 'do the thing', attributes: {} },
+    thread: [], project: { name: 'proj', path: '/repos/proj' },
+    worktree: '/wt/MON-9', branch: 'bc/MON-9', workspace: '/ws',
+    stateDir: '/ws/.bridge-commander', cli: 'bc-axi',
+  };
+  const documented = PLACEHOLDERS.map((p) => p.name);
+  assert.deepStrictEqual(documented, [...Object.keys(briefVars(sample)), 'ATTR_<NAME>'],
+    'every placeholder the brief renders is documented, in the order it is filled');
+  for (const p of PLACEHOLDERS) assert.ok(p.desc && p.desc.trim(), p.name + ' has a description');
+});
+
+test('the documented frontmatter keys are exactly FM_KEYS', () => {
+  assert.deepStrictEqual(FRONTMATTER.map((f) => f.key), FM_KEYS);
+  for (const f of FRONTMATTER) assert.ok(f.desc && f.desc.trim(), f.key + ' has a description');
 });

--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -256,3 +256,16 @@ test('…and does exactly what it always did while a switcher mode is up', () =>
     assert.strictEqual(renders.length, before + 1, 'one repaint, as before');
   }
 });
+
+// The panel that says what a playbook may contain: markup here, text on the
+// server (server/playbooks.js), so there is only ever one copy of it.
+test('the playbooks section holds the reference panel, and does not restate its text', () => {
+  const sec = element('ss-playbooks');
+  assert.ok(sec.includes('id="pb-ref"'), 'the reference panel sits in the playbooks section');
+  assert.ok(sec.indexOf('id="pb-list"') < sec.indexOf('id="pb-ref"'), 'under the list');
+  assert.ok(!/CARD_ID|keep_worktree/.test(html), 'the names live on the server, not in the markup');
+
+  const pb = fs.readFileSync(ui('js', 'pbmanager.js'), 'utf8');
+  assert.match(pb, /r\.reference/, 'the section renders what /api/playbooks sent');
+  assert.ok(!/CARD_ID|keep_worktree/.test(pb), 'and holds no second copy of the list');
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -626,6 +626,16 @@ body.resizing { user-select: none; cursor: col-resize; }
   border: 1px solid var(--line); border-radius: 5px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pb-name:hover { color: var(--accent); border-color: var(--accent2); }
 .pb-tag { flex: none; color: var(--faint); font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px; }
+/* the reference: tight rows, and it scrolls on its own so the playbook list
+   above it keeps its place on a phone */
+#pb-ref { display: flex; flex-direction: column; gap: 2px; max-height: 34vh; overflow-y: auto;
+  border-top: 1px solid var(--line); padding-top: 8px; margin-top: 4px; }
+#pb-ref .ss-title { margin-top: 6px; }
+#pb-ref .ss-title:first-child { margin-top: 0; }
+.pb-ref-note { font-family: inherit; margin-bottom: 2px; }
+.pb-ref-row { display: flex; gap: 6px; align-items: baseline; font-size: 11px; line-height: 1.35; }
+.pb-ref-k { flex: none; font-family: var(--mono); color: var(--accent); }
+.pb-ref-d { color: var(--faint); min-width: 0; overflow-wrap: anywhere; }
 
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -188,6 +188,11 @@
         <div class="ss-title">playbooks</div>
         <div id="pb-list"></div>
         <div id="pb-dir" class="ss-note"></div>
+        <!-- the two vocabularies a playbook is written in, rendered from
+             /api/playbooks `reference` (server/playbooks.js owns the text).
+             Visible without a click, and scrolling on its own so it never
+             pushes the list off a phone screen. -->
+        <div id="pb-ref"></div>
       </section>
     </div>
   </section>

--- a/ui/js/pbmanager.js
+++ b/ui/js/pbmanager.js
@@ -16,9 +16,11 @@ import { fileNotice } from './filepane.js';
 
 const listEl = document.getElementById('pb-list');
 const dirEl = document.getElementById('pb-dir');
+const refEl = document.getElementById('pb-ref');
 
 let items = null;  // [{id, source, file}] — last answer from the server
 let dir = '';      // where a copy lands
+let reference = null; // {placeholders, frontmatter} — written in server/playbooks.js
 let loading = false;
 
 // Paints from the last answer and fetches when there isn't one. `reload` is
@@ -35,6 +37,7 @@ export async function renderPlaybooks(reload) {
     const r = await api.playbooks();
     items = r.items || [];
     dir = r.dir || '';
+    reference = r.reference || null;
   } catch (e) {
     listEl.textContent = '⚠ ' + e.message;
     return;
@@ -65,6 +68,42 @@ function paint() {
   }
   if (!items.length) listEl.textContent = 'no playbooks';
   dirEl.textContent = dir;
+  paintRef();
+}
+
+// The reference: two blocks of `name — one line`, from the server's own text.
+// One loop, no markdown, nothing restated here — an added placeholder shows up
+// the moment playbooks.js names it.
+function paintRef() {
+  refEl.textContent = '';
+  if (!reference) return;
+  block('placeholders', '{{NAME}} in the playbook, filled at card start. A name that is not one of '
+    + 'these is left in the brief exactly as written.', reference.placeholders, 'name');
+  block('frontmatter', 'an optional --- block at the very top, read by the code that starts the '
+    + 'card. All keys optional.', reference.frontmatter, 'key');
+}
+
+function block(title, note, rows, field) {
+  if (!rows || !rows.length) return;
+  const h = document.createElement('div');
+  h.className = 'ss-title';
+  h.textContent = title;
+  const n = document.createElement('div');
+  n.className = 'ss-note pb-ref-note';
+  n.textContent = note;
+  refEl.append(h, n);
+  for (const r of rows) {
+    const row = document.createElement('div');
+    row.className = 'pb-ref-row';
+    const k = document.createElement('code');
+    k.className = 'pb-ref-k';
+    k.textContent = r[field];
+    const d = document.createElement('span');
+    d.className = 'pb-ref-d';
+    d.textContent = r.desc;
+    row.append(k, d);
+    refEl.appendChild(row);
+  }
 }
 
 async function open(p) {


### PR DESCRIPTION
# Description

Writing a playbook takes two vocabularies — the `{{PLACEHOLDERS}}` the brief renders and the five frontmatter keys — and neither was readable anywhere but the source. The playbooks tab now shows both under the list, one line each.

The text lives in `server/playbooks.js` beside the code that implements it, and a test pins it there: the documented placeholders must equal the keys `briefVars()` actually fills, and the documented keys must equal `FM_KEYS`. Adding either without a line of prose turns the suite red, so the panel cannot go stale.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` → **752 pass, 0 fail**, run by the lieutenant in the worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
