### PR TITLE
feat(ui): the card number goes back on the kanban tile

### DIFF
--- a/test/tile-card-number.test.js
+++ b/test/tile-card-number.test.js
@@ -1,0 +1,47 @@
+'use strict';
+// The card number is back on the kanban tile — the number ALONE, never the
+// prefix, because the owner's color already says whose card it is. util.js is
+// browser ES-module code that touches no DOM at import, so the renderer runs
+// directly; board.js and table.js bind DOM at import, so where the element goes
+// (tile yes, table no) is pinned at the source level, same as av-dispatch.test.js.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const ui = (...p) => path.join(__dirname, '..', 'ui', ...p);
+const utilMod = import(pathToFileURL(ui('js', 'util.js')).href);
+const boardSrc = fs.readFileSync(ui('js', 'board.js'), 'utf8');
+const tableSrc = fs.readFileSync(ui('js', 'table.js'), 'utf8');
+const css = fs.readFileSync(ui('app.css'), 'utf8');
+
+test('the tile carries the number and not the prefix', async () => {
+  const { cardNumHtml } = await utilMod;
+  const html = cardNumHtml('MNC-62');
+  assert.match(html, /62/, 'the number is on the tile');
+  assert.ok(!html.includes('MNC-'), 'the prefix is not');
+  assert.strictEqual(cardNumHtml('MNC-62'), '<span class="t-num">62</span>');
+});
+
+test('an id with no trailing number gets no element at all', async () => {
+  const { cardNumHtml } = await utilMod;
+  // archived cards really are shaped like this — a guess would be worse than nothing
+  for (const id of ['pipeline-test-b6', 'bc-unblock-server', 'MNC', '', undefined]) {
+    assert.strictEqual(cardNumHtml(id), '', String(id) + ': no number element, not an empty one');
+  }
+});
+
+test('the number is drawn on the tile and nowhere else', () => {
+  assert.match(boardSrc, /cardNumHtml\(c\.id\) \+ cornerInd/, 'tileHtml draws it beside the title');
+  assert.ok(!tableSrc.includes('cardNumHtml'), 'the table is untouched');
+  assert.match(tableSrc, /'<tr data-id="' \+ esc\(c\.id\)/, 'and its row still carries the full id, un-stripped');
+});
+
+test('the number is dim, monospace and never wraps', () => {
+  const rule = /\.tile \.t-num \{([^}]*)\}/.exec(css);
+  assert.ok(rule, '.t-num is styled');
+  assert.match(rule[1], /font-family: var\(--mono\)/);
+  assert.match(rule[1], /color: var\(--faint\)/);
+  assert.match(rule[1], /white-space: nowrap/);
+});

--- a/ui/app.css
+++ b/ui/app.css
@@ -432,6 +432,8 @@ body.resizing { user-select: none; cursor: col-resize; }
   flex: 1; font-size: 14.5px; font-weight: 570; line-height: 1.35;
   display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden;
 }
+/* the card number: dim, monospace, on the title's baseline, never wrapping */
+.tile .t-num { flex: none; align-self: baseline; font-family: var(--mono); font-size: 10.5px; color: var(--faint); white-space: nowrap; }
 /* label + PR chips share ONE wrapping row — keeps tiles vertically compact */
 .tile .t-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 5px; align-items: center; }
 .tile .t-foot { display: flex; align-items: center; gap: 7px; margin-top: 6px; font-size: 12px; color: var(--faint); }

--- a/ui/js/board.js
+++ b/ui/js/board.js
@@ -3,7 +3,7 @@
 // ltswitcher.js — not on the board.)
 import { S, columns, cards, lieutenants, lieutenant, lieutenantColor, cardVisible, cardStatus, cardRecency, targetOwedState, targetOwedStale, toggleFilter, filterSelected, workerFor, render } from './state.js';
 import { api } from './api.js';
-import { esc, agoSpanHtml, cardEmoji, cardPrs, prChipHtml, ctxBarHtml } from './util.js';
+import { esc, agoSpanHtml, cardEmoji, cardNumHtml, cardPrs, prChipHtml, ctxBarHtml } from './util.js';
 import { labelChipHtml } from './labels.js';
 import { openDetail } from './detail.js';
 import { openLieutenantChat } from './chat.js';
@@ -69,7 +69,7 @@ function tileHtml(c) {
     stripe +
     '<div class="t-row1">' + box + '<span class="t-emoji">' + esc(cardEmoji(c)) + '</span>' +
     '<span class="t-title">' + esc(c.title || c.id) + '</span>' +
-    cornerInd + '</div>' +
+    cardNumHtml(c.id) + cornerInd + '</div>' +
     (labels || prs || order ? '<div class="t-chips">' + order + labels + prs + '</div>' : '') +
     '<div class="t-foot">' +
     '<span class="t-owner' + (filterSelected('owner', c.owner) ? ' active' : '') + '" data-owner="' + esc(c.owner) +

--- a/ui/js/util.js
+++ b/ui/js/util.js
@@ -60,6 +60,16 @@ export function cardEmoji(card) {
   return '▫️';
 }
 
+// The kanban tile carries the card's NUMBER, never the prefix: the owner's
+// color already says whose card it is, so MNC- on forty tiles is noise. The
+// rule is the trailing -<digits> of the id — an explicit id like
+// pipeline-test-b6 has no number and gets no element at all, rather than a
+// guess. (The table and the detail panel keep the full id — you copy ids there.)
+export function cardNumHtml(id) {
+  const m = /-(\d+)$/.exec(String(id || ''));
+  return m ? '<span class="t-num">' + m[1] + '</span>' : '';
+}
+
 // attributes.prs — [{url, state: open|merged|closed}] — the only PR source on a card
 const PR_STATES = new Set(['open', 'merged', 'closed']);
 export function cardPrs(card) {


### PR DESCRIPTION
A kanban tile showed a title and nothing else — you could not tell which card you were looking at without opening it. Now it carries the number, and only the number: the owner's colour already says whose card it is, so `MNC-` repeated on forty tiles of that colour is noise. Dim, monospace, on the title's baseline, never wrapping. Kanban tiles only — the table and the detail panel keep the full id, because that is where you scan and copy ids from. An id with no trailing `-<digits>` (`pipeline-test-b6`, `bc-unblock-server` — archived cards are shaped like that) gets no element at all rather than a guess.

One helper in `util.js`, one span in `tileHtml`, one CSS rule. `node --test test/*.test.js harness/test/*.test.js` → 769 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)