### PR TITLE
feat(ui): the config screen gets a lieutenants tab, and the button its real name

### DIFF
--- a/server/playbooks.js
+++ b/server/playbooks.js
@@ -220,7 +220,7 @@ function briefVars(b) {
   return vars;
 }
 
-// ---------- the reference the workspace screen shows ----------
+// ---------- the reference the config screen shows ----------
 //
 // Editing a playbook takes two vocabularies — the placeholders briefVars()
 // fills and the keys FM_KEYS accepts — and neither is readable from the UI.

--- a/server/server.js
+++ b/server/server.js
@@ -461,6 +461,18 @@ function registerCardLabels() {
 const LT_PALETTE = ['#58b6ff', '#3ecf8e', '#e6c04a', '#c678dd', '#e2795b', '#56b6c2', '#98c379', '#e06c75'];
 function findLieutenant(id) { return board.lieutenants.find((l) => l.id === id); }
 
+// Is this lieutenant's session actually up? Three answers, and the difference
+// between the last two is why the config screen shows it at all — a dead
+// lieutenant is indistinguishable from a live one on the board:
+//   none — never spawned, so there is no session to be up (no ref)
+//   live — the harness says its session is there
+//   dead — it had one and it is gone (superviseTick is what brings it back)
+async function sessionState(lt) {
+  if (!isHarnessRef(lt.ref)) return 'none';
+  try { return (await harnessFor(lt.ref).alive(lt.ref)) ? 'live' : 'dead'; }
+  catch (e) { return 'dead'; } // an unknown harness cannot answer for it either
+}
+
 // ---------- card-id minting (prefix + counter, both the LIEUTENANT's) ----------
 // A card id is <PREFIX>-<n>: the prefix names the lieutenant that created it,
 // the number is that lieutenant's own counter — incremented at creation, never
@@ -2909,7 +2921,7 @@ function serveStatic(res, rel) {
 }
 
 // The one uri the artifact routes accept that is not listed on a card: a
-// playbook. The workspace screen edits them in the same editor a card artifact
+// playbook. The config screen edits them in the same editor a card artifact
 // opens in, which means the same GET, the same version check and the same 409 —
 // a second file API would be a second place to get all of that wrong. So the
 // widening is exactly one shape and nothing else: `<playbooks dir>/<name>.md`,
@@ -2937,6 +2949,31 @@ function playbookSource(uri) {
   try { if (fs.lstatSync(file).isSymbolicLink()) return ''; }
   catch (e) { if (e.code !== 'ENOENT') return ''; }
   return source;
+}
+
+// The second — and last — uri the artifact routes accept that is no card's:
+// a lieutenant's charter, `<workspace>/lieutenants/<id>/README.md`. The config
+// screen edits it in the same editor a playbook opens in, so it rides the same
+// GET, the same version check and the same 409.
+//
+// The widening is exactly one shape. charterPath() BUILDS the only acceptable
+// path from the workspace root and a REGISTERED id, and the uri has to equal
+// it — which is what refuses an unregistered id, another file in that folder, a
+// subdirectory of it, and a directory prefix from the client all at once.
+// Returns the path when it is one, '' otherwise.
+function charterFile(uri) {
+  if (typeof uri !== 'string' || !uri.startsWith('file://')) return '';
+  const file = uri.slice('file://'.length);
+  // path.resolve is idempotent on a clean absolute path — a `..` segment or a
+  // relative path changes it, so `<dir>/../../board.json` never gets this far.
+  if (path.resolve(file) !== file) return '';
+  if (!board.lieutenants.some((l) => charterPath(WORKSPACE, l.id) === file)) return '';
+  // A symlink named README.md is not the charter: what it points at is what
+  // would be read or written. Refused here rather than followed. (ENOENT is
+  // fine — a lieutenant that has never written its memory file still opens it.)
+  try { if (fs.lstatSync(file).isSymbolicLink()) return ''; }
+  catch (e) { if (e.code !== 'ENOENT') return ''; }
+  return file;
 }
 
 // ---------- server ----------
@@ -3022,8 +3059,9 @@ const server = http.createServer(async (req, res) => {
     if (route === 'GET /api/artifact') {
       const uri = url.searchParams.get('uri') || '';
       const raw = url.searchParams.get('raw') === '1' || url.searchParams.get('raw') === 'true';
+      const charter = charterFile(uri);
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
-        c.attributes.artifacts.some((a) => a && a.uri === uri)) || !!playbookSource(uri);
+        c.attributes.artifacts.some((a) => a && a.uri === uri)) || !!playbookSource(uri) || !!charter;
       if (!listed) return sendJson(res, 404, { error: 'unknown artifact' });
       // A promoted chat attachment (attachment://id) resolves to its stored file
       // via the sidecar; file:// / bare paths read directly.
@@ -3080,7 +3118,14 @@ const server = http.createServer(async (req, res) => {
       }
       let data;
       try { data = fs.readFileSync(file); }
-      catch (e) { return sendJson(res, 404, { error: 'unreadable: ' + e.message }); }
+      catch (e) {
+        // A lieutenant that has never written its memory file still has one to
+        // open: the board owns the path, so "not written yet" answers as the
+        // empty document at version '' — which is exactly what the PUT below
+        // reads as "I expect no file", so the first 💾 creates it.
+        if (charter && e.code === 'ENOENT') return sendJson(res, 200, { name, content: '', version: '' });
+        return sendJson(res, 404, { error: 'unreadable: ' + e.message });
+      }
       if (data.length > 2e6) return sendJson(res, 413, { error: 'file too large to preview' });
       if (data.includes(0)) return sendJson(res, 415, { error: 'binary file' });
       // The version travels with the content so an editor can hand it back on
@@ -3094,9 +3139,10 @@ const server = http.createServer(async (req, res) => {
     // this machine. The board has no auth of its own (the network boundary is
     // the auth boundary), so every guard below is load-bearing:
     //   - the uri must ALREADY be listed on a live card, or be a WORKSPACE
-    //     playbook (playbookSource) — the GET's allowlist minus the packaged
-    //     playbooks, which are read-only. Anything else is 403, and there is no
-    //     flag to turn it off;
+    //     playbook (playbookSource), or a registered lieutenant's charter
+    //     (charterFile) — the GET's allowlist minus the packaged playbooks,
+    //     which are read-only. Anything else is 403, and there is no flag to
+    //     turn it off;
     //   - file:// only, absolute, no `..` (path.resolve is idempotent on a
     //     clean absolute path), and no symlink anywhere along it (realpath must
     //     come back unchanged), so a listed artifact can never be a door to
@@ -3120,8 +3166,9 @@ const server = http.createServer(async (req, res) => {
       const uri = String(body.uri || '');
       if (typeof body.content !== 'string') return sendJson(res, 400, { error: 'content required' });
       const pbSource = playbookSource(uri);
+      const charter = charterFile(uri);
       const listed = board.cards.some((c) => Array.isArray(c.attributes && c.attributes.artifacts) &&
-        c.attributes.artifacts.some((a) => a && a.uri === uri)) || pbSource === 'workspace';
+        c.attributes.artifacts.some((a) => a && a.uri === uri)) || pbSource === 'workspace' || !!charter;
       if (!listed) {
         // A packaged playbook is readable and never writable: it is a git
         // checkout of this repo, so the edit is a copy into the workspace.
@@ -3146,6 +3193,11 @@ const server = http.createServer(async (req, res) => {
           return sendJson(res, 404, { error: 'unreadable: ' + e.message });
         }
         const dir = path.dirname(file);
+        // A charter's folder is the board's to make: a lieutenant registered
+        // without one has no other way to get `lieutenants/<id>/`. mkdir is a
+        // no-op when it is already there — including when it is a symlink,
+        // which the check right below still refuses.
+        if (charter) { try { fs.mkdirSync(dir, { recursive: true }); } catch (e2) { /* the check below answers */ } }
         try { if (fs.realpathSync(dir) !== dir) throw new Error('symlink'); }
         catch (e2) { return sendJson(res, 403, { error: 'artifact path resolves elsewhere (symlink) — refusing to write' }); }
       }
@@ -3227,7 +3279,24 @@ const server = http.createServer(async (req, res) => {
     }
 
     // ----- lieutenants -----
-    if (route === 'GET /api/lieutenants') return sendJson(res, 200, { lieutenants: board.lieutenants });
+    // `live=1` adds what the config screen's lieutenants tab shows and the board
+    // payload cannot: the next card id this lieutenant would mint, how many live
+    // cards it owns, where its charter file is, and — the one fact a board tile
+    // never tells you — whether its session is actually up. The probe shells out
+    // to the harness once per lieutenant, so it is gated the way /api/projects
+    // gates its git reads: the tab asks, nobody else pays.
+    if (route === 'GET /api/lieutenants') {
+      if (!/^(1|true)$/.test(url.searchParams.get('live') || '')) {
+        return sendJson(res, 200, { lieutenants: board.lieutenants });
+      }
+      const lieutenants = await Promise.all(board.lieutenants.map(async (l) => Object.assign({}, l, {
+        cards: board.cards.filter((c) => c.owner === l.id).length,
+        next: l.prefix + '-' + ((l.cardSeq || 0) + 1),
+        memory: charterPath(WORKSPACE, l.id),
+        session: await sessionState(l),
+      })));
+      return sendJson(res, 200, { lieutenants });
+    }
     if (route === 'POST /api/lieutenants') {
       const body = JSON.parse(await readBody(req) || '{}');
       if (body.ref !== undefined && body.ref !== null && !isHarnessRef(body.ref)) {
@@ -3559,7 +3628,7 @@ const server = http.createServer(async (req, res) => {
       // `playbooks` stays the plain id list the picker and the CLI read.
       // `items` says WHERE each one comes from — resolvePlaybook already decides
       // which file wins, so where it landed is the answer, not a second guess at
-      // the same rule. That is what lets the workspace screen open a workspace
+      // the same rule. That is what lets the config screen open a workspace
       // playbook for editing and offer to copy a packaged one first.
       const items = ids.map((id) => {
         const file = resolvePlaybook(STATE_DIR, id);

--- a/test/charter-edit.test.js
+++ b/test/charter-edit.test.js
@@ -1,0 +1,188 @@
+'use strict';
+// Editing a lieutenant's charter through the artifact routes — what the config
+// screen's lieutenants section rides on.
+//
+// The charter is a file (server/charter.js: <workspace>/lieutenants/<id>/README.md),
+// so editing one is the file screen and the same PUT /api/artifact a card
+// artifact is saved with: one editor, one version check, one 409. That means
+// exactly one more widening of the gate, and this file is where its edges live.
+// The accepted shape is the path charterPath() BUILDS from the workspace root
+// and a REGISTERED id — nothing else. Not an unregistered id, not another file
+// in that folder, not a subdirectory of it, not a symlink, and no directory
+// prefix from the client. The playbook and card-artifact paths are untouched.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+const { startServerWithLieutenant, withOwner } = require('./helper');
+const { charterPath } = require('../server/charter.js');
+
+const sha256 = (s) => crypto.createHash('sha256').update(s).digest('hex');
+const uriOf = (f) => 'file://' + f;
+const get = (s, uri) => s.api('GET', '/api/artifact?uri=' + encodeURIComponent(uri));
+
+// startServerWithLieutenant registers "ada"; her memory folder is not written
+// until something writes a charter, which is the interesting starting state.
+async function boot(text) {
+  const s = await startServerWithLieutenant();
+  const file = charterPath(s.dir, 'ada');
+  if (text != null) {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, text);
+  }
+  return { s, file };
+}
+
+test('a registered lieutenant’s charter reads and writes through the artifact routes, version check and all', async () => {
+  const { s, file } = await boot('# Ada\n\nowns the compiler.\n');
+  try {
+    const uri = uriOf(file);
+    const got = await get(s, uri);
+    assert.strictEqual(got.status, 200, JSON.stringify(got.body));
+    assert.strictEqual(got.body.name, 'README.md');
+    assert.strictEqual(got.body.content, '# Ada\n\nowns the compiler.\n');
+    assert.strictEqual(got.body.version, sha256('# Ada\n\nowns the compiler.\n'));
+
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'rewritten\n', version: got.body.version });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'rewritten\n');
+
+    // …and a stale version is still refused, carrying what is on disk now
+    const stale = await s.api('PUT', '/api/artifact', { uri, content: 'mine\n', version: got.body.version });
+    assert.strictEqual(stale.status, 409);
+    assert.match(stale.body.error, /changed on disk/);
+    assert.strictEqual(stale.body.content, 'rewritten\n');
+    assert.strictEqual(stale.body.version, sha256('rewritten\n'));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'rewritten\n', 'nothing was written');
+  } finally { await s.stop(); }
+});
+
+// A lieutenant registered without --charter-file has no memory file and no
+// folder to put one in. The row still offers ✎, so the GET has to answer — with
+// the empty document at version '', which is what the PUT reads as "I expect no
+// file" (the same create a derived card artifact is written with).
+test('a lieutenant with no charter yet opens on the empty document, and the first save creates it', async () => {
+  const { s, file } = await boot();
+  try {
+    assert.ok(!fs.existsSync(path.dirname(file)), 'no memory folder to start with');
+    const uri = uriOf(file);
+    const got = await get(s, uri);
+    assert.strictEqual(got.status, 200, JSON.stringify(got.body));
+    assert.deepStrictEqual({ name: got.body.name, content: got.body.content, version: got.body.version },
+      { name: 'README.md', content: '', version: '' });
+
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'first words\n', version: '' });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'first words\n');
+    assert.strictEqual(put.body.version, sha256('first words\n'));
+
+    // and now it is an ordinary file: the create version no longer applies
+    const again = await s.api('PUT', '/api/artifact', { uri, content: 'clobber\n', version: '' });
+    assert.strictEqual(again.status, 409);
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'first words\n');
+  } finally { await s.stop(); }
+});
+
+// ---------- what the gate refuses ----------
+// Each of these is its own test on purpose: they are the reasons this is a
+// charter route and not a workspace file API, and a single collapsed test would
+// let one of them rot green.
+
+async function refused(s, uri, content) {
+  const g = await get(s, uri);
+  assert.strictEqual(g.status, 404, 'GET ' + uri + ' → ' + JSON.stringify(g.body));
+  const p = await s.api('PUT', '/api/artifact', { uri, content: content || 'pwned\n', version: '' });
+  assert.strictEqual(p.status, 403, 'PUT ' + uri + ' → ' + JSON.stringify(p.body));
+}
+
+test('the README of an id no lieutenant holds is refused', async () => {
+  const { s } = await boot('mine\n');
+  try {
+    const ghost = charterPath(s.dir, 'mallory');
+    fs.mkdirSync(path.dirname(ghost), { recursive: true });
+    fs.writeFileSync(ghost, 'not a lieutenant\n');
+    await refused(s, uriOf(ghost));
+    assert.strictEqual(fs.readFileSync(ghost, 'utf8'), 'not a lieutenant\n');
+  } finally { await s.stop(); }
+});
+
+test('another file in the lieutenant’s own folder is refused — the charter is README.md and only that', async () => {
+  const { s, file } = await boot('mine\n');
+  try {
+    const other = path.join(path.dirname(file), 'notes.md');
+    fs.writeFileSync(other, 'private\n');
+    await refused(s, uriOf(other));
+    assert.strictEqual(fs.readFileSync(other, 'utf8'), 'private\n');
+  } finally { await s.stop(); }
+});
+
+test('a README in a SUBDIRECTORY of the lieutenant’s folder is refused — the folder is not a tree to edit', async () => {
+  const { s, file } = await boot('mine\n');
+  try {
+    const sub = path.join(path.dirname(file), 'examples');
+    fs.mkdirSync(sub, { recursive: true });
+    const nested = path.join(sub, 'README.md');
+    fs.writeFileSync(nested, 'nested\n');
+    await refused(s, uriOf(nested));
+    assert.strictEqual(fs.readFileSync(nested, 'utf8'), 'nested\n');
+  } finally { await s.stop(); }
+});
+
+test('a charter that is a symlink is refused, not followed', async () => {
+  const { s, file } = await boot();
+  try {
+    const secret = path.join(s.dir, 'secret.md');
+    fs.writeFileSync(secret, 'the good stuff\n');
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.symlinkSync(secret, file);
+    await refused(s, uriOf(file));
+    assert.strictEqual(fs.readFileSync(secret, 'utf8'), 'the good stuff\n');
+  } finally { await s.stop(); }
+});
+
+test('a traversal out of the lieutenants folder is refused — the client never supplies a prefix', async () => {
+  const { s, file } = await boot('mine\n');
+  try {
+    const brd = path.join(s.dir, '.bridge-commander', 'board.json');
+    const before = fs.readFileSync(brd, 'utf8');
+    const dir = path.dirname(file);
+    await refused(s, uriOf(path.join(dir, '..', '..', '.bridge-commander', 'board.json')));
+    // the un-normalized spelling too — the string is what arrives, not a path object
+    await refused(s, 'file://' + dir + '/../../.bridge-commander/board.json');
+    // …and one that spells its way BACK to a real charter is still not one
+    await refused(s, 'file://' + dir + '/../ada/README.md');
+    assert.strictEqual(fs.readFileSync(brd, 'utf8'), before, 'the board is untouched');
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'mine\n', 'and so is the charter');
+  } finally { await s.stop(); }
+});
+
+test('a retired lieutenant’s charter stops being editable — the id is what the gate matches', async () => {
+  const { s, file } = await boot('mine\n');
+  try {
+    assert.strictEqual((await get(s, uriOf(file))).status, 200);
+    const r = await s.api('DELETE', '/api/lieutenants/ada', { actor: 'user' });
+    assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+    await refused(s, uriOf(file));
+    assert.strictEqual(fs.readFileSync(file, 'utf8'), 'mine\n', 'the file is kept, just not writable from here');
+  } finally { await s.stop(); }
+});
+
+test('a card artifact and a playbook still read and write exactly as they did', async () => {
+  const { s } = await boot('mine\n');
+  try {
+    const f = path.join(s.dir, 'report.md');
+    fs.writeFileSync(f, 'v1\n');
+    const cr = await s.api('POST', '/api/cards', withOwner({ title: 'Deliverable' }));
+    const add = await s.api('POST', '/api/cards/' + cr.body.card.id + '/artifacts', { uri: f, label: 'report' });
+    const uri = add.body.artifact.uri;
+    const got = await get(s, uri);
+    assert.strictEqual(got.status, 200);
+    const put = await s.api('PUT', '/api/artifact', { uri, content: 'v2\n', version: got.body.version });
+    assert.strictEqual(put.status, 200, JSON.stringify(put.body));
+    assert.strictEqual(fs.readFileSync(f, 'utf8'), 'v2\n');
+
+    const packaged = (await s.api('GET', '/api/playbooks')).body.items.find((p) => p.source === 'packaged');
+    assert.strictEqual((await get(s, uriOf(packaged.file))).status, 200, 'a packaged playbook still opens');
+  } finally { await s.stop(); }
+});

--- a/test/lieutenants.test.js
+++ b/test/lieutenants.test.js
@@ -506,3 +506,81 @@ test('prefix + counter are backfilled for lieutenants that predate them, without
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ---------- GET /api/lieutenants?live=1 ----------
+// What the config screen's lieutenants tab reads, and only it: the probe shells
+// out to the harness once per lieutenant, so the plain list stays the cheap read
+// the CLI and everything else use. Four facts the board payload cannot give —
+// the id the next card would carry, how many live cards are owned, where the
+// charter file is, and whether the session is actually up.
+test('live=1 adds the next card id, the live-card count, the charter path and the session state', async () => {
+  const fdir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-fake-'));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-test-'));
+  const s = await startServer({
+    dir,
+    // the supervision loop is off: a dead lieutenant must stay dead long enough
+    // to be reported as dead, which is the whole point of the column
+    env: { BC_FAKE_STATE: fdir, BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0' },
+    seed(d) {
+      fs.mkdirSync(path.join(d, '.bridge-commander'), { recursive: true });
+      fs.writeFileSync(path.join(d, '.bridge-commander', 'board.json'), JSON.stringify({
+        lieutenants: [
+          // up: the fake harness reads a session marker file as alive
+          { id: 'ada', name: 'Ada', color: '#58b6ff', prefix: 'ADA', cardSeq: 6, chat: [],
+            ref: { harness: 'fake', session: 'bc-lt-ada', cwd: '/tmp' } },
+          // had a session, marker gone
+          { id: 'grace', name: 'Grace', color: '#3ecf8e', prefix: 'GRC', cardSeq: 0, chat: [],
+            ref: { harness: 'fake', session: 'bc-lt-grace', cwd: '/tmp' } },
+          // registered, never spawned
+          { id: 'hedy', name: 'Hedy', color: '#e6c04a', prefix: 'HED', cardSeq: 41, chat: [] },
+        ],
+        cards: [
+          { id: 'ADA-5', title: 'one', type: 'implementation', owner: 'ada', column: 'backlog',
+            labels: [], attributes: {}, body: '', events: [], thread: [] },
+          { id: 'ADA-6', title: 'two', type: 'implementation', owner: 'ada', column: 'working',
+            labels: [], attributes: {}, body: '', events: [], thread: [] },
+        ],
+      }));
+      fs.mkdirSync(fdir, { recursive: true });
+      fs.writeFileSync(path.join(fdir, 'bc-lt-ada.json'), JSON.stringify({ cwd: '/tmp', resumeId: null }) + '\n');
+    },
+  });
+  try {
+    // the plain read is untouched — no probe, no extra fields
+    const plain = (await s.api('GET', '/api/lieutenants')).body.lieutenants;
+    assert.deepStrictEqual(plain.map((l) => l.id), ['ada', 'grace', 'hedy']);
+    for (const l of plain) assert.ok(!('session' in l) && !('next' in l), l.id + ' carries no probe');
+
+    const r = await s.api('GET', '/api/lieutenants?live=1');
+    assert.strictEqual(r.status, 200);
+    const lts = r.body.lieutenants;
+    assert.deepStrictEqual(lts.map((l) => l.id), ['ada', 'grace', 'hedy'], 'ordered as the board orders them');
+    const by = Object.fromEntries(lts.map((l) => [l.id, l]));
+
+    // the number it would mint next — the id of the card he has not created yet
+    assert.strictEqual(by.ada.next, 'ADA-7');
+    assert.strictEqual(by.hedy.next, 'HED-42');
+    assert.strictEqual(by.grace.next, 'GRC-1');
+    for (const l of lts) assert.strictEqual(l.prefix, l.next.split('-')[0], l.id + ' mints under its own prefix');
+
+    // live cards owned — the count matches the board
+    const board = (await s.api('GET', '/api/board')).body;
+    for (const l of lts) {
+      assert.strictEqual(l.cards, board.cards.filter((c) => c.owner === l.id).length, l.id + ' card count');
+    }
+    assert.strictEqual(by.ada.cards, 2);
+    assert.strictEqual(by.hedy.cards, 0);
+
+    // …and the fact the board never shows
+    assert.strictEqual(by.ada.session, 'live');
+    assert.strictEqual(by.grace.session, 'dead');
+    assert.strictEqual(by.hedy.session, 'none');
+
+    // the charter path is the server's to derive — the client never spells it
+    for (const l of lts) assert.strictEqual(l.memory, charterPath(dir, l.id));
+  } finally {
+    await s.stop();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(fdir, { recursive: true, force: true });
+  }
+});

--- a/test/playbook-edit.test.js
+++ b/test/playbook-edit.test.js
@@ -1,5 +1,5 @@
 'use strict';
-// Editing a playbook through the artifact routes — what the workspace screen's
+// Editing a playbook through the artifact routes — what the config screen's
 // playbooks section rides on.
 //
 // A playbook is a file the captain owns, so editing one is the file screen and

--- a/test/playbooks.test.js
+++ b/test/playbooks.test.js
@@ -301,7 +301,7 @@ test('init SYMLINKS the worker-duties skill, repoints a stale link, and leaves a
   fs.rmSync(home, { recursive: true, force: true });
 });
 
-// ---------- the reference the workspace screen shows ----------
+// ---------- the reference the config screen shows ----------
 //
 // Two lists documenting the two vocabularies, and the whole point of them is
 // that they cannot drift: they are checked against the code that implements

--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -1,6 +1,7 @@
 'use strict';
-// The settings screen: labels left the gear dropdown for a board-region mode of
-// their own, beside the chat. Two things are pinned here — where the markup
+// The config screen (#settings-screen): labels left the gear dropdown for a
+// board-region mode of their own, beside the chat — the gear is this browser's
+// settings, that screen is the board's. Two things are pinned here — the markup
 // lives (ui/index.html), and the rule that decides which modes are remembered
 // (setBoardMode in ui/js/main.js). main.js binds DOM at import, so the function
 // is lifted out of the source and run against stubs, same spirit as
@@ -30,11 +31,11 @@ function element(id) {
   assert.fail('#' + id + ' is never closed');
 }
 
-test('the label manager markup lives in the workspace screen, not the gear panel', () => {
+test('the label manager markup lives in the config screen, not the gear panel', () => {
   const panel = element('settings-panel');
   assert.ok(!panel.includes('id="lm-list"'), 'the gear dropdown no longer holds the label list');
   assert.ok(!panel.includes('id="lm-new"'), 'nor the new-label form');
-  assert.ok(panel.includes('id="workspace-open"'), 'it holds the row that opens the screen instead');
+  assert.ok(panel.includes('id="config-open"'), 'it holds the row that opens the screen instead');
   assert.ok(!panel.includes('id="labels-open"'), 'and the row is no longer called labels');
 
   const screen = element('settings-screen');
@@ -44,15 +45,22 @@ test('the label manager markup lives in the workspace screen, not the gear panel
   assert.ok(element('board-wrap').includes('id="settings-screen"'));
 });
 
-// The gear row is THIS BROWSER's list; the screen it opens is the WORKSPACE —
-// the board everyone shares. The row said "labels" while the screen held one
-// section; it holds two now, so the row names the screen instead of its first
-// section, and the screen says what it is.
-test('the workspace row and heading name the workspace, and playbooks are a section of it', () => {
+// The gear row is THIS BROWSER's list; the screen it opens is the BOARD's own
+// settings — what everyone on it shares. It is what the captain calls it, which
+// is config: the same word on the row and on the heading, and the old
+// "workspace" spelling survives nowhere, id included.
+test('the gear row and the heading say config, and nothing still says workspace-open', () => {
   const panel = element('settings-panel');
-  assert.match(panel, /<button id="workspace-open"[^>]*>🗂 workspace<\/button>/);
+  assert.match(panel, /<button id="config-open"[^>]*>🗂 config<\/button>/);
   const screen = element('settings-screen');
-  assert.match(screen, /class="ss-head">workspace</, 'the screen is headed workspace');
+  assert.match(screen, /class="ss-head">config</, 'the screen is headed config');
+  for (const [where, src] of [['index.html', html], ['main.js', mainSrc], ['app.css', fs.readFileSync(ui('app.css'), 'utf8')]]) {
+    assert.ok(!src.includes('workspace-open'), where + ' carries no workspace-open');
+  }
+});
+
+test('the playbooks section is a section of that screen', () => {
+  const screen = element('settings-screen');
   assert.ok(screen.includes('id="ss-playbooks"'), 'the screen has a playbooks section');
   assert.ok(screen.includes('id="pb-list"'), 'with the list the section renders into');
   assert.ok(screen.includes('id="ss-labels"'), 'and the labels section is still there');
@@ -60,30 +68,30 @@ test('the workspace row and heading name the workspace, and playbooks are a sect
   assert.match(element('ss-playbooks'), /class="ss-title">playbooks</);
 });
 
-test('the workspace row hands off to the screen the way monitoring hands off to the monitor', () => {
-  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
-  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
+test('the config row hands off to the screen the way monitoring hands off to the monitor', () => {
+  assert.match(mainSrc, /getElementById\('config-open'\)\.onclick[\s\S]*?setBoardMode\('settings'\)/);
+  assert.match(mainSrc, /getElementById\('config-open'\)\.onclick[\s\S]*?spEl\.hidden = true/);
   // …landing on labels, every time: the tab is not remembered either
-  assert.match(mainSrc, /getElementById\('workspace-open'\)\.onclick[\s\S]*?setWsTab\('labels'\)/);
+  assert.match(mainSrc, /getElementById\('config-open'\)\.onclick[\s\S]*?setWsTab\('labels'\)/);
 });
 
 // ---------- the tab strip ----------
 // The sections stack no longer: one tab per section in the heading row, one
-// section visible. The pairing is data-tab ⇄ data-sec, so the third and fourth
-// section (projects, lieutenants) are markup plus one WS_RENDER entry.
+// section visible. The pairing is data-tab ⇄ data-sec, so a fourth section
+// (lieutenants) is markup plus one WS_RENDER entry — the switching below never
+// learns its name.
+const SECTIONS = ['labels', 'playbooks', 'projects', 'lieutenants'];
 test('the heading row carries a tab per section', () => {
   const screen = element('settings-screen');
   const tabs = element('ss-tabs');
   const tabNames = [...tabs.matchAll(/data-tab="([^"]+)"/g)].map((m) => m[1]);
-  assert.deepStrictEqual(tabNames, ['labels', 'playbooks', 'projects'], 'a button per section');
+  assert.deepStrictEqual(tabNames, SECTIONS, 'a button per section');
   const secNames = [...screen.matchAll(/data-sec="([^"]+)"/g)].map((m) => m[1]);
   assert.deepStrictEqual(secNames, tabNames, 'every tab names a section of the screen');
   // every section lives inside the screen, and labels is the one that starts up
-  assert.ok(screen.includes('id="ss-labels"') && screen.includes('id="ss-playbooks"')
-    && screen.includes('id="ss-projects"'));
+  for (const s of SECTIONS) assert.ok(screen.includes('id="ss-' + s + '"'), s + ' is in the screen');
   assert.match(element('ss-labels'), /class="ss-sec on"/, 'labels is the section shown at rest');
-  assert.match(element('ss-playbooks'), /class="ss-sec"/);
-  assert.match(element('ss-projects'), /class="ss-sec"/);
+  for (const s of SECTIONS.slice(1)) assert.match(element('ss-' + s), /class="ss-sec"/);
   // the active tab is marked the way the ▦☰🧊 switcher marks its mode: .on
   const css = fs.readFileSync(ui('app.css'), 'utf8');
   assert.match(css, /#view-seg button\.on, #ss-tabs button\.on/, 'the tabs reuse the switcher rule');
@@ -98,8 +106,8 @@ function loadSetWsTab() {
   const fnAt = mainSrc.indexOf('function setWsTab', start);
   const end = mainSrc.indexOf('\n}\n', fnAt) + 3;
   assert.ok(start > -1 && fnAt > start && end > fnAt, 'setWsTab found in main.js');
-  const secs = ['labels', 'playbooks', 'projects'].map((sec) => ({ dataset: { sec }, on: false }));
-  const tabs = ['labels', 'playbooks', 'projects'].map((tab) => ({ dataset: { tab }, on: false }));
+  const secs = SECTIONS.map((sec) => ({ dataset: { sec }, on: false }));
+  const tabs = SECTIONS.map((tab) => ({ dataset: { tab }, on: false }));
   for (const el of [...secs, ...tabs]) el.classList = { toggle: (c, v) => { el.on = v; } };
   const document = {
     querySelectorAll: (q) => (q.includes('data-sec') ? secs : tabs),
@@ -107,20 +115,20 @@ function loadSetWsTab() {
   const painted = [];
   const stub = (name) => (reload) => painted.push([name, reload]);
   const make = new Function('document', 'renderLabelManager', 'renderPlaybooks', 'renderProjects',
-    mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
-  const api = make(document, stub('labels'), stub('playbooks'), stub('projects'));
+    'renderLieutenants', mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
+  const api = make(document, stub('labels'), stub('playbooks'), stub('projects'), stub('lieutenants'));
   return { secs, tabs, painted, ...api };
 }
 
 test('switching to a tab shows that section and hides every other one', () => {
-  const { setWsTab, secs, tabs, wsTab } = loadSetWsTab();
-  setWsTab('playbooks');
-  assert.strictEqual(wsTab(), 'playbooks');
-  assert.deepStrictEqual(secs.map((s) => s.on), [false, true, false]);
-  assert.deepStrictEqual(tabs.map((t) => t.on), [false, true, false]);
-  setWsTab('labels');
-  assert.deepStrictEqual(secs.map((s) => s.on), [true, false, false]);
-  assert.deepStrictEqual(tabs.map((t) => t.on), [true, false, false]);
+  const only = (name) => SECTIONS.map((s) => s === name);
+  for (const name of SECTIONS) {
+    const { setWsTab, secs, tabs, wsTab } = loadSetWsTab();
+    setWsTab(name);
+    assert.strictEqual(wsTab(), name);
+    assert.deepStrictEqual(secs.map((s) => s.on), only(name));
+    assert.deepStrictEqual(tabs.map((t) => t.on), only(name));
+  }
 });
 
 test('a section paints when its tab is shown, and only then', () => {
@@ -209,7 +217,7 @@ function loadScreenExits(remembered) {
   return { S, renders, ...make(document, localStorage, S, () => {}, () => renders.push(1)) };
 }
 
-test('the workspace heading row carries a back control', () => {
+test('the config heading row carries a back control', () => {
   const row = /<div class="ss-headrow">[\s\S]*?<\/div>/.exec(element('settings-screen'))[0];
   assert.match(row, /id="ss-back"/, 'the ⟵ is in the heading row');
   assert.ok(row.indexOf('id="ss-back"') < row.indexOf('class="ss-head"'), 'left of the title');
@@ -275,7 +283,7 @@ test('the playbooks section holds the reference panel, and does not restate its 
 // The third section, added the way the second one said a third would be: markup,
 // a tab, one WS_RENDER entry, and a module of its own. Showing only — the
 // registry is written from a terminal, never from here.
-test('projects are a section of the workspace screen, painted by their own module', () => {
+test('projects are a section of the config screen, painted by their own module', () => {
   const sec = element('ss-projects');
   assert.match(sec, /class="ss-title">projects</);
   assert.ok(sec.includes('id="pj-list"'), 'with the list the section renders into');
@@ -287,4 +295,49 @@ test('projects are a section of the workspace screen, painted by their own modul
   assert.ok(!/api\.addProject|POST|DELETE/.test(pj), 'and the section only ever shows');
   const apiSrc = fs.readFileSync(ui('js', 'api.js'), 'utf8');
   assert.match(apiSrc, /projects: \(git\) => j\('GET', '\/api\/projects' \+ \(git \? '\?git=1' : ''\)\)/);
+});
+
+// The fourth section, added exactly the way the third one said a fourth would
+// be: markup, a tab, one WS_RENDER entry, a module of its own — and the
+// tab-switching code untouched (asserted above, where SECTIONS drives it).
+test('lieutenants are a section of the config screen, painted by their own module', () => {
+  const sec = element('ss-lieutenants');
+  assert.match(sec, /class="ss-title">lieutenants</);
+  assert.ok(sec.includes('id="lt-list"'), 'with the list the section renders into');
+  assert.match(mainSrc, /import \{ renderLieutenants \} from '\.\/ltmanager\.js'/);
+  assert.match(mainSrc, /const WS_RENDER = \{[^}]*lieutenants: renderLieutenants/, 'one WS_RENDER entry');
+
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  assert.match(lt, /api\.lieutenants\(true\)/, 'the tab is what asks for the session probes');
+  const apiSrc = fs.readFileSync(ui('js', 'api.js'), 'utf8');
+  assert.match(apiSrc, /lieutenants: \(live\) => j\('GET', '\/api\/lieutenants' \+ \(live \? '\?live=1' : ''\)\)/);
+});
+
+// The two actions are the point: neither is new. ⚙ calls the switcher's own
+// openLtSettings, ✎ goes through openArtifactFile — so there is no second form
+// over the same four fields and no second editor. And retire is NOT here: the
+// switcher's ⋯ menu is the one door onto it.
+test('the lieutenant row reuses the settings modal and the file screen, and offers no retire', () => {
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  assert.match(lt, /import \{ openLtSettings \} from '\.\/ltswitcher\.js'/);
+  assert.match(lt, /onclick[^\n]*openLtSettings\(l\.id\)|\(\) => openLtSettings\(l\.id\)/,
+    'the ⚙ action calls the existing handler');
+  assert.match(fs.readFileSync(ui('js', 'ltswitcher.js'), 'utf8'), /export function openLtSettings/);
+
+  assert.match(lt, /import \{ openArtifactFile \} from '\.\/detail\.js'/);
+  assert.ok(!/mountFileEditor|CodeMirror|ls-color|ls-grid|ls-voice/.test(lt),
+    'and mounts neither an editor nor a second settings form');
+  assert.ok(!/retire/i.test(lt), 'retiring stays in the switcher — one door onto the destructive verb');
+});
+
+// The facts the row exists for. Three of them are nowhere else in the UI: the
+// next card id, the live-card count, and whether the session is up.
+test('a lieutenant row reports the prefix, the next number, the cards and the session', () => {
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  assert.match(lt, /'mints', l\.next/, 'the id the next card would carry');
+  assert.match(lt, /l\.cards === 1 \? '1 live card'/, 'the live-card count');
+  assert.match(lt, /SESSION\[l\.session\]/, 'and the session state');
+  for (const state of ['live', 'dead', 'none']) {
+    assert.match(lt, new RegExp('\\n  ' + state + ': \\{'), state + ' is a state the row says out loud');
+  }
 });

--- a/ui/app.css
+++ b/ui/app.css
@@ -653,6 +653,26 @@ body.resizing { user-select: none; cursor: col-resize; }
 .pj-v { min-width: 0; color: var(--text); font-family: var(--mono); overflow-wrap: anywhere; }
 .pj-warn .pj-v { color: var(--danger); }
 
+/* lieutenants: one block each, reading like a project's — face/name/id on the
+   head line, then what it mints next, what it owns, and whether it is alive */
+#lt-list { display: flex; flex-direction: column; gap: 12px; }
+.lt-row { display: flex; flex-direction: column; gap: 2px; }
+.lt-head { display: flex; gap: 8px; align-items: center; margin-bottom: 2px; }
+#lt-list .lt-face { width: 22px; height: 22px; }
+.lt-name { flex: 1; min-width: 0; color: var(--text); font-size: 13px; font-weight: 650;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lt-id { flex: none; color: var(--faint); font-size: 10.5px; font-family: var(--mono); }
+.lt-fact { display: flex; gap: 6px; align-items: baseline; font-size: 11px; line-height: 1.35; }
+.lt-k { flex: none; width: 52px; color: var(--faint); }
+.lt-v { min-width: 0; color: var(--text); font-family: var(--mono); overflow-wrap: anywhere; }
+.lt-live .lt-v { color: var(--ok); }
+.lt-dead .lt-v { color: var(--danger); }
+.lt-none .lt-v { color: var(--faint); }
+.lt-acts { display: flex; gap: 6px; margin-top: 5px; }
+.lt-act { color: var(--dim); font-size: 11.5px; padding: 2px 8px;
+  border: 1px solid var(--line); border-radius: 5px; }
+.lt-act:hover { color: var(--accent); border-color: var(--accent2); }
+
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
 .lm-row input[type=color], #lm-color { width: 26px; height: 22px; padding: 0; border: 1px solid var(--line); border-radius: 5px; background: none; cursor: pointer; flex: none; }
@@ -1091,8 +1111,8 @@ a.a-uri { color: var(--accent); }
 .mon-rss { flex: none; width: 52px; text-align: right; color: var(--faint); font-family: var(--mono); font-size: 11.5px; }
 .mon-empty { color: var(--faint); font-size: 12px; text-align: center; padding: 10px 0; }
 #mon-containers { color: var(--dim); font-size: 12px; }
-#mon-open, #workspace-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
-#mon-open:hover, #workspace-open:hover { color: var(--accent); border-color: var(--accent2); }
+#mon-open, #config-open { border: 1px solid var(--line); border-radius: 7px; color: var(--dim); padding: 3px 9px; font-size: 13px; }
+#mon-open:hover, #config-open:hover { color: var(--accent); border-color: var(--accent2); }
 
 /* context bar (chat header, switcher rows, Working tiles): used ÷ window from agentStatus.
    Green → yellow → red; red ≈ auto-compact territory (~80%). Rendered only

--- a/ui/index.html
+++ b/ui/index.html
@@ -94,12 +94,13 @@
   <div class="sp-row">
     <button id="mon-open" title="live machine & per-agent load (samples only while open)">📈 machine load</button>
   </div>
-  <!-- everything above this line is about THIS BROWSER. The workspace is not:
-       it is the board itself, shared by everyone on it, so it hands off to a
-       screen of its own. -->
-  <div class="sp-title">workspace</div>
+  <!-- everything above this line is about THIS BROWSER. The config screen is
+       not: it is the board itself, shared by everyone on it, so it hands off to
+       a screen of its own. This dropdown is the browser's settings; that screen
+       is the board's. -->
+  <div class="sp-title">config</div>
   <div class="sp-row">
-    <button id="workspace-open" title="labels and playbooks — the board's own settings">🗂 workspace</button>
+    <button id="config-open" title="labels, playbooks, projects and lieutenants — the board's own settings">🗂 config</button>
   </div>
 </div>
 
@@ -154,9 +155,8 @@
     <div id="table"></div>
     <div id="archive"></div>
     <div id="filepane"></div>
-    <!-- the workspace screen: one section per thing the BOARD owns, as opposed
-         to the browser looking at it. Labels and playbooks today; projects and
-         lieutenants move in later. -->
+    <!-- the config screen: one section per thing the BOARD owns, as opposed to
+         the browser looking at it — labels, playbooks, projects, lieutenants. -->
     <div id="settings-screen">
       <!-- the heading row carries the tabs: one button per section, wearing the
            same segmented look as the ▦☰🧊 switcher. data-tab pairs with the
@@ -167,11 +167,12 @@
            without the ⟵ there is no exit. Wears the file screen's crumb look. -->
       <div class="ss-headrow">
         <button type="button" id="ss-back" class="fs-back" title="back to the board">⟵</button>
-        <div class="ss-head">workspace</div>
-        <span id="ss-tabs" role="group" aria-label="workspace section">
+        <div class="ss-head">config</div>
+        <span id="ss-tabs" role="group" aria-label="config section">
           <button type="button" data-tab="labels" class="on">labels</button>
           <button type="button" data-tab="playbooks">playbooks</button>
           <button type="button" data-tab="projects">projects</button>
+          <button type="button" data-tab="lieutenants">lieutenants</button>
         </span>
       </div>
       <section class="ss-sec on" id="ss-labels" data-sec="labels">
@@ -201,6 +202,15 @@
       <section class="ss-sec" id="ss-projects" data-sec="projects">
         <div class="ss-title">projects</div>
         <div id="pj-list"></div>
+      </section>
+      <!-- lieutenants: who is on this board, what each one mints next, and the
+           one fact the board never shows — whether its session is still up.
+           Both actions reuse what exists: ⚙ opens the switcher's own settings
+           modal, ✎ opens the charter on the file screen. Retiring stays in the
+           switcher's ⋯ menu — one path to the destructive verb. -->
+      <section class="ss-sec" id="ss-lieutenants" data-sec="lieutenants">
+        <div class="ss-title">lieutenants</div>
+        <div id="lt-list"></div>
       </section>
     </div>
   </section>

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -99,6 +99,7 @@ export const api = {
   // server for the two reads off each clone (remote, default branch) — the
   // projects tab wants them, nothing else does, and nothing else pays for them.
   projects: (git) => j('GET', '/api/projects' + (git ? '?git=1' : '')),
+  lieutenants: (live) => j('GET', '/api/lieutenants' + (live ? '?live=1' : '')),
   // slash commands the current chat target's harness answers (composer autocomplete)
   commands: (target) => j('GET', '/api/commands?target=' + encodeURIComponent(target)),
 };

--- a/ui/js/detail.js
+++ b/ui/js/detail.js
@@ -473,7 +473,7 @@ export async function artifactWritten(ev) {
 
 // Open any file the artifact routes will serve on the file screen, through the
 // SAME drafts, versions and 409 handling a card artifact gets — which is what
-// makes the workspace screen's playbooks an editing surface without a second
+// makes the config screen's playbooks an editing surface without a second
 // editor, a second file API or a second lost-update story behind them.
 // `opts` adds what the caller knows: `crumb` (where this came from) and
 // `readOnly` — the line a save is refused with, for a file that has to be

--- a/ui/js/ltmanager.js
+++ b/ui/js/ltmanager.js
@@ -1,0 +1,139 @@
+// The config screen's lieutenants section: who is on this board, and the facts
+// about each one that nowhere else shows.
+//
+// Three of them are invisible today. The card PREFIX and the NEXT number it
+// would mint — the id of the card he is about to create, before he creates it.
+// The count of live cards it owns. And whether its SESSION is up: a lieutenant
+// whose agent died still sits on the board looking exactly like a working one,
+// so this row is the only place the difference reads.
+//
+// Both actions reuse what already exists — ⚙ is the switcher's own settings
+// modal (name, colour, avatar, voice), ✎ opens the charter on the file screen,
+// the same editor a playbook opens in. Retiring is deliberately absent: the
+// switcher's ⋯ menu already has it, and a second door onto the one destructive
+// verb is how it gets opened by accident.
+import { api } from './api.js';
+import { lieutenantColor } from './state.js';
+import { avatarHtml } from './avatars.js';
+import { openLtSettings } from './ltswitcher.js';
+import { openArtifactFile } from './detail.js';
+
+const listEl = document.getElementById('lt-list');
+
+// [{id, name, color, avatar, prefix, next, cards, memory, session}] — the last
+// answer from /api/lieutenants?live=1, in the order the board holds them.
+let items = null;
+let loading = false;
+
+// Same contract as the projects and playbooks sections: `reload` is what the tab
+// passes on the way in, so entering reads the session probes afresh while the
+// renders that follow — one per board event — repaint what is already here.
+// Nothing runs while another tab is up, so opening the screen for labels asks
+// the harness nothing.
+export async function renderLieutenants(reload) {
+  if (reload) items = null;
+  if (items) return paint();
+  if (loading) return;
+  loading = true;
+  try {
+    items = (await api.lieutenants(true)).lieutenants || [];
+  } catch (e) {
+    listEl.textContent = '⚠ ' + e.message;
+    return;
+  } finally { loading = false; }
+  paint();
+}
+
+// The three session states the server answers with, each said as the thing the
+// captain would do about it.
+const SESSION = {
+  live: { text: 'live', cls: 'lt-live', title: 'the harness says its session is up' },
+  dead: { text: 'dead', cls: 'lt-dead', title: 'it had a session and it is gone — the board respawns it, or reset it yourself' },
+  none: { text: 'no session', cls: 'lt-none', title: 'never spawned: this lieutenant is registered but nothing is running for it' },
+};
+
+function paint() {
+  listEl.textContent = '';
+  for (const l of items) {
+    const row = document.createElement('div');
+    row.className = 'lt-row';
+    row.appendChild(head(l));
+    row.appendChild(fact('mints', l.next, 'the id of the next card ' + (l.name || l.id) + ' creates'));
+    row.appendChild(fact('cards', l.cards === 1 ? '1 live card' : l.cards + ' live cards'));
+    const st = SESSION[l.session] || SESSION.none;
+    row.appendChild(fact('session', st.text, st.title, st.cls));
+    row.appendChild(actions(l));
+    listEl.appendChild(row);
+  }
+  if (!items.length) listEl.textContent = 'no lieutenants';
+}
+
+// avatar in its own colour, the display name, and the id — the id is what every
+// verb takes, so it reads as a value rather than a caption.
+function head(l) {
+  const el = document.createElement('div');
+  el.className = 'lt-head';
+  const face = document.createElement('span');
+  if (Number.isInteger(l.avatar) && l.avatar >= 0 && l.avatar <= 63) {
+    face.className = 'lt-face';
+    face.style.borderColor = lieutenantColor(l.id);
+    face.innerHTML = avatarHtml(l.avatar);
+  } else {
+    face.className = 'lt-dot';
+    face.style.background = lieutenantColor(l.id);
+  }
+  const name = document.createElement('span');
+  name.className = 'lt-name';
+  name.textContent = l.name || l.id;
+  const id = document.createElement('span');
+  id.className = 'lt-id';
+  id.textContent = l.id;
+  el.append(face, name, id);
+  return el;
+}
+
+function fact(key, value, title, cls) {
+  const row = document.createElement('div');
+  row.className = 'lt-fact' + (cls ? ' ' + cls : '');
+  if (title) row.title = title;
+  const k = document.createElement('span');
+  k.className = 'lt-k';
+  k.textContent = key;
+  const v = document.createElement('span');
+  v.className = 'lt-v';
+  v.textContent = value;
+  row.append(k, v);
+  return row;
+}
+
+function actions(l) {
+  const el = document.createElement('div');
+  el.className = 'lt-acts';
+  el.append(
+    action('⚙ settings', 'name, colour, avatar, voice, card prefix', () => openLtSettings(l.id)),
+    action('✎ charter', l.memory, () => openCharter(l)),
+  );
+  return el;
+}
+
+function action(label, title, onClick) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'lt-act';
+  b.textContent = label;
+  b.title = title;
+  b.onclick = onClick;
+  return b;
+}
+
+// The charter is a file, so editing it is the file screen — the same 💾, the
+// same version check, the same 409 as a playbook or a card artifact. A
+// lieutenant that never wrote one opens on the empty document (the board answers
+// version '' for it), and the first save creates the file.
+async function openCharter(l) {
+  try {
+    await openArtifactFile('file://' + l.memory, (l.name || l.id) + ' — README.md');
+  } catch (e) {
+    listEl.textContent = '⚠ cannot open the charter of ' + l.id + ' — ' + e.message;
+  }
+}

--- a/ui/js/ltswitcher.js
+++ b/ui/js/ltswitcher.js
@@ -174,7 +174,9 @@ const lsPrefix = document.getElementById('ls-prefix');
 const lsVoice = document.getElementById('ls-voice');
 const lsGrid = document.getElementById('ls-grid');
 let lsLtId = null;
-function openLtSettings(ltId) {
+// Exported for the config screen's lieutenants tab: its ⚙ is THIS modal, not a
+// second form over the same four fields.
+export function openLtSettings(ltId) {
   const l = lieutenant(ltId);
   if (!l) return;
   lsLtId = ltId;

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -21,6 +21,7 @@ import { renderNotifications, onOpenCard as notifOnOpenCard } from './notify.js'
 import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from './labels.js';
 import { renderPlaybooks } from './pbmanager.js';
 import { renderProjects } from './projmanager.js';
+import { renderLieutenants } from './ltmanager.js';
 import './resize.js'; // draggable side-panel widths
 import './keepalivesettings.js'; // the pocket switch: hold the audio session open
 
@@ -87,10 +88,10 @@ document.getElementById('mon-open').onclick = () => {
   gearBtn.classList.remove('on');
   openMonitor();
 };
-// ⚙️ → workspace: same handoff, to the workspace screen in the board region (so
-// the chat stays at its side). Mobile lives in the board tab, like the file
-// screen. The dropdown is this browser; the screen is the board everyone shares.
-document.getElementById('workspace-open').onclick = () => {
+// ⚙️ → config: same handoff, to the config screen in the board region (so the
+// chat stays at its side). Mobile lives in the board tab, like the file screen.
+// The dropdown is this browser; the screen is the board everyone shares.
+document.getElementById('config-open').onclick = () => {
   spEl.hidden = true;
   gearBtn.classList.remove('on');
   S.view = 'board';
@@ -98,7 +99,7 @@ document.getElementById('workspace-open').onclick = () => {
   setBoardMode('settings');
 };
 
-// ---------- workspace screen tabs ----------
+// ---------- config screen tabs ----------
 // One tab per section, one section visible. The tab is a class toggle over
 // [data-sec] plus one variable — nothing is persisted, so entering from the
 // gear always lands on labels, the same way the screen itself is not
@@ -107,7 +108,7 @@ document.getElementById('workspace-open').onclick = () => {
 // the source afresh on the way in), the render loop repaints it without. A new
 // section is a <section data-sec>, a <button data-tab> and one entry here; the
 // switching below never learns its name.
-const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks, projects: renderProjects };
+const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks, projects: renderProjects, lieutenants: renderLieutenants };
 let wsTab = 'labels';
 function setWsTab(tab) {
   wsTab = tab;

--- a/ui/js/pbmanager.js
+++ b/ui/js/pbmanager.js
@@ -1,4 +1,4 @@
-// The workspace screen's playbooks section: every playbook the board can start
+// The config screen's playbooks section: every playbook the board can start
 // a card with, and the way to edit one.
 //
 // A playbook is a file, so editing one is the file screen — the same editor,

--- a/ui/js/projmanager.js
+++ b/ui/js/projmanager.js
@@ -1,4 +1,4 @@
-// The workspace screen's projects section: the registry a card's `repo`
+// The config screen's projects section: the registry a card's `repo`
 // attribute has to name, and the facts that decide whether a start off one will
 // work — how many live cards point at it, where it pushes, and the branch a
 // fresh worktree starts detached from.


### PR DESCRIPTION
\`workspace\` reads like a filesystem, not like what that screen is. He calls it *configurações*, so the gear row and the heading say **config** — `workspace-open` → `config-open`, glyph unchanged. The gear dropdown is still this browser's settings; that screen is the board's.

The fourth tab is **lieutenants**: one row each, in board order, carrying the three facts nothing else in the UI shows — the card prefix and the number it would mint next, the live cards owned, and whether the session is actually up. That last one is the point: a dead lieutenant looks identical to a live one on the board. It rides `GET /api/lieutenants?live=1`, gated the way `/api/projects` gates its git reads — the tab asks, nobody else pays.

Both actions reuse what exists: ⚙ opens the switcher's own settings modal, ✎ opens `lieutenants/<id>/README.md` on the file screen. No retire — the switcher's ⋯ menu is the one door onto it.

The charter edit is the second and last widening of the artifact gate: exactly the path `charterPath()` builds from the workspace root and a *registered* id, which is what refuses an unregistered id, another file in that folder, a subdirectory, a symlink and a traversal in one rule. A lieutenant that never wrote a charter opens on the empty document at version `''`, so the first 💾 creates the folder and the file.

**Tests:** `node --test test/*.test.js harness/test/*.test.js` → **783 pass, 0 fail**. New: `test/charter-edit.test.js` (gate edges, one test per refusal), the `live=1` block in `test/lieutenants.test.js`, and the tab/rename/reuse assertions in `test/settings-screen.test.js`. Smoke-tested against a real server in a browser: rows render, ✎ opens and saves a charter that did not exist, ⚙ opens the existing modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)