### PR TITLE
feat(ui): the lieutenants tab becomes a list

### DIFF
--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -334,10 +334,53 @@ test('the lieutenant row reuses the settings modal and the file screen, and offe
 // next card id, the live-card count, and whether the session is up.
 test('a lieutenant row reports the prefix, the next number, the cards and the session', () => {
   const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
-  assert.match(lt, /'mints', l\.next/, 'the id the next card would carry');
-  assert.match(lt, /l\.cards === 1 \? '1 live card'/, 'the live-card count');
+  assert.match(lt, /l\.next \+ ' · ' \+ countText\(l\.cards\) \+ ' · '/, 'the id the next card would carry');
+  assert.match(lt, /countText = \(n\)/, 'the live-card count');
   assert.match(lt, /SESSION\[l\.session\]/, 'and the session state');
   for (const state of ['live', 'dead', 'none']) {
     assert.match(lt, new RegExp('\\n  ' + state + ': \\{'), state + ' is a state the row says out loud');
   }
+});
+
+// The tab is a list, not a form: the three facts are one run of text in one
+// element — `WAL-4 · 14 cards · live` — not a label/value pair apiece. Eight
+// rows fit a phone only because nothing here spells `mints` or `cards` out as
+// a caption eight times over.
+test('the three facts are one line, not a label/value pair per fact', () => {
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  assert.match(lt, /el\.className = 'lt-facts'/, 'one element carries the run');
+  assert.ok(!/'lt-k'|'lt-v'|'lt-fact'|function fact\(/.test(lt), 'and no key/value pair survives');
+  const css = fs.readFileSync(ui('app.css'), 'utf8');
+  assert.ok(!/\.lt-k \{|\.lt-v \{|\.lt-fact \{|\.lt-head \{/.test(css), 'nor the rules that laid them out');
+  // the density rule the playbooks list already has: rows a few px apart
+  assert.match(css, /#lt-list \{[^}]*gap: 4px/, 'rows sit as close as playbook rows');
+  assert.match(css, /\.lt-row \{[^}]*display: flex;[^}]*align-items: center/, 'and each row is one line');
+  assert.ok(!/\.lt-row \{[^}]*flex-direction: column/.test(css), 'not a stack');
+  // colour is the only thing the session keeps
+  for (const [state, v] of [['live', 'ok'], ['dead', 'danger'], ['none', 'faint']]) {
+    assert.match(css, new RegExp('\\.lt-' + state + ' \\{ color: var\\(--' + v + '\\)'), state + ' keeps its colour');
+  }
+});
+
+// `1 card`, not `1 cards`, and not `14 live cards` either — the word `live`
+// belongs to the section, said once, not to every row.
+test('the card count reads 1 card and 14 cards', () => {
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  const src = /const countText = [^\n]+/.exec(lt);
+  assert.ok(src, 'countText is a one-liner the test can lift');
+  const countText = new Function(src[0] + '; return countText;')();
+  assert.strictEqual(countText(1), '1 card');
+  assert.strictEqual(countText(0), '0 cards');
+  assert.strictEqual(countText(14), '14 cards');
+});
+
+// Icons, not full-width buttons — but the words they lose are still reachable,
+// and they call exactly the handlers they called as words.
+test('the two actions are icons carrying their words in a title', () => {
+  const lt = fs.readFileSync(ui('js', 'ltmanager.js'), 'utf8');
+  assert.match(lt, /action\('⚙', 'settings — [^']+', \(\) => openLtSettings\(l\.id\)\)/);
+  assert.match(lt, /action\('✎', 'charter — ' \+ l\.memory, \(\) => openCharter\(l\)\)/);
+  assert.match(lt, /b\.title = title/, 'the title is what carries the words');
+  const css = fs.readFileSync(ui('app.css'), 'utf8');
+  assert.match(css, /\.lt-acts \{[^}]*margin-left: auto/, 'and they sit at the right end of the row');
 });

--- a/ui/app.css
+++ b/ui/app.css
@@ -653,23 +653,25 @@ body.resizing { user-select: none; cursor: col-resize; }
 .pj-v { min-width: 0; color: var(--text); font-family: var(--mono); overflow-wrap: anywhere; }
 .pj-warn .pj-v { color: var(--danger); }
 
-/* lieutenants: one block each, reading like a project's — face/name/id on the
-   head line, then what it mints next, what it owns, and whether it is alive */
-#lt-list { display: flex; flex-direction: column; gap: 12px; }
-.lt-row { display: flex; flex-direction: column; gap: 2px; }
-.lt-head { display: flex; gap: 8px; align-items: center; margin-bottom: 2px; }
-#lt-list .lt-face { width: 22px; height: 22px; }
-.lt-name { flex: 1; min-width: 0; color: var(--text); font-size: 13px; font-weight: 650;
+/* lieutenants: one line each, as dense as a playbook row — face, name, id, the
+   three facts as one dim run, and the two actions as icons at the right end.
+   The facts run stays whole at any width — the name is what ellipses — so all
+   eight lieutenants are one screen on a phone. */
+#lt-list { display: flex; flex-direction: column; gap: 4px; }
+.lt-row { display: flex; gap: 8px; align-items: center; }
+#lt-list .lt-face { width: 18px; height: 18px; }
+.lt-name { flex: 0 1 auto; min-width: 0; color: var(--text); font-size: 12.5px; font-weight: 650;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .lt-id { flex: none; color: var(--faint); font-size: 10.5px; font-family: var(--mono); }
-.lt-fact { display: flex; gap: 6px; align-items: baseline; font-size: 11px; line-height: 1.35; }
-.lt-k { flex: none; width: 52px; color: var(--faint); }
-.lt-v { min-width: 0; color: var(--text); font-family: var(--mono); overflow-wrap: anywhere; }
-.lt-live .lt-v { color: var(--ok); }
-.lt-dead .lt-v { color: var(--danger); }
-.lt-none .lt-v { color: var(--faint); }
-.lt-acts { display: flex; gap: 6px; margin-top: 5px; }
-.lt-act { color: var(--dim); font-size: 11.5px; padding: 2px 8px;
+/* grows into the gap and never shrinks — the name is what gives way, so a long
+   one ellipses rather than a fact getting clipped in half */
+.lt-facts { flex: 1 0 auto; color: var(--faint); font-size: 11px; font-family: var(--mono);
+  white-space: nowrap; }
+.lt-live { color: var(--ok); }
+.lt-dead { color: var(--danger); }
+.lt-none { color: var(--faint); }
+.lt-acts { flex: none; display: flex; gap: 4px; margin-left: auto; }
+.lt-act { color: var(--dim); font-size: 12px; line-height: 1; padding: 3px 7px;
   border: 1px solid var(--line); border-radius: 5px; }
 .lt-act:hover { color: var(--accent); border-color: var(--accent2); }
 

--- a/ui/js/ltmanager.js
+++ b/ui/js/ltmanager.js
@@ -52,66 +52,74 @@ const SESSION = {
   none: { text: 'no session', cls: 'lt-none', title: 'never spawned: this lieutenant is registered but nothing is running for it' },
 };
 
+// One line per lieutenant, the way the playbooks tab is one line per playbook:
+// face, name, id, the three facts as a single dim run, and the two actions as
+// icons at the right end. Eight of them fit a phone screen.
 function paint() {
   listEl.textContent = '';
   for (const l of items) {
     const row = document.createElement('div');
     row.className = 'lt-row';
-    row.appendChild(head(l));
-    row.appendChild(fact('mints', l.next, 'the id of the next card ' + (l.name || l.id) + ' creates'));
-    row.appendChild(fact('cards', l.cards === 1 ? '1 live card' : l.cards + ' live cards'));
-    const st = SESSION[l.session] || SESSION.none;
-    row.appendChild(fact('session', st.text, st.title, st.cls));
-    row.appendChild(actions(l));
+    row.append(face(l), name(l), id(l), facts(l), actions(l));
     listEl.appendChild(row);
   }
   if (!items.length) listEl.textContent = 'no lieutenants';
 }
 
-// avatar in its own colour, the display name, and the id — the id is what every
-// verb takes, so it reads as a value rather than a caption.
-function head(l) {
-  const el = document.createElement('div');
-  el.className = 'lt-head';
-  const face = document.createElement('span');
+// the avatar in its own colour, or a plain dot when it has none
+function face(l) {
+  const el = document.createElement('span');
   if (Number.isInteger(l.avatar) && l.avatar >= 0 && l.avatar <= 63) {
-    face.className = 'lt-face';
-    face.style.borderColor = lieutenantColor(l.id);
-    face.innerHTML = avatarHtml(l.avatar);
+    el.className = 'lt-face';
+    el.style.borderColor = lieutenantColor(l.id);
+    el.innerHTML = avatarHtml(l.avatar);
   } else {
-    face.className = 'lt-dot';
-    face.style.background = lieutenantColor(l.id);
+    el.className = 'lt-dot';
+    el.style.background = lieutenantColor(l.id);
   }
-  const name = document.createElement('span');
-  name.className = 'lt-name';
-  name.textContent = l.name || l.id;
-  const id = document.createElement('span');
-  id.className = 'lt-id';
-  id.textContent = l.id;
-  el.append(face, name, id);
   return el;
 }
 
-function fact(key, value, title, cls) {
-  const row = document.createElement('div');
-  row.className = 'lt-fact' + (cls ? ' ' + cls : '');
-  if (title) row.title = title;
-  const k = document.createElement('span');
-  k.className = 'lt-k';
-  k.textContent = key;
-  const v = document.createElement('span');
-  v.className = 'lt-v';
-  v.textContent = value;
-  row.append(k, v);
-  return row;
+function name(l) {
+  const el = document.createElement('span');
+  el.className = 'lt-name';
+  el.textContent = l.name || l.id;
+  return el;
+}
+
+// the id is what every verb takes, so it reads as a value rather than a caption
+function id(l) {
+  const el = document.createElement('span');
+  el.className = 'lt-id';
+  el.textContent = l.id;
+  return el;
+}
+
+const countText = (n) => (n === 1 ? '1 card' : n + ' cards');
+
+// The three facts as one line — `WAL-4 · 14 cards · live`. Separators, not
+// labels: the section heading says what these are once, so eight rows do not
+// each spell it out. The session is the one part that keeps a colour of its
+// own, because a dead one has to be what the eye lands on.
+function facts(l) {
+  const st = SESSION[l.session] || SESSION.none;
+  const el = document.createElement('span');
+  el.className = 'lt-facts';
+  el.title = 'next card id · live cards it owns · session';
+  const sess = document.createElement('span');
+  sess.className = st.cls;
+  sess.textContent = st.text;
+  sess.title = st.title;
+  el.append(l.next + ' · ' + countText(l.cards) + ' · ', sess);
+  return el;
 }
 
 function actions(l) {
-  const el = document.createElement('div');
+  const el = document.createElement('span');
   el.className = 'lt-acts';
   el.append(
-    action('⚙ settings', 'name, colour, avatar, voice, card prefix', () => openLtSettings(l.id)),
-    action('✎ charter', l.memory, () => openCharter(l)),
+    action('⚙', 'settings — name, colour, avatar, voice, card prefix', () => openLtSettings(l.id)),
+    action('✎', 'charter — ' + l.memory, () => openCharter(l)),
   );
   return el;
 }


### PR DESCRIPTION
Eight lieutenants took seven lines each — centred label/value stack, `live cards` spelled out per row, two full-width buttons under it — so five filled a phone screen. The playbooks tab beside it is one tight line per playbook; now this one is too: face, name, id, the three facts as a single dim run (`WAL-4 · 14 cards · live`), and ⚙ / ✎ as icons at the right end with their words in a `title`. Session keeps its colour. All eight fit a 390px viewport with room to spare.

Layout only: same fields, same endpoint, same handlers. `node --test test/*.test.js harness/test/*.test.js` → 786 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)