### PR TITLE
feat(ui): the workspace screen gets a projects tab

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -65,7 +65,7 @@ const { workerBrief, listPlaybooks, resolvePlaybook, playbooksDir, PACKAGED_PLAY
 const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
 const gitrev = require(path.join(__dirname, 'gitrev.js'));
-const { execFile } = require('child_process');
+const { execFile, execFileSync } = require('child_process');
 
 // ---------- args ----------
 function parseArgs(argv) {
@@ -1761,6 +1761,30 @@ async function addProject(body) {
   return { project };
 }
 
+// What a registered clone says about itself: where it pushes, and the branch a
+// fresh worktree starts detached from. Both are read from the checkout, never
+// from the registry — `source` records what the clone was made from once and
+// then goes stale, while these two follow the repo.
+//
+// A missing `.git` short-circuits: without it there is nothing to read, and
+// `git -C` would happily answer for whatever repo the path happens to sit
+// inside. Nothing here throws — a read that fails is a null field, so a row the
+// server cannot describe still renders with what it has.
+function projectGit(dir) {
+  const out = { remote: null, branch: null, missing: !dir || !fs.existsSync(dir) };
+  if (out.missing || !fs.existsSync(path.join(dir, '.git'))) return out;
+  const read = (args) => {
+    try {
+      return execFileSync('git', ['-C', dir].concat(args),
+        { encoding: 'utf8', timeout: 2000, stdio: ['ignore', 'pipe', 'ignore'] }).trim() || null;
+    } catch (e) { return null; }
+  };
+  out.remote = read(['remote', 'get-url', 'origin']);
+  const head = read(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD']);
+  out.branch = head ? head.replace(/^origin\//, '') : null;
+  return out;
+}
+
 // ---------- workers (F5: card.start, worker.signal, worker done) ----------
 // A worker lives as a tmux WINDOW inside its owning lieutenant's session
 // (papercut #8): ref = { session: <lieutenant session>, window: 'w-<card-id>' }.
@@ -3358,7 +3382,23 @@ const server = http.createServer(async (req, res) => {
     }
 
     // ----- projects (F6) -----
-    if (route === 'GET /api/projects') return sendJson(res, 200, { projects: board.projects });
+    // The registry as it is stored, plus what a reader needs to trust a row.
+    // `cards` is board data (the live cards whose `repo` names this project), so
+    // it is always there and costs nothing. `remote` and `branch` are two git
+    // reads off the clone — only ?git=1 pays for them, so the CLI and every
+    // other caller of this route are unchanged.
+    // Ordered by live-card count then name: the registry grows monotonically and
+    // most of it is idle, so the ones actually in use lead.
+    if (route === 'GET /api/projects') {
+      const git = /^(1|true)$/.test(url.searchParams.get('git') || '');
+      const projects = board.projects.map((p) => {
+        const out = Object.assign({}, p,
+          { cards: board.cards.filter((c) => c.attributes && c.attributes.repo === p.name).length });
+        return git ? Object.assign(out, projectGit(p.path)) : out;
+      });
+      projects.sort((a, b) => (b.cards - a.cards) || String(a.name).localeCompare(String(b.name)));
+      return sendJson(res, 200, { projects });
+    }
     if (route === 'POST /api/projects') {
       const r = await addProject(JSON.parse(await readBody(req) || '{}'));
       if (r.error) return sendJson(res, r.code || 400, { error: r.error });

--- a/test/projects.test.js
+++ b/test/projects.test.js
@@ -9,7 +9,7 @@ const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
 const { execFileSync } = require('node:child_process');
-const { startServerWithLieutenant, runCli } = require('./helper');
+const { startServerWithLieutenant, withOwner, runCli } = require('./helper');
 
 function makeRepo(root, name) {
   const repo = path.join(root, name);
@@ -89,6 +89,76 @@ test('project add via CLI clones and registers', async () => {
       '--name', 'stale', '--workspace', wsDir, '--port', String(s.port)]);
     assert.strictEqual(stale.code, 1);
     assert.match(stale.stderr, /unknown flag --mode/);
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// ---------- what the projects tab reads ----------
+// The registry alone does not say whether a project is worth looking at, nor
+// whether a start off it will work. `cards` is board data and always there;
+// remote and default branch are read off the clone and only for a caller that
+// asks, because every other caller of this route wants neither.
+test('GET /api/projects: live-card count always, git facts only with ?git=1, ordered by use', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-projects-'));
+  const repo = makeRepo(root, 'alpha');
+  const wsDir = path.join(root, 'ws');
+  fs.mkdirSync(wsDir);
+  const s = await startServerWithLieutenant({ dir: wsDir });
+  try {
+    for (const name of ['alpha', 'beta', 'gamma']) {
+      assert.strictEqual((await s.api('POST', '/api/projects', { source: repo, name })).status, 200);
+    }
+    // gamma: two live cards. alpha: one live and one archived — the archived one
+    // does not count. beta: none.
+    await s.api('POST', '/api/cards', withOwner({ title: 'g one', attributes: { repo: 'gamma' } }));
+    await s.api('POST', '/api/cards', withOwner({ title: 'g two', attributes: { repo: 'gamma' } }));
+    await s.api('POST', '/api/cards', withOwner({ title: 'a one', attributes: { repo: 'alpha' } }));
+    await s.api('POST', '/api/cards', withOwner({ title: 'a gone', attributes: { repo: 'alpha' } }));
+    assert.strictEqual((await s.api('POST', '/api/cards/a-gone/archive', { actor: 'agent' })).status, 200);
+
+    let list = (await s.api('GET', '/api/projects')).body.projects;
+    assert.deepStrictEqual(list.map((p) => [p.name, p.cards]),
+      [['gamma', 2], ['alpha', 1], ['beta', 0]], 'card count descending, then name');
+    assert.ok(list.every((p) => p.remote === undefined && p.branch === undefined),
+      'no git read for a caller that did not ask');
+
+    list = (await s.api('GET', '/api/projects?git=1')).body.projects;
+    const gamma = list.find((p) => p.name === 'gamma');
+    assert.strictEqual(gamma.remote, repo, 'a real checkout says where it pushes');
+    assert.strictEqual(gamma.branch, 'main', 'and the branch a worktree starts detached from');
+    assert.strictEqual(gamma.missing, false);
+    assert.strictEqual(gamma.cards, 2, 'the count is there either way');
+  } finally {
+    await s.stop();
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// A path that is gone, or is a directory that was never a checkout, is exactly
+// when the row matters — so it renders with what there is, and the request is
+// still a 200.
+test('GET /api/projects?git=1: an unreadable clone is null fields, never an error', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-projects-'));
+  const repo = makeRepo(root, 'app');
+  const wsDir = path.join(root, 'ws');
+  fs.mkdirSync(wsDir);
+  const s = await startServerWithLieutenant({ dir: wsDir });
+  try {
+    for (const name of ['ghost', 'bare']) {
+      assert.strictEqual((await s.api('POST', '/api/projects', { source: repo, name })).status, 200);
+    }
+    fs.rmSync(path.join(wsDir, 'projects', 'ghost'), { recursive: true, force: true });
+    fs.rmSync(path.join(wsDir, 'projects', 'bare', '.git'), { recursive: true, force: true });
+
+    const r = await s.api('GET', '/api/projects?git=1');
+    assert.strictEqual(r.status, 200);
+    const by = Object.fromEntries(r.body.projects.map((p) => [p.name, p]));
+    assert.deepStrictEqual([by.ghost.remote, by.ghost.branch], [null, null], 'nothing on disk to read');
+    assert.strictEqual(by.ghost.missing, true, 'and the row says the path is gone');
+    assert.deepStrictEqual([by.bare.remote, by.bare.branch], [null, null], 'a directory is not a checkout');
+    assert.strictEqual(by.bare.missing, false, 'the path is there — it is just not a repo');
   } finally {
     await s.stop();
     fs.rmSync(root, { recursive: true, force: true });

--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -75,13 +75,15 @@ test('the heading row carries a tab per section', () => {
   const screen = element('settings-screen');
   const tabs = element('ss-tabs');
   const tabNames = [...tabs.matchAll(/data-tab="([^"]+)"/g)].map((m) => m[1]);
-  assert.deepStrictEqual(tabNames, ['labels', 'playbooks'], 'a button per section');
+  assert.deepStrictEqual(tabNames, ['labels', 'playbooks', 'projects'], 'a button per section');
   const secNames = [...screen.matchAll(/data-sec="([^"]+)"/g)].map((m) => m[1]);
   assert.deepStrictEqual(secNames, tabNames, 'every tab names a section of the screen');
-  // both sections live inside the screen, and labels is the one that starts up
-  assert.ok(screen.includes('id="ss-labels"') && screen.includes('id="ss-playbooks"'));
+  // every section lives inside the screen, and labels is the one that starts up
+  assert.ok(screen.includes('id="ss-labels"') && screen.includes('id="ss-playbooks"')
+    && screen.includes('id="ss-projects"'));
   assert.match(element('ss-labels'), /class="ss-sec on"/, 'labels is the section shown at rest');
   assert.match(element('ss-playbooks'), /class="ss-sec"/);
+  assert.match(element('ss-projects'), /class="ss-sec"/);
   // the active tab is marked the way the ▦☰🧊 switcher marks its mode: .on
   const css = fs.readFileSync(ui('app.css'), 'utf8');
   assert.match(css, /#view-seg button\.on, #ss-tabs button\.on/, 'the tabs reuse the switcher rule');
@@ -104,9 +106,9 @@ function loadSetWsTab() {
   };
   const painted = [];
   const stub = (name) => (reload) => painted.push([name, reload]);
-  const make = new Function('document', 'renderLabelManager', 'renderPlaybooks',
+  const make = new Function('document', 'renderLabelManager', 'renderPlaybooks', 'renderProjects',
     mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
-  const api = make(document, stub('labels'), stub('playbooks'));
+  const api = make(document, stub('labels'), stub('playbooks'), stub('projects'));
   return { secs, tabs, painted, ...api };
 }
 
@@ -268,4 +270,21 @@ test('the playbooks section holds the reference panel, and does not restate its 
   const pb = fs.readFileSync(ui('js', 'pbmanager.js'), 'utf8');
   assert.match(pb, /r\.reference/, 'the section renders what /api/playbooks sent');
   assert.ok(!/CARD_ID|keep_worktree/.test(pb), 'and holds no second copy of the list');
+});
+
+// The third section, added the way the second one said a third would be: markup,
+// a tab, one WS_RENDER entry, and a module of its own. Showing only — the
+// registry is written from a terminal, never from here.
+test('projects are a section of the workspace screen, painted by their own module', () => {
+  const sec = element('ss-projects');
+  assert.match(sec, /class="ss-title">projects</);
+  assert.ok(sec.includes('id="pj-list"'), 'with the list the section renders into');
+  assert.match(mainSrc, /import \{ renderProjects \} from '\.\/projmanager\.js'/);
+  assert.match(mainSrc, /const WS_RENDER = \{[^}]*projects: renderProjects/, 'one WS_RENDER entry');
+
+  const pj = fs.readFileSync(ui('js', 'projmanager.js'), 'utf8');
+  assert.match(pj, /api\.projects\(true\)/, 'the tab is what asks for the git reads');
+  assert.ok(!/api\.addProject|POST|DELETE/.test(pj), 'and the section only ever shows');
+  const apiSrc = fs.readFileSync(ui('js', 'api.js'), 'utf8');
+  assert.match(apiSrc, /projects: \(git\) => j\('GET', '\/api\/projects' \+ \(git \? '\?git=1' : ''\)\)/);
 });

--- a/ui/app.css
+++ b/ui/app.css
@@ -637,6 +637,20 @@ body.resizing { user-select: none; cursor: col-resize; }
 .pb-ref-k { flex: none; font-family: var(--mono); color: var(--accent); }
 .pb-ref-d { color: var(--faint); min-width: 0; overflow-wrap: anywhere; }
 
+/* projects: one block per registered project — name and live-card count on the
+   head line, the path under it, then the git facts as key/value rows */
+#pj-list { display: flex; flex-direction: column; gap: 12px; }
+.pj-row { display: flex; flex-direction: column; gap: 2px; }
+.pj-head { display: flex; gap: 8px; align-items: baseline; }
+.pj-name { flex: 1; min-width: 0; color: var(--text); font-size: 13px; font-weight: 650;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pj-n { flex: none; color: var(--faint); font-size: 10.5px; font-family: var(--mono); }
+.pj-path { margin-bottom: 2px; }
+.pj-fact { display: flex; gap: 6px; align-items: baseline; font-size: 11px; line-height: 1.35; }
+.pj-k { flex: none; width: 46px; color: var(--faint); }
+.pj-v { min-width: 0; color: var(--text); font-family: var(--mono); overflow-wrap: anywhere; }
+.pj-warn .pj-v { color: var(--danger); }
+
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
 .lm-row input[type=color], #lm-color { width: 26px; height: 22px; padding: 0; border: 1px solid var(--line); border-radius: 5px; background: none; cursor: pointer; flex: none; }

--- a/ui/index.html
+++ b/ui/index.html
@@ -171,6 +171,7 @@
         <span id="ss-tabs" role="group" aria-label="workspace section">
           <button type="button" data-tab="labels" class="on">labels</button>
           <button type="button" data-tab="playbooks">playbooks</button>
+          <button type="button" data-tab="projects">projects</button>
         </span>
       </div>
       <section class="ss-sec on" id="ss-labels" data-sec="labels">
@@ -193,6 +194,13 @@
              Visible without a click, and scrolling on its own so it never
              pushes the list off a phone screen. -->
         <div id="pb-ref"></div>
+      </section>
+      <!-- projects: the registry a card's `repo` attribute has to name. Showing
+           only — registering one clones a repo and removing one deletes a
+           checkout that may hold uncommitted work, so both stay at a terminal. -->
+      <section class="ss-sec" id="ss-projects" data-sec="projects">
+        <div class="ss-title">projects</div>
+        <div id="pj-list"></div>
       </section>
     </div>
   </section>

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -89,6 +89,10 @@ export const api = {
   // the playbooks a card can point at — read off disk server-side, so a
   // playbook added a second ago is in the next answer. Never cached here.
   playbooks: () => j('GET', '/api/playbooks'),
+  // the registered projects, already ordered by live-card count. `git` asks the
+  // server for the two reads off each clone (remote, default branch) — the
+  // projects tab wants them, nothing else does, and nothing else pays for them.
+  projects: (git) => j('GET', '/api/projects' + (git ? '?git=1' : '')),
   // slash commands the current chat target's harness answers (composer autocomplete)
   commands: (target) => j('GET', '/api/commands?target=' + encodeURIComponent(target)),
 };

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -20,6 +20,7 @@ import { openMonitor, closeMonitor, monitorOpen } from './monitor.js';
 import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js';
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import { renderPlaybooks } from './pbmanager.js';
+import { renderProjects } from './projmanager.js';
 import './resize.js'; // draggable side-panel widths
 import './keepalivesettings.js'; // the pocket switch: hold the audio session open
 
@@ -106,7 +107,7 @@ document.getElementById('workspace-open').onclick = () => {
 // the source afresh on the way in), the render loop repaints it without. A new
 // section is a <section data-sec>, a <button data-tab> and one entry here; the
 // switching below never learns its name.
-const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks };
+const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks, projects: renderProjects };
 let wsTab = 'labels';
 function setWsTab(tab) {
   wsTab = tab;

--- a/ui/js/projmanager.js
+++ b/ui/js/projmanager.js
@@ -1,0 +1,77 @@
+// The workspace screen's projects section: the registry a card's `repo`
+// attribute has to name, and the facts that decide whether a start off one will
+// work — how many live cards point at it, where it pushes, and the branch a
+// fresh worktree starts detached from.
+//
+// Showing only. Registering a project clones a repo and removing one deletes a
+// checkout that may hold uncommitted work; neither belongs behind a click.
+import { api } from './api.js';
+
+const listEl = document.getElementById('pj-list');
+
+let items = null; // [{name, path, cards, remote, branch, missing}] — last answer
+let loading = false;
+
+// Same contract as the playbooks section: `reload` is what the tab passes on the
+// way in, so entering the tab reads disk afresh while the renders that follow —
+// one per board event — repaint what is already here. Nothing runs while another
+// tab is up, so opening the screen for labels shells out to git not at all.
+export async function renderProjects(reload) {
+  if (reload) items = null;
+  if (items) return paint();
+  if (loading) return;
+  loading = true;
+  try {
+    items = (await api.projects(true)).projects || [];
+  } catch (e) {
+    listEl.textContent = '⚠ ' + e.message;
+    return;
+  } finally { loading = false; }
+  paint();
+}
+
+function paint() {
+  listEl.textContent = '';
+  for (const p of items) {
+    const row = document.createElement('div');
+    row.className = 'pj-row';
+    const head = document.createElement('div');
+    head.className = 'pj-head';
+    // The name is the string a card's `repo` must match exactly, so it is the
+    // one thing here that reads as a value rather than a caption.
+    const name = document.createElement('span');
+    name.className = 'pj-name';
+    name.textContent = p.name;
+    const n = document.createElement('span');
+    n.className = 'pj-n';
+    n.textContent = p.cards === 1 ? '1 card' : p.cards + ' cards';
+    n.title = 'live cards with repo: ' + p.name;
+    head.append(name, n);
+    const where = document.createElement('div');
+    where.className = 'ss-note pj-path';
+    where.textContent = p.path;
+    row.append(head, where);
+    // A project whose clone is gone keeps its row and says so — that is exactly
+    // the moment you need to see it, and no git fact would be true anyway.
+    if (p.missing) row.append(fact('⚠', 'path not on disk', 'pj-warn'));
+    else {
+      row.append(fact('remote', p.remote || 'none'));
+      row.append(fact('branch', p.branch || 'unknown'));
+    }
+    listEl.appendChild(row);
+  }
+  if (!items.length) listEl.textContent = 'no projects';
+}
+
+function fact(key, value, cls) {
+  const row = document.createElement('div');
+  row.className = 'pj-fact' + (cls ? ' ' + cls : '');
+  const k = document.createElement('span');
+  k.className = 'pj-k';
+  k.textContent = key;
+  const v = document.createElement('span');
+  v.className = 'pj-v';
+  v.textContent = value;
+  row.append(k, v);
+  return row;
+}


### PR DESCRIPTION
# Description

The registered projects were only visible from the CLI. The workspace screen has a third tab showing each one with the facts that decide whether a card can name it and a start off it will work: live cards, remote, default branch, path — ordered by live-card count, because the registry only grows and most of it is idle.

`GET /api/projects` carries the live-card count always (board data, free) and reads the clone for remote and default branch only under `?git=1`, so the CLI and every other caller pay nothing. A registered path that is gone, or is not a checkout, returns null fields and a 200 rather than an error — the row that can't be described is the one worth seeing.

Nothing is stored differently: `board.projects` is unchanged, and the tab is show-only.

## How has this change been tested?

`node --test test/*.test.js harness/test/*.test.js` → **755 pass, 0 fail**, run by the lieutenant in the worktree. `test/projects.test.js` covers the count, the `?git=1` gate, the ordering, and an unreadable clone answering with nulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
