### PR TITLE
feat(onboarding): a first run that ends with Bridget already talking

### DIFF
--- a/FIRST-RUN.md
+++ b/FIRST-RUN.md
@@ -72,8 +72,26 @@ one — never on your own initiative.
 show the install command the block printed for this machine, **ask**, install it on a yes, and run
 the command again. On a no: there is no board without it — say so plainly and stop.
 
+**`first run blocked (root)`** — you are uid 0, and Claude Code refuses `--dangerously-skip-permissions`
+as root, so Bridget could never start. The block prints the two ways forward; **ask which one**.
+The normal-user route (`useradd -m dev && su - dev`, then install the skill and run again there) is
+the right default. `--allow-root` launches her with `IS_SANDBOX=1`, turning off a guard that exists
+for good reasons — offer it only for a container they are about to delete, and only if they say yes.
+
 **`first run blocked (port-busy)`** — everything from 4780 up is taken. Ask which port they want and
 pass `--port <N>`.
+
+**The board comes up but Bridget's session does not.** The command prints her pane verbatim and
+names the cause from what is in it. Two you will meet on a fresh machine:
+
+- **the `claude` CLI has never been run** — her pane is parked on Claude Code's own setup wizard
+  (the theme picker), which appears *before* any login question. Tell them to run `claude` once in
+  their own terminal, answer it, `/exit`, then say the word and you run the command again. Do not
+  answer that wizard for them; it picks their theme and their login method.
+- **not installed / not logged in** — the block names which, from the pane.
+
+In every one of these the board is already up and her welcome message is already on it. Re-running
+the same command is always the way forward; nothing is lost.
 
 There is also a **git identity** warning (`user.name` / `user.email` unset). It is a warning, not a
 failure: the board comes up regardless, it is recorded in the first-run state, and Bridget picks it
@@ -85,14 +103,22 @@ The command's last lines are the board URL. Hand it over as-is:
 
 > Your board is at **http://localhost:4780/** — open it. Bridget is already there with a message.
 
-**If you are on a remote machine** (ssh, a devbox, a container), `localhost` means the remote box,
-not their laptop. Tell them to forward the port from their own machine:
+**If the board is not on the machine their browser is on**, `localhost` is the wrong machine. The
+server binds `127.0.0.1` on purpose — there is no app auth, so anything that can reach the port can
+drive the fleet. Do not widen the bind to fix a browser problem. In order of preference:
 
-```sh
-ssh -L 4780:127.0.0.1:4780 <the host they ssh'd to>
-```
-
-Then the same URL works in their browser.
+1. **Run the workspace where the browser is.** This is the normal case, and the reason the default
+   is loopback. A workspace is a folder; it does not have to live on a server.
+2. **Over ssh** — a tunnel from their own machine, nothing on the board changes:
+   ```sh
+   ssh -L 4780:127.0.0.1:4780 <the host they ssh'd to>
+   ```
+   Then the same `http://localhost:4780/` works in their browser.
+3. **In a container** — `docker run -p` will *not* reach a loopback bind, and publishing the port
+   is not a workaround for it. Either ssh into the host and tunnel as above, or, if the container
+   is on a private bridge network they control, have them re-run with an address the host can
+   reach: `bc-axi init --onboard --host <container-ip>`. Say the trade plainly first: **anything
+   that can reach that address can drive the board, with no login.** Their call, not yours.
 
 **If Bridget's session did not start** (the command says so, loudly), the board is still up and her
 message is still on it — she just cannot answer. It is almost always the `claude` CLI: missing, or

--- a/FIRST-RUN.md
+++ b/FIRST-RUN.md
@@ -85,10 +85,21 @@ pass `--port <N>`.
 names the cause from what is in it. Two you will meet on a fresh machine:
 
 - **the `claude` CLI has never been run** — her pane is parked on Claude Code's own setup wizard
-  (the theme picker), which appears *before* any login question. Tell them to run `claude` once in
-  their own terminal, answer it, `/exit`, then say the word and you run the command again. Do not
-  answer that wizard for them; it picks their theme and their login method.
+  (the theme picker), which appears *before* any login question.
+- **the folder-trust question** — `Quick safety check: Is this a project you created or one you
+  trust?`. Claude Code asks it for any directory it has not seen before, also before login.
 - **not installed / not logged in** — the block names which, from the pane.
+
+For all of these the recipe is the same and the **directory matters**: have them run
+
+```sh
+cd <the workspace folder> && claude
+```
+
+answer whatever it asks, `/exit`, then run the first-run command again. Running `claude` in their
+home directory does **not** clear the trust question — Bridget is spawned in the workspace, so the
+question is about that folder. Never answer those wizards for them: they pick a theme, a login
+method, and what a machine is trusted with.
 
 In every one of these the board is already up and her welcome message is already on it. Re-running
 the same command is always the way forward; nothing is lost.
@@ -116,9 +127,17 @@ drive the fleet. Do not widen the bind to fix a browser problem. In order of pre
    Then the same `http://localhost:4780/` works in their browser.
 3. **In a container** — `docker run -p` will *not* reach a loopback bind, and publishing the port
    is not a workaround for it. Either ssh into the host and tunnel as above, or, if the container
-   is on a private bridge network they control, have them re-run with an address the host can
-   reach: `bc-axi init --onboard --host <container-ip>`. Say the trade plainly first: **anything
-   that can reach that address can drive the board, with no login.** Their call, not yours.
+   is on a private bridge network they control, re-run with an address the host can reach:
+   ```sh
+   bc-axi init --onboard --host <container-ip>
+   ```
+   Say the trade plainly **before** you run it: anything that can reach that address can drive the
+   board, with no login. Their call, not yours.
+
+   Asking for this after the board is already up is fine — that is the normal order, since nobody
+   discovers the browser cannot reach it until they try. The command restarts the server on the new
+   address, says so, writes the bind into `config.json` so it survives, and prints the URL that
+   actually works. Hand over **that** URL, not `localhost`.
 
 **If Bridget's session did not start** (the command says so, loudly), the board is still up and her
 message is still on it — she just cannot answer. It is almost always the `claude` CLI: missing, or

--- a/FIRST-RUN.md
+++ b/FIRST-RUN.md
@@ -77,6 +77,8 @@ as root, so Bridget could never start. The block prints the two ways forward; **
 The normal-user route (`useradd -m dev && su - dev`, then install the skill and run again there) is
 the right default. `--allow-root` launches her with `IS_SANDBOX=1`, turning off a guard that exists
 for good reasons — offer it only for a container they are about to delete, and only if they say yes.
+Everything you hand them to run by hand from then on needs that same `IS_SANDBOX=1` in front of
+`claude --dangerously-skip-permissions`.
 
 If you install Claude Code with `curl -fsSL https://claude.ai/install.sh | bash`, note that it does
 **not** edit anyone's PATH — it prints "Installation complete" and leaves it to you. As root, whose
@@ -111,6 +113,16 @@ form that meets every one of those screens:
 ```sh
 cd <the workspace folder> && claude --dangerously-skip-permissions
 ```
+
+**As root** (only ever reachable via `--allow-root`), that line needs the escape hatch her spawn
+uses, or it dies on the root refusal instead of reaching any of those screens:
+
+```sh
+cd <the workspace folder> && IS_SANDBOX=1 claude --dangerously-skip-permissions
+```
+
+The blocks the command prints already carry the right form for the user running it — copy what it
+printed rather than retyping this.
 
 answer whatever it asks (`2. Yes, I accept` on the consent screen), `/exit`, then run the first-run
 command again. **Never answer those screens for them.** They choose a theme, a login method, what a

--- a/FIRST-RUN.md
+++ b/FIRST-RUN.md
@@ -78,6 +78,16 @@ The normal-user route (`useradd -m dev && su - dev`, then install the skill and 
 the right default. `--allow-root` launches her with `IS_SANDBOX=1`, turning off a guard that exists
 for good reasons — offer it only for a container they are about to delete, and only if they say yes.
 
+If you install Claude Code with `curl -fsSL https://claude.ai/install.sh | bash`, note that it does
+**not** edit anyone's PATH — it prints "Installation complete" and leaves it to you. As root, whose
+`~/.profile` does not pick up `~/.local/bin`, the next step then dies with `command not found`. Do
+both, for the user who will run it:
+
+```sh
+export PATH="$HOME/.local/bin:$PATH"
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc   # her session is launched from a shell too
+```
+
 **`first run blocked (port-busy)`** — everything from 4780 up is taken. Ask which port they want and
 pass `--port <N>`.
 
@@ -87,19 +97,24 @@ names the cause from what is in it. Two you will meet on a fresh machine:
 - **the `claude` CLI has never been run** — her pane is parked on Claude Code's own setup wizard
   (the theme picker), which appears *before* any login question.
 - **the folder-trust question** — `Quick safety check: Is this a project you created or one you
-  trust?`. Claude Code asks it for any directory it has not seen before, also before login.
+  trust?`. Claude Code asks it for any directory it has not already trusted, also before login.
+  Trust is inherited from a trusted ancestor, so a workspace under a home directory they have
+  already used Claude Code in may never ask.
+- **the bypass-permissions consent screen** — `WARNING: Claude Code running in Bypass Permissions
+  mode`, with `1. No, exit` preselected. This one is raised **by the launch flag the spawn uses**,
+  so a hand-run of plain `claude` never meets it and can never clear it.
 - **not installed / not logged in** — the block names which, from the pane.
 
-For all of these the recipe is the same and the **directory matters**: have them run
+For all of these, have them run it by hand **in the workspace, with the flag** — that is the only
+form that meets every one of those screens:
 
 ```sh
-cd <the workspace folder> && claude
+cd <the workspace folder> && claude --dangerously-skip-permissions
 ```
 
-answer whatever it asks, `/exit`, then run the first-run command again. Running `claude` in their
-home directory does **not** clear the trust question — Bridget is spawned in the workspace, so the
-question is about that folder. Never answer those wizards for them: they pick a theme, a login
-method, and what a machine is trusted with.
+answer whatever it asks (`2. Yes, I accept` on the consent screen), `/exit`, then run the first-run
+command again. **Never answer those screens for them.** They choose a theme, a login method, what a
+machine is trusted with, and whether an agent may skip permission prompts — none of which is yours.
 
 In every one of these the board is already up and her welcome message is already on it. Re-running
 the same command is always the way forward; nothing is lost.

--- a/FIRST-RUN.md
+++ b/FIRST-RUN.md
@@ -1,0 +1,107 @@
+# First run — for the agent the user already has
+
+You are the user's own Claude Code (or Codex) session, in whatever folder they opened you in, and
+they have just asked for Bridge Commander for the first time. **This file covers only that: getting
+a board up with lieutenant Bridget on it.** The moment she is talking, you are finished — the rest
+of the setup is a conversation she has with them, not a document you follow.
+
+Read the whole file before you start. It is short on purpose.
+
+## What you are aiming at
+
+One command does the work:
+
+```sh
+bc-axi init --onboard
+```
+
+It refuses to eat a code project, brings the board up, writes Bridget's charter, starts her session
+in a tmux session of its own, and leaves a welcome message on the board before the person has said
+anything. It installs nothing, and it is safe to run again — a second run resumes where the first
+one stopped.
+
+`bc-axi` is at `<checkout>/cli/bc-axi`; SKILL.md step 0 tells you how to resolve the checkout.
+
+## Rules that are not negotiable
+
+- **Never ask the person to type a tmux command.** Not in a step, not in an error message, not as a
+  suggestion. tmux is underneath; they never have to know it is there. If you catch yourself writing
+  `tmux new -s ...` into a message to them, that is a bug in this flow — report it instead.
+- **Install nothing without asking.** Ask a yes/no question with the actual command in it, wait for
+  the answer, then run it yourself.
+- **Stop where Bridget starts.** Do not install `treehouse` or `no-mistakes`, do not register a
+  project, do not create cards, do not explain the board. That is hers, and doing it for her leaves
+  the person with a board they have never used.
+
+## 1. Is this folder allowed to be a workspace?
+
+A workspace is its own folder, **beside** the code, never inside it — it holds the board, its
+lieutenants, and the worktrees workers run in.
+
+`init --onboard` decides this itself, before it writes anything, in this order:
+
+1. **`.bridge-commander/` present** → an existing workspace. It continues; this is a re-run.
+   (This check is first because a workspace is itself a git repo, and every later signal would
+   misread it.)
+2. **empty folder** → go.
+3. **a `.git/`, a manifest (`package.json`, `pyproject.toml`, `go.mod`, `Cargo.toml`, …), or source
+   files** → refused, naming what it found.
+4. **non-empty and none of those** → refused as a judgement call, listing what is in there.
+
+If you already know you are sitting in a repo, you can skip the refusal and go straight to asking —
+but run the command anyway when unsure. Guessing is what it is there to stop.
+
+## 2. Run it
+
+```sh
+cd <the workspace folder>
+bc-axi init --onboard
+```
+
+Everything it prints is for you, not for them. Three failures are worth knowing by name — each one
+prints its own block, and each one is recoverable without losing anything:
+
+**`first run refused (project)` / `(unclear)`** — you are in the wrong folder. Tell them what it
+found, in their words: *"this looks like your code — Bridge Commander wants a folder of its own,
+next to it."* Then propose a path (`~/myfleet` is a fine default), **ask**, create it yourself,
+`cd` in, and run the command again. Only pass `--here` if they explicitly say this folder is the
+one — never on your own initiative.
+
+**`first run blocked (tmux-missing)`** — tmux is not installed. Say why it is needed in one line
+(*"lieutenants are real agent sessions and they live in tmux; you will never have to touch it"*),
+show the install command the block printed for this machine, **ask**, install it on a yes, and run
+the command again. On a no: there is no board without it — say so plainly and stop.
+
+**`first run blocked (port-busy)`** — everything from 4780 up is taken. Ask which port they want and
+pass `--port <N>`.
+
+There is also a **git identity** warning (`user.name` / `user.email` unset). It is a warning, not a
+failure: the board comes up regardless, it is recorded in the first-run state, and Bridget picks it
+up before the first card. Do not stop for it.
+
+## 3. Give them the URL, and stop
+
+The command's last lines are the board URL. Hand it over as-is:
+
+> Your board is at **http://localhost:4780/** — open it. Bridget is already there with a message.
+
+**If you are on a remote machine** (ssh, a devbox, a container), `localhost` means the remote box,
+not their laptop. Tell them to forward the port from their own machine:
+
+```sh
+ssh -L 4780:127.0.0.1:4780 <the host they ssh'd to>
+```
+
+Then the same URL works in their browser.
+
+**If Bridget's session did not start** (the command says so, loudly), the board is still up and her
+message is still on it — she just cannot answer. It is almost always the `claude` CLI: missing, or
+not logged in. Get that sorted with them, then run the same command again.
+
+## 4. That is the end of your job
+
+Say one line — *"Bridget will take it from here; talk to her on the board"* — and stop. Do not
+narrate the board, do not stay in the loop, do not pre-answer her questions.
+
+If they come back to this same session later and ask for the board again, `bc-axi open` prints the
+URL and starts the server if it is down. That is the whole re-entry.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,14 @@ missing). You never have to use tmux yourself.
 
 Two things worth knowing before you start, because they are the only ways a first run stops early:
 
-- **Run `claude` once by hand first** if this machine has never run it — it has a setup screen
-  (theme, then login) that a spawned session cannot answer for you.
+- **Run `claude` once by hand, inside the workspace folder**, if this machine has never run it.
+  It has setup screens a spawned session cannot answer for you — a theme picker, a login, and a
+  trust question about that specific folder (which is why running it in your home directory is not
+  enough).
 - **Not as root.** Claude Code refuses `--dangerously-skip-permissions` as root, so a lieutenant
   cannot start there. Use a normal user (a throwaway container can pass `--allow-root`, and the
-  tool will tell you what that costs).
+  tool will tell you what that costs). If you need to install Claude Code as that user,
+  `curl -fsSL https://claude.ai/install.sh | bash` puts it in `~/.local/bin` without root.
 
 ## Board views
 

--- a/README.md
+++ b/README.md
@@ -18,24 +18,26 @@ kanban board.
 
 ## Install
 
-Just some dependencies and a new skill:
+One skill:
 
 ```sh
-# dependencies
-curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh
-curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
-
-# bridge-commander
-npx skills add tonylampada/bridge-commander -g -y   # first /bridge-commander run clones the full tool
+npx skills add tonylampada/bridge-commander -g -y
 ```
 
-## Quickstart
+That is the whole install. The rest happens in the terminal you already have.
 
-- Create an empty folder (e.g. `myfleet`)
-- Start `claude` in that folder, **inside tmux** (not optional — the lieutenant lives in the tmux session)
+## Start
+
+- Make an empty folder (e.g. `myfleet`) and start `claude` in it
 - `/bridge-commander`
-- Open the printed board URL (default `http://localhost:4780/`)
-- Talk to your lieutenant from there — he'll guide you through the rest of the setup
+- Open the board URL it prints (default `http://localhost:4780/`)
+
+**Bridget** is already there with a message waiting. She's your first lieutenant, and she does the
+rest of the setup with you — the two optional tools, your first repo, and a short checklist that
+runs as real cards on the board.
+
+You need `tmux` and `git` on the machine (your agent will offer to install `tmux` if it is
+missing). You never have to use tmux yourself.
 
 ## Board views
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Two things worth knowing before you start, because they are the only ways a firs
   enough).
 - **Not as root.** Claude Code refuses `--dangerously-skip-permissions` as root, so a lieutenant
   cannot start there. Use a normal user (a throwaway container can pass `--allow-root`, and the
-  tool will tell you what that costs). If you need to install Claude Code as that user,
+  tool will tell you what that costs — and that anything you then run by hand needs `IS_SANDBOX=1`
+  in front of it). If you need to install Claude Code as that user,
   `curl -fsSL https://claude.ai/install.sh | bash` puts it in `~/.local/bin` without root.
 
 ## Board views

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ runs as real cards on the board.
 You need `tmux` and `git` on the machine (your agent will offer to install `tmux` if it is
 missing). You never have to use tmux yourself.
 
+Two things worth knowing before you start, because they are the only ways a first run stops early:
+
+- **Run `claude` once by hand first** if this machine has never run it — it has a setup screen
+  (theme, then login) that a spawned session cannot answer for you.
+- **Not as root.** Claude Code refuses `--dangerously-skip-permissions` as root, so a lieutenant
+  cannot start there. Use a normal user (a throwaway container can pass `--allow-root`, and the
+  tool will tell you what that costs).
+
 ## Board views
 
 The board region has three modes, toggled next to the filter (▦ / ☰ / 🧊):

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bridge-commander
-description: Turn the current directory into a Bridge Commander workspace and become its founding lieutenant (the teleport), or re-enter an existing one. Use when the user asks to init/set up bridge command, open the bridge board, or orchestrate work through the kanban board.
+description: Set up Bridge Commander for the first time (an empty folder becomes a board with a lieutenant already on it), or turn the current directory into a workspace and become its founding lieutenant (the teleport), or re-enter an existing one. Use when the user asks to init/set up bridge command, open the bridge board, or orchestrate work through the kanban board.
 ---
 
 # Bridge Commander — the teleport
@@ -22,23 +22,32 @@ Some skill installers copy only this file. Resolve the tool checkout, in order:
 full usage). `DOCTRINE.md` and `OPERATIONS.md` live in the checkout root — read them from
 there, not next to this file, unless this dir is the tool.
 
-## 1. Verify you are inside tmux
+## 1. Which of the two runs is this?
 
-Check `$TMUX`. If it is empty, REFUSE to init and tell the user exactly this, then stop:
+**Is there a `.bridge-commander/` directory here (or in a parent)?**
 
-> Bridge Commander lieutenants live in tmux sessions — I need to be running inside one.
-> Please start `tmux new -s <workspace-name>`, launch me again in there, and re-invoke
-> this skill.
+- **No — this is a first run.** Read **`FIRST-RUN.md` in the checkout** and follow it, instead of
+  the rest of this file. It is one command, and it ends with a board and a lieutenant named
+  Bridget already talking to the user; onboarding is hers from there. Do not ask the user to
+  start tmux — the first run handles tmux itself and never mentions it to them.
+- **Yes — a workspace exists.** Continue below: you are joining it as a lieutenant.
 
-(Your tmux session becomes your permanent address: the server wakes you by typing into it,
-and the captain can always `tmux attach` to it.)
+## 2. Verify you are inside tmux
 
-## 2. Confirm you are in the intended workspace directory
+Check `$TMUX`. If it is empty you cannot BE a lieutenant of this workspace from here — a
+lieutenant's tmux session is its permanent address (the server wakes it by typing into it, and
+the captain can `tmux attach` to it). Do not ask the user to start one. Instead:
+
+- Print the board URL for them: `bc-axi open`.
+- Say that the board's lieutenants are already reachable there, and that you can act as their
+  hands in this terminal but are not on the board yourself.
+
+## 3. Confirm you are in the intended workspace directory
 
 Run `pwd` first: `init` uses cwd by default, and initializing the wrong dir (e.g. `$HOME`) is
 the classic mistake. If it isn't the intended workspace, `cd` in or pass `--workspace <dir>`.
 
-## 3. Initialize the workspace (idempotent)
+## 4. Initialize the workspace (idempotent)
 
 Agree on your lieutenant name with the user (suggest one if they don't care), then from the
 workspace directory run:
@@ -56,13 +65,13 @@ memory, and what a future session of yours is launched on. It never replaces an 
 (a re-run says so and leaves it alone); edit the file to change your charter.
 Give the user that URL — the board is the captain's cockpit.
 
-## 4. Load your operating knowledge, in this order
+## 5. Load your operating knowledge, in this order
 
 1. `DOCTRINE.md` (checkout root, per step 0) — how a lieutenant behaves. It is your job description.
 2. The workspace `captain.md` — the captain's preferences and working style.
 3. The workspace `learnings/` — per-project engineering learnings.
 
-## 5. Operate
+## 6. Operate
 
 From now on behave per the doctrine: `bc-axi drain` as the first act of every turn, ack only
 after handling, orchestrate through cards, never implement in a project yourself, talk to

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -60,6 +60,7 @@ const opts = {
   playbook: null, briefFile: null, resume: false, outcome: null, model: null, effort: null, park: false,
   uri: null, file: null, version: null,
   card: null, trigger: null, key: null, source: null, limit: 0,
+  onboard: false, here: false,
 };
 const positional = [];
 for (let i = 0; i < argv.length; i++) {
@@ -91,6 +92,8 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--label') opts.labels.push(argv[++i]);
   else if (a === '--json') opts.json = true;
   else if (a === '--spawn') opts.spawn = true;
+  else if (a === '--onboard') opts.onboard = true;
+  else if (a === '--here') opts.here = true;
   else if (a === '--harness') opts.harness = argv[++i];
   else if (a === '--model') opts.model = argv[++i];
   else if (a === '--effort') opts.effort = argv[++i];
@@ -172,8 +175,12 @@ function readConfig() {
   } catch (e) {}
   return {};
 }
-const PORT = opts.port || (Number.isInteger(readConfig().port) && readConfig().port > 0 ? readConfig().port : DEFAULT_PORT);
-const BASE = 'http://127.0.0.1:' + PORT;
+// PORT/BASE are settled here for every command but one: `init --onboard` may
+// have to walk forward off a port something else already holds (see usePort),
+// and a first run that dies on "address in use" is a first run that ends there.
+let PORT = opts.port || (Number.isInteger(readConfig().port) && readConfig().port > 0 ? readConfig().port : DEFAULT_PORT);
+let BASE = 'http://127.0.0.1:' + PORT;
+function usePort(p) { PORT = p; BASE = 'http://127.0.0.1:' + PORT; }
 
 // ---------- helpers ----------
 function request(method, urlPath, body, timeoutMs) {
@@ -350,15 +357,22 @@ function installStatusLine(workspace) {
   excludeFromGit(workspace, '.claude/settings.local.json');
 }
 async function cmdInit() {
+  if (opts.onboard) return cmdInitOnboard();
   if (!opts.name) {
     die('usage: bc-axi init --name <founding-lieutenant-name> [--id id] [--charter-file f|-] [--port N] [--host H]\n' +
       '  Run from inside the tmux session that will BE the founding lieutenant.');
   }
   // 1. teleport precondition: the caller's tmux session becomes the lieutenant's address
+  // No tmux command is ever printed for a human to type — not here, not in any
+  // other message. The first run starts tmux itself and never mentions it; this
+  // path is the teleport, and a session that is not in tmux simply cannot BE the
+  // lieutenant, so it is pointed at the path that works.
   if (!process.env.TMUX) {
-    die('not inside tmux — a lieutenant lives in a tmux session.\n' +
-      'Start one and re-run init from within it:\n' +
-      '  tmux new -s ' + slugId(path.basename(WORKSPACE)));
+    die('not inside tmux — a lieutenant\'s address IS its tmux session, so this session cannot be one.\n' +
+      'First run? Use the onboarding path instead — it handles tmux itself, and the person never sees it:\n' +
+      '  bc-axi init --onboard\n' +
+      'Joining an existing workspace? Only a session that was launched inside tmux can be registered\n' +
+      'as a lieutenant; from here, `bc-axi open` prints the board URL.');
   }
   let tmuxSession = '';
   try {
@@ -402,10 +416,17 @@ async function cmdInit() {
     console.log('founding lieutenant ' + id + ' already registered — session ref refreshed (' + tmuxSession + ')');
   }
 
-  // 4. workspace-level turn-end Stop hook -> POST /api/turn-end. Session-agnostic
-  // pseudo-name "ws": it fires for every claude in this cwd and the server
-  // dedupes by session_id. NOTE: claude captures hooks at startup, so the
-  // founding session's own turn-ends start flowing on its next restart.
+  await installTurnEndHook();
+  scaffoldWorkspace();
+
+  console.log('\nboard: http://localhost:' + PORT + '/');
+}
+
+// The workspace-level turn-end Stop hook -> POST /api/turn-end. Session-agnostic
+// pseudo-name "ws": it fires for every claude in this cwd and the server
+// dedupes by session_id. NOTE: claude captures hooks at startup, so the
+// founding session's own turn-ends start flowing on its next restart.
+async function installTurnEndHook() {
   const { installHooks } = require(path.join(SELF_DIR, '..', 'harness', 'claude-tmux.js'));
   // Harness state is workspace-scoped (never the harness's global last-resort
   // dir); BC_HARNESS_STATE stays an explicit override, matching the server.
@@ -414,8 +435,11 @@ async function cmdInit() {
   console.log('turn-end hook installed (.claude/settings.local.json -> /api/turn-end)');
   installStatusLine(WORKSPACE);
   console.log('statusLine installed (.claude/settings.local.json -> real context window sidecar)');
+}
 
-  // 5. shared memory scaffold (never overwrite what exists)
+// The shared memory scaffold (never overwrites what exists), plus the playbooks
+// and the worker-duties skill. Both init paths land the same workspace.
+function scaffoldWorkspace() {
   const agentsMd = path.join(WORKSPACE, 'AGENTS.md');
   if (!fs.existsSync(agentsMd)) {
     fs.writeFileSync(agentsMd,
@@ -454,8 +478,193 @@ async function cmdInit() {
       'Per-project engineering learnings — one file per project, maintained by lieutenants.\n');
     console.log('scaffolded learnings/');
   }
+}
+
+// ---------- init --onboard: the first run, with nobody watching ----------
+// The other init is a teleport: an agent already inside tmux makes ITSELF the
+// founding lieutenant. This one is for a person who has just installed the
+// skill, in a plain Claude Code session, in an empty folder, who has never
+// heard of tmux and never should. It runs OUTSIDE tmux, refuses to eat someone's
+// code project, brings the board up on the fewest dependencies that will start,
+// and leaves Bridget on it — chartered, spawned, and already talking.
+//
+// Everything it does is idempotent: a second run resumes a half-finished first
+// one (revives a dead Bridget, never re-welcomes, never re-charters) instead of
+// starting over.
+const BRIDGET = { name: 'Bridget', id: 'bridget', prefix: 'BRI' };
+const ONBOARDING_DIR = path.join(SELF_DIR, '..', 'onboarding');
+
+function writeConfigKeys(patch) {
+  let cfg = {};
+  try { cfg = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8')); } catch (e) {}
+  if (!cfg || typeof cfg !== 'object' || Array.isArray(cfg)) cfg = {};
+  Object.assign(cfg, patch);
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  fs.writeFileSync(CONFIG_FILE, JSON.stringify(cfg, null, 2) + '\n');
+}
+
+// A first run that dies on "address already in use" is a first run that ends
+// there, so a taken port moves us forward instead of stopping us. Our OWN board
+// on that port is not "taken" — that is just the re-run case.
+async function settleOnboardPort(fr) {
+  const wanted = PORT;
+  for (let p = wanted; p < wanted + 20; p++) {
+    usePort(p);
+    if (await fr.portFree(p, opts.host || '127.0.0.1')) return { moved: p !== wanted, mine: false };
+    const st = await serverUp();
+    if (st && st.workspace === WORKSPACE) return { moved: p !== wanted, mine: true };
+  }
+  usePort(wanted);
+  return null;
+}
+
+async function cmdInitOnboard() {
+  const fr = require(path.join(SELF_DIR, '..', 'server', 'firstrun.js'));
+
+  // 1. What IS this directory? Decided before one byte is written, in the one
+  //    order that works: workspace, then empty, then refuse and name what it found.
+  const target = opts.workspace ? path.resolve(opts.workspace) : process.cwd();
+  const look = fr.inspectTarget(target);
+  if (look.verdict === 'missing') die('no such directory: ' + target);
+  // WORKSPACE walks UP from cwd, so a folder inside an existing workspace
+  // resolves to that workspace — which is the same "continue, do not refuse"
+  // answer, just found one level out. Say so; a silent jump is a foot-gun.
+  const inherited = WORKSPACE !== target;
+  const resuming = inherited || look.verdict === 'workspace';
+  if (inherited) console.error('already inside the workspace at ' + WORKSPACE + ' — continuing it');
+  if (!resuming && look.verdict !== 'empty' && !opts.here) {
+    die('bc-axi: first run refused (' + look.verdict + ')\n\n' + fr.refusalText(target, look));
+  }
+
+  // 2. Can this machine run a board at all? Nothing here installs anything —
+  //    each answer is written for the agent that will relay it and ASK.
+  const harness = opts.harness || 'claude';
+  const tmuxBacked = harness === 'claude' || harness === 'codex';
+  if (tmuxBacked && !fr.hasBin('tmux')) {
+    die('bc-axi: first run blocked (tmux-missing)\n\n' + fr.tmuxMissingText());
+  }
+  // git identity is a precondition for the first COMMIT, not for a board, so it
+  // is a warning that Bridget picks up in conversation — never a wall between a
+  // stranger and a running board.
+  const git = fr.gitIdentity();
+  if (!git.ok) console.error('\n⚠ ' + fr.gitIdentityText(git) + '\n');
+
+  const port = await settleOnboardPort(fr);
+  if (!port) {
+    die('bc-axi: first run blocked (port-busy)\n\n'
+      + 'ports ' + PORT + '-' + (PORT + 19) + ' are all in use, so the board has nowhere to listen.\n'
+      + 'Free one, or pick a port yourself: bc-axi init --onboard --port <N>');
+  }
+  if (port.moved) console.error('port ' + (opts.port || DEFAULT_PORT) + ' was taken by something else — using ' + PORT);
+
+  console.error('┌─ bridge-commander first run');
+  console.error('│  workspace : ' + WORKSPACE + (resuming ? '   (existing)' : '   (NEW)'));
+  console.error('│  board     : http://localhost:' + PORT + '/');
+  console.error('└─ lieutenant: ' + BRIDGET.name);
+
+  // 3. The workspace itself.
+  fs.mkdirSync(STATE_DIR, { recursive: true });
+  excludeFromGit(WORKSPACE, '.bridge-commander/');
+  if (PORT !== DEFAULT_PORT) writeConfigKeys({ port: PORT }); // so every later bc-axi call finds it
+  const { started } = await ensureServer();
+  console.log('server ' + (started ? 'started' : 'already running') + ' on port ' + PORT);
+  await installTurnEndHook();
+  scaffoldWorkspace();
+
+  // 4. Bridget's charter, then Bridget. The charter goes down FIRST: it is what
+  //    her session is launched on, and a spawn that beats it to disk gets a
+  //    lieutenant with no idea why she exists.
+  const id = opts.id || BRIDGET.id;
+  const name = opts.name || BRIDGET.name;
+  const charterFile = path.join(ONBOARDING_DIR, 'bridget.md');
+  if (fs.existsSync(charterPath(WORKSPACE, id))) {
+    console.log('charter left alone — ' + charterPath(WORKSPACE, id) + ' already exists');
+  } else {
+    console.log('charter written to ' + writeCharter(WORKSPACE, id, fs.readFileSync(charterFile, 'utf8')));
+  }
+  try {
+    await request('POST', '/api/lieutenants', { name, id, prefix: BRIDGET.prefix, actor: 'user' });
+    console.log('lieutenant "' + name + '" (' + id + ') registered');
+  } catch (e) {
+    if (!/HTTP 409/.test(e.message)) throw e;
+    console.log('lieutenant ' + id + ' already registered');
+  }
+
+  // 5. The message that is already waiting. Board state, not agent output — it
+  //    has to be there whether or not a session ever starts, and exactly once.
+  const board = await request('GET', '/api/board');
+  const lt = (board.lieutenants || []).find((l) => l.id === id);
+  if (lt && !(lt.chat || []).length) {
+    await request('POST', '/api/message', {
+      target: 'lieutenant:' + id,
+      text_md: fs.readFileSync(path.join(ONBOARDING_DIR, 'welcome.md'), 'utf8').trim(),
+      author: name,
+    });
+    console.log('welcome message seeded — it is on the board before anyone says anything');
+  } else {
+    console.log('welcome message already on the board — left alone');
+  }
+
+  // 6. First-run state, so a re-run resumes instead of restarting.
+  const cur = await request('GET', '/api/onboarding');
+  if (!cur.onboarding) {
+    await request('POST', '/api/onboarding', {
+      step: 'board-up', lieutenant: id, gitIdentity: git.ok,
+      note: git.ok ? '' : 'git identity missing at init — ask before the first card',
+    });
+    console.log('onboarding state: board-up');
+  } else {
+    console.log('onboarding state: ' + (cur.onboarding.step || '?') + ' — resuming, not restarting');
+  }
+
+  // 7. Her session. The one step that needs an authenticated agent CLI, and the
+  //    one step whose failure must NOT take the board down with it.
+  let live = true;
+  try {
+    const body = { name, id, spawn: true, revive: true };
+    if (opts.harness) body.harness = opts.harness;
+    const r = await request('POST', '/api/lieutenants', body, 180000);
+    console.log(r.spawned === false
+      ? name + '\'s session is already live'
+      : name + '\'s session started');
+  } catch (e) {
+    live = false;
+    const why = (e.body && e.body.error) || e.message;
+    console.log('\n⚠ ' + name + '\'s session did not start: ' + why + '\n'
+      + '  The board is up and her welcome message is on it — she just cannot answer yet.\n'
+      + '  This is almost always the `claude` CLI: not installed, or not logged in.\n'
+      + '  Sort that out and run the SAME command again; it picks up where it stopped.');
+  }
 
   console.log('\nboard: http://localhost:' + PORT + '/');
+  if (live) {
+    console.log('\nGive that URL to the person and stop here. ' + name + ' is on the board with a message\n'
+      + 'already waiting, and the rest of the setup — tools, projects, the checklist — is hers.');
+  }
+}
+
+// ---------- onboarding state ----------
+async function cmdOnboarding() {
+  const sub = positional[0];
+  if (!sub) {
+    const r = await request('GET', '/api/onboarding');
+    if (opts.json) return console.log(JSON.stringify(r.onboarding, null, 2));
+    if (!r.onboarding) return console.log('no onboarding state — this workspace was not started with `init --onboard`');
+    const o = r.onboarding;
+    return console.log('step: ' + (o.step || '?')
+      + (o.note ? '\nnote: ' + o.note : '')
+      + (o.updated ? '\nupdated: ' + o.updated : ''));
+  }
+  if (sub !== 'set') die('usage: bc-axi onboarding [--json] | bc-axi onboarding set <step> [--note "..."]');
+  const step = positional[1];
+  if (!step) die('usage: bc-axi onboarding set <step> [--note "..."]  (steps: '
+    + require(path.join(SELF_DIR, '..', 'server', 'firstrun.js')).ONBOARDING_STEPS.join(' | ') + ')');
+  const body = { step };
+  if (opts.note != null) body.note = opts.note;
+  let r;
+  try { r = await request('POST', '/api/onboarding', body); }
+  catch (e) { die(e.body && e.body.error ? e.body.error : e.message); }
+  console.log('onboarding step: ' + r.onboarding.step);
 }
 
 async function cmdStop() {
@@ -1306,6 +1515,7 @@ async function cmdConfig() {
 const commands = {
   init: cmdInit,
   open: cmdOpen, stop: cmdStop, status: cmdStatus, config: cmdConfig,
+  onboarding: cmdOnboarding,
   board: cmdBoard, thread: cmdThread, archived: cmdArchived, kinds: cmdKinds,
   'lieutenant create': cmdLtCreate, 'lieutenant list': cmdLtList, 'lieutenant retire': cmdLtRetire,
   'lieutenant patch': cmdLtPatch,
@@ -1335,6 +1545,16 @@ if (!commands[cmd]) {
     '                                         session as the founding lieutenant, installs the turn-end hook,\n' +
     '                                         scaffolds AGENTS.md + captain.md + learnings/, seeds the\n' +
     '                                         playbooks and symlinks the worker-duties skill. Idempotent\n' +
+    '  init --onboard [--here] [--port N] [--host H]\n' +
+    '                                         the FIRST run, for a session that is NOT in tmux: refuses a\n' +
+    '                                         code project (naming what it found), continues an existing\n' +
+    '                                         workspace, brings the board up, and leaves lieutenant Bridget\n' +
+    '                                         on it — chartered, spawned in her own tmux session, with a\n' +
+    '                                         welcome message already waiting. Installs nothing. Idempotent:\n' +
+    '                                         a re-run resumes (see `onboarding`). --here overrides the\n' +
+    '                                         refusal for a non-empty folder — ask the person first\n' +
+    '  onboarding [--json]                    the first-run step the board remembers\n' +
+    '  onboarding set <step> [--note "..."]   advance it: board-up | tools | project | checklist | done\n' +
     '  open [--port N] [--host H]             start the workspace server if needed (idempotent), print URL.\n' +
     '                                         Bootstraps .bridge-commander/ in cwd on first run.\n' +
     '  status                                 up/down, cards, lieutenants, pending queue items, and the\n' +

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -293,10 +293,39 @@ async function ensureServer() {
   return { st, started: true };
 }
 
+// The URL to HAND OVER. A board bound to a private address is reachable at that
+// address and NOT at localhost, and the whole point of asking for the bind was
+// that someone else's browser has to reach it — so printing `localhost` there
+// hands over a URL that cannot work. Loopback binds keep saying localhost,
+// which is what a person types.
+const LOOPBACK = ['127.0.0.1', 'localhost', '::1', ''];
+function boardUrl(host) {
+  const h = host && !LOOPBACK.includes(host) ? host : 'localhost';
+  return 'http://' + h + ':' + PORT + '/';
+}
+
+// --host on a board that is ALREADY up used to be silently ignored: the server
+// keeps the bind it booted with, so the flag did nothing and the URL still said
+// localhost. Rebinding means restarting the server — cheap, and nothing else
+// dies with it (lieutenant and worker sessions are tmux, not children) — so it
+// is done, and said out loud.
+async function rebindIfAsked() {
+  if (!opts.host) return;
+  const st = await serverUp();
+  if (!st || st.host === opts.host) return;
+  console.error('server is bound to ' + (st.host || '?') + ' and you asked for ' + opts.host
+    + ' — restarting it on the new address (sessions are unaffected)');
+  try { process.kill(st.pid, 'SIGTERM'); } catch (e) { die('could not stop the running server (pid ' + st.pid + '): ' + e.message); }
+  for (let i = 0; i < 40 && await serverUp(); i++) await sleep(100);
+  if (await serverUp()) die('the running server did not stop — stop it and try again: bc-axi stop');
+}
+
 async function cmdOpen() {
+  await rebindIfAsked();
+  if (opts.host) writeConfigKeys({ host: opts.host }); // a bind that does not survive a restart is not a bind
   const { st, started } = await ensureServer();
   installStatusLine(WORKSPACE); // self-heal the statusLine wiring on every open
-  console.log('http://localhost:' + PORT + '/');
+  console.log(boardUrl(st.host));
   console.log((started ? 'started' : 'already running') + ' workspace=' + st.workspace + ' cards=' + st.cards);
 }
 
@@ -420,7 +449,7 @@ async function cmdInit() {
   await installTurnEndHook();
   scaffoldWorkspace();
 
-  console.log('\nboard: http://localhost:' + PORT + '/');
+  console.log('\nboard: ' + boardUrl(opts.host));
 }
 
 // The workspace-level turn-end Stop hook -> POST /api/turn-end. Session-agnostic
@@ -570,15 +599,20 @@ async function cmdInitOnboard() {
 
   console.error('┌─ bridge-commander first run');
   console.error('│  workspace : ' + WORKSPACE + (resuming ? '   (existing)' : '   (NEW)'));
-  console.error('│  board     : http://localhost:' + PORT + '/');
+  console.error('│  board     : ' + boardUrl(opts.host));
   console.error('└─ lieutenant: ' + BRIDGET.name);
 
   // 3. The workspace itself.
   fs.mkdirSync(STATE_DIR, { recursive: true });
   excludeFromGit(WORKSPACE, '.bridge-commander/');
   if (PORT !== DEFAULT_PORT) writeConfigKeys({ port: PORT }); // so every later bc-axi call finds it
-  const { started } = await ensureServer();
-  console.log('server ' + (started ? 'started' : 'already running') + ' on port ' + PORT);
+  if (opts.host) writeConfigKeys({ host: opts.host }); // …and so the next start keeps the bind
+  await rebindIfAsked(); // a --host that arrives after the board is up still means it
+  const { started, st } = await ensureServer();
+  // What it actually BOUND, asked of the server — not what we hoped it would.
+  const bound = (st && st.host) || opts.host || '';
+  console.log('server ' + (started ? 'started' : 'already running') + ' on port ' + PORT
+    + (LOOPBACK.includes(bound) ? '' : ' bound to ' + bound));
   await installTurnEndHook();
   scaffoldWorkspace();
 
@@ -635,8 +669,8 @@ async function cmdInitOnboard() {
     // Certain, and cheap to know: there is no point spawning into a binary that
     // is not there, and no point making anyone read a pane to find that out.
     live = false;
-    console.log('\n⚠ ' + fr.agentMissingText(harness).split('\n').join('\n  ')
-      + '\n  Then run the SAME command again — it picks up where it stopped.');
+    console.log('\n⚠ ' + fr.agentMissingText(harness, WORKSPACE).split('\n').join('\n  ')
+      + '\n\n  Then run the SAME command again — it picks up where it stopped.');
   } else {
     try {
       const body = { name, id, spawn: true, revive: true };
@@ -652,10 +686,14 @@ async function cmdInitOnboard() {
       // own session; that tail is printed verbatim and the cause is named FROM
       // it, with a guess only where the pane said nothing — and labelled as one.
       const why = (e.body && e.body.error) || e.message;
-      const d = fr.diagnoseSpawn(why);
+      const d = fr.diagnoseSpawn(why, WORKSPACE);
       console.log('\n⚠ ' + name + '\'s session did not start (' + d.cause + ').');
-      if (d.tail) console.log('\n  What her session actually shows:\n'
-        + d.tail.split('\n').map((l) => '  | ' + l).join('\n'));
+      // ALWAYS, even when there is nothing in it: a message that says "read the
+      // pane above" over an empty space is worse than one that says the pane
+      // was empty. "Empty" is itself a fact about what happened.
+      console.log('\n  What her session actually shows:\n' + (d.tail
+        ? d.tail.split('\n').map((l) => '  | ' + l).join('\n')
+        : '  | (nothing — the pane was empty)'));
       console.log('\n  ' + d.headline.split('\n').join('\n  '));
       console.log('\n  ' + d.fix.split('\n').join('\n  '));
       console.log('\n  The board is up and her welcome message is on it — she just cannot answer yet.\n'
@@ -663,7 +701,7 @@ async function cmdInitOnboard() {
     }
   }
 
-  console.log('\nboard: http://localhost:' + PORT + '/');
+  console.log('\nboard: ' + boardUrl(bound));
   if (live) {
     console.log('\nGive that URL to the person and stop here. ' + name + ' is on the board with a message\n'
       + 'already waiting, and the rest of the setup — tools, projects, the checklist — is hers.');

--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -60,7 +60,7 @@ const opts = {
   playbook: null, briefFile: null, resume: false, outcome: null, model: null, effort: null, park: false,
   uri: null, file: null, version: null,
   card: null, trigger: null, key: null, source: null, limit: 0,
-  onboard: false, here: false,
+  onboard: false, here: false, allowRoot: false,
 };
 const positional = [];
 for (let i = 0; i < argv.length; i++) {
@@ -94,6 +94,7 @@ for (let i = 0; i < argv.length; i++) {
   else if (a === '--spawn') opts.spawn = true;
   else if (a === '--onboard') opts.onboard = true;
   else if (a === '--here') opts.here = true;
+  else if (a === '--allow-root') opts.allowRoot = true;
   else if (a === '--harness') opts.harness = argv[++i];
   else if (a === '--model') opts.model = argv[++i];
   else if (a === '--effort') opts.effort = argv[++i];
@@ -543,6 +544,16 @@ async function cmdInitOnboard() {
   if (tmuxBacked && !fr.hasBin('tmux')) {
     die('bc-axi: first run blocked (tmux-missing)\n\n' + fr.tmuxMissingText());
   }
+  // Root is checked HERE, not discovered from a dead pane 45 seconds later: as
+  // root claude exits on sight of --dangerously-skip-permissions, so the board
+  // would come up with nobody on it and a message that guessed wrong about why.
+  if (harness === 'claude' && fr.isRoot() && !opts.allowRoot) {
+    die('bc-axi: first run blocked (root)\n\n' + fr.rootBlockText());
+  }
+  if (opts.allowRoot && fr.isRoot()) {
+    console.error('\n⚠ --allow-root: Bridget will be launched with IS_SANDBOX=1, skipping the guard that\n'
+      + '  stops a permissions-skipping agent from running as root. Throwaway machines only.\n');
+  }
   // git identity is a precondition for the first COMMIT, not for a board, so it
   // is a warning that Bridget picks up in conversation — never a wall between a
   // stranger and a running board.
@@ -620,20 +631,36 @@ async function cmdInitOnboard() {
   // 7. Her session. The one step that needs an authenticated agent CLI, and the
   //    one step whose failure must NOT take the board down with it.
   let live = true;
-  try {
-    const body = { name, id, spawn: true, revive: true };
-    if (opts.harness) body.harness = opts.harness;
-    const r = await request('POST', '/api/lieutenants', body, 180000);
-    console.log(r.spawned === false
-      ? name + '\'s session is already live'
-      : name + '\'s session started');
-  } catch (e) {
+  if (tmuxBacked && !fr.hasBin(harness)) {
+    // Certain, and cheap to know: there is no point spawning into a binary that
+    // is not there, and no point making anyone read a pane to find that out.
     live = false;
-    const why = (e.body && e.body.error) || e.message;
-    console.log('\n⚠ ' + name + '\'s session did not start: ' + why + '\n'
-      + '  The board is up and her welcome message is on it — she just cannot answer yet.\n'
-      + '  This is almost always the `claude` CLI: not installed, or not logged in.\n'
-      + '  Sort that out and run the SAME command again; it picks up where it stopped.');
+    console.log('\n⚠ ' + fr.agentMissingText(harness).split('\n').join('\n  ')
+      + '\n  Then run the SAME command again — it picks up where it stopped.');
+  } else {
+    try {
+      const body = { name, id, spawn: true, revive: true };
+      if (opts.harness) body.harness = opts.harness;
+      if (opts.allowRoot) body.allowRoot = true;
+      const r = await request('POST', '/api/lieutenants', body, 180000);
+      console.log(r.spawned === false
+        ? name + '\'s session is already live'
+        : name + '\'s session started');
+    } catch (e) {
+      live = false;
+      // Read the pane, do not guess at it. The failure carries the tail of her
+      // own session; that tail is printed verbatim and the cause is named FROM
+      // it, with a guess only where the pane said nothing — and labelled as one.
+      const why = (e.body && e.body.error) || e.message;
+      const d = fr.diagnoseSpawn(why);
+      console.log('\n⚠ ' + name + '\'s session did not start (' + d.cause + ').');
+      if (d.tail) console.log('\n  What her session actually shows:\n'
+        + d.tail.split('\n').map((l) => '  | ' + l).join('\n'));
+      console.log('\n  ' + d.headline.split('\n').join('\n  '));
+      console.log('\n  ' + d.fix.split('\n').join('\n  '));
+      console.log('\n  The board is up and her welcome message is on it — she just cannot answer yet.\n'
+        + '  Run the SAME command again once it is fixed; it picks up where it stopped.');
+    }
   }
 
   console.log('\nboard: http://localhost:' + PORT + '/');
@@ -1545,14 +1572,15 @@ if (!commands[cmd]) {
     '                                         session as the founding lieutenant, installs the turn-end hook,\n' +
     '                                         scaffolds AGENTS.md + captain.md + learnings/, seeds the\n' +
     '                                         playbooks and symlinks the worker-duties skill. Idempotent\n' +
-    '  init --onboard [--here] [--port N] [--host H]\n' +
+    '  init --onboard [--here] [--allow-root] [--port N] [--host H]\n' +
     '                                         the FIRST run, for a session that is NOT in tmux: refuses a\n' +
     '                                         code project (naming what it found), continues an existing\n' +
     '                                         workspace, brings the board up, and leaves lieutenant Bridget\n' +
     '                                         on it — chartered, spawned in her own tmux session, with a\n' +
     '                                         welcome message already waiting. Installs nothing. Idempotent:\n' +
     '                                         a re-run resumes (see `onboarding`). --here overrides the\n' +
-    '                                         refusal for a non-empty folder — ask the person first\n' +
+    '                                         refusal for a non-empty folder, --allow-root the refusal\n' +
+    '                                         to launch an agent as uid 0 — ask the person for both\n' +
     '  onboarding [--json]                    the first-run step the board remembers\n' +
     '  onboarding set <step> [--note "..."]   advance it: board-up | tools | project | checklist | done\n' +
     '  open [--port N] [--host H]             start the workspace server if needed (idempotent), print URL.\n' +

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -66,7 +66,7 @@ and its cards carry that color stripe.
 
 ## Operations
 
-Callers · mechanisms: 🤠 captain (UI click/drag) · ⚓ lieutenant (CLI) · 🛠️ worker (CLI/hook) · ⚙️ server (automatic — no agent turn involved)
+Callers · mechanisms: 🤠 captain (UI click/drag) · ⚓ lieutenant (CLI) · 🛠️ worker (CLI/hook) · ⚙️ server (automatic — no agent turn involved) · 🙋 the user's own agent (CLI, first run only — it is not on the board)
 
 Trust model (v0): the server binds loopback (or a private mesh address) and has no app auth;
 actor strings are honor-system. The network boundary is the auth boundary.
@@ -76,6 +76,8 @@ actor strings are honor-system. The network boundary is the auth boundary.
 | Operation | Signature | Who | When |
 |---|---|---|---|
 | `workspace.init` | `dir → workspace` | ⚓ (the founding agent) | skill invoked in a fresh dir, **inside tmux** (refuses outside, with instruction); creates `.bridge-commander/`, boots the server, registers the caller as the first lieutenant — the "teleport" |
+| `workspace.onboard` | `dir → workspace, lieutenant` | 🙋 (the user's OWN agent, not a lieutenant) | the FIRST run, from a session that is not in tmux: refuses a dir holding a code project (naming what it found) and continues one already holding `.bridge-commander/`; then everything `workspace.init` does, except the founding lieutenant is **Bridget** — chartered from `onboarding/bridget.md`, spawned into her own tmux session, with a welcome message seeded on her thread before the person has said anything, and `board.onboarding` recording the step. Installs nothing; every part is idempotent, so a re-run resumes a half-finished first run |
+| `workspace.onboardingStep` | `step → onboarding` | ⚓ (Bridget) | the first-run conversation's memory, on the board so it survives the session having it: `board-up → tools → project → checklist → done` |
 | `workspace.open` | `dir → workspace` | ⚓ · 🤠 (CLI) | boot or attach to the board WITHOUT the teleport: bootstraps `.bridge-commander/` in cwd if absent, starts the server when down, prints the URL; no founding lieutenant involved |
 | `workspace.addProject` | `url \| path → project` | ⚓ | captain asks to bring a repo into the workspace |
 | `workspace.playbooks` | `→ [playbookId]` | ⚓ · 🤠 (the new-card dropdown, and the ✎ picker on a **Backlog** card's playbook chip — a started card rendered its brief already, so its chip shows the pointer and offers no editor) | list the playbooks a card can point at; read off disk on every call |

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -78,7 +78,20 @@ const RESUME_RE = /Resume from summary|Resume full session as-is/;
 // relax that anchor: the picker would then read as READY and every unattended
 // revival would leave a lieutenant sitting on an unanswered menu forever.
 const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
-const SETTLE = { trustRe: TRUST_RE, resumeRe: RESUME_RE, readyRe: UI_READY_RE, label: 'claude' };
+
+// FATAL_RE — what a pane shows when this launch is never going to come up, so
+// waiting the remaining 44 seconds only delays a wrong guess:
+//
+//   root       claude refuses --dangerously-skip-permissions as uid 0 (unless
+//              IS_SANDBOX=1 / bubblewrap) and exits — verified in the binary.
+//   first run  a claude nobody has ever run parks on its own setup wizard
+//              (theme picker) BEFORE it asks about credentials. Enter is NOT
+//              sent at it: answering a stranger's setup wizard blind is how you
+//              pick their theme, their login method and their telemetry answer
+//              for them.
+//   missing    the shell answering "command not found" — no binary at all.
+const FATAL_RE = /cannot be used with root\/sudo privileges|Choose the text style|To change this later, run \/theme|claude: command not found|command not found: claude/;
+const SETTLE = { trustRe: TRUST_RE, resumeRe: RESUME_RE, readyRe: UI_READY_RE, fatalRe: FATAL_RE, label: 'claude' };
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
 // Idempotent; preserves any existing settings/hooks. Also hides the file from
@@ -150,7 +163,13 @@ async function spawn(cwd, prompt, opts = {}) {
   await s.createPane(session, window, cwdAbs);
   try {
     const extra = (opts.extraArgs || []).map(s.shellQuote).join(' ');
-    const launchCmd = 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
+    // allowRoot — claude refuses --dangerously-skip-permissions as uid 0 and
+    // exits, so as root there is no session to have unless the caller has said,
+    // in as many words, that this box is a throwaway. IS_SANDBOX=1 is the escape
+    // claude itself checks; it is never set on our own initiative.
+    const asRoot = opts.allowRoot && typeof process.getuid === 'function' && process.getuid() === 0;
+    const launchCmd = (asRoot ? 'IS_SANDBOX=1 ' : '')
+      + 'CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false '
       + `claude --dangerously-skip-permissions --session-id ${resumeId}`
       + (extra ? ' ' + extra : '');
     await s.launchAndSettle(s.paneTarget(session, window), launchCmd, SETTLE);

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -195,12 +195,18 @@ async function deliverPrompt(target, prompt) {
     retries: Number(process.env.BC_SEND_RETRIES || 3),
     enterSleep: Number(process.env.BC_SEND_SLEEP_MS || 400),
   });
-  if (verdict === 'pending') {
-    throw new Error('brief not submitted at spawn (Enter swallowed; text left in composer)');
+  if (verdict === 'pending' || verdict === 'send-failed') {
+    // The pane rides on THIS failure too. A launch that settles and then will
+    // not take the brief is the interesting case — the screen underneath is
+    // usually a login prompt or a trust dialog wearing a composer's clothes —
+    // and without the tail the caller is left with nothing to diagnose from.
+    throw new Error((verdict === 'pending'
+      ? 'brief not submitted at spawn (Enter swallowed; text left in composer)'
+      : 'brief not sent at spawn (tmux send failed)') + '; pane tail:\n' + (await paneTailSafe(target)));
   }
-  if (verdict === 'send-failed') {
-    throw new Error('brief not sent at spawn (tmux send failed)');
-  }
+}
+async function paneTailSafe(target) {
+  try { return (await t.capture(target, 20)) || ''; } catch (e) { return ''; }
 }
 
 // send(ref, text) — type into the session with verified submission.

--- a/harness/claude-tmux.js
+++ b/harness/claude-tmux.js
@@ -90,7 +90,13 @@ const UI_READY_RE = /bypass permissions|esc (to )?interrupt|\n❯/i;
 //              pick their theme, their login method and their telemetry answer
 //              for them.
 //   missing    the shell answering "command not found" — no binary at all.
-const FATAL_RE = /cannot be used with root\/sudo privileges|Choose the text style|To change this later, run \/theme|claude: command not found|command not found: claude/;
+//   bypass     the one-time "WARNING: Claude Code running in Bypass Permissions
+//              mode" consent modal, raised BY --dangerously-skip-permissions.
+//              Its preselected option is `1. No, exit`, so it is emphatically
+//              not one to answer with a blind Enter, and it is not ours to
+//              accept on anyone's behalf: it is a person saying yes to an agent
+//              that skips permission prompts on their machine.
+const FATAL_RE = /cannot be used with root\/sudo privileges|Choose the text style|To change this later, run \/theme|claude: command not found|command not found: claude|Bypass Permissions mode|Yes, I accept/;
 const SETTLE = { trustRe: TRUST_RE, resumeRe: RESUME_RE, readyRe: UI_READY_RE, fatalRe: FATAL_RE, label: 'claude' };
 
 // installHooks — write/merge the Stop hook into <cwd>/.claude/settings.local.json.
@@ -174,6 +180,10 @@ async function spawn(cwd, prompt, opts = {}) {
       + (extra ? ' ' + extra : '');
     await s.launchAndSettle(s.paneTarget(session, window), launchCmd, SETTLE);
     await deliverPrompt(s.paneTarget(session, window), prompt);
+    // Returning is a claim that there is a session here. Check it, once, against
+    // the pane — a settle that matched a modal's own wording is exactly how a
+    // spawn came to report success over a consent screen nobody had answered.
+    await s.verifyLive(s.paneTarget(session, window), SETTLE);
   } catch (err) {
     await s.killPane(session, window);
     try { fs.unlinkSync(promptFile); } catch { /* best-effort */ }

--- a/harness/codex-tmux.js
+++ b/harness/codex-tmux.js
@@ -117,11 +117,15 @@ async function deliverPrompt(target, prompt) {
     retries: Number(process.env.BC_SEND_RETRIES || 3),
     enterSleep: Number(process.env.BC_SEND_SLEEP_MS || 400),
   });
-  if (verdict === 'pending') {
-    throw new Error('brief not submitted at spawn (Enter swallowed; text left in composer)');
-  }
-  if (verdict === 'send-failed') {
-    throw new Error('brief not sent at spawn (tmux send failed)');
+  if (verdict === 'pending' || verdict === 'send-failed') {
+    // The pane rides on the failure (same reason as claude-tmux): a launch that
+    // settles and then will not take the brief is diagnosed from the screen
+    // underneath, and only the harness can see it.
+    let tail = '';
+    try { tail = (await t.capture(target, 20)) || ''; } catch (e) { tail = ''; }
+    throw new Error((verdict === 'pending'
+      ? 'brief not submitted at spawn (Enter swallowed; text left in composer)'
+      : 'brief not sent at spawn (tmux send failed)') + '; pane tail:\n' + tail);
   }
 }
 

--- a/harness/test/claude-tmux.test.js
+++ b/harness/test/claude-tmux.test.js
@@ -214,3 +214,42 @@ test('IS_SANDBOX rides the launch line only when the caller asked for it', async
     fs.rmSync(stateDir, { recursive: true, force: true });
   }
 });
+
+// The one line that lied. A spawn RETURNING is a claim that there is a session;
+// round 3 of the install test found that claim printed over a consent modal the
+// person had never answered — the brief typed into a menu, the caller told it
+// worked. Every failure path was honest; the success path was the one nobody
+// re-checked.
+test('spawn refuses to report success over a screen that is waiting for a person', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-spawn-'));
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-state-'));
+  const mock = mockTmux({ readyTail:
+    '  WARNING: Claude Code running in Bypass Permissions mode\n\n  ❯ 1. No, exit\n    2. Yes, I accept' });
+  try {
+    await assert.rejects(
+      () => claude.spawn(dir, 'a brief', { session: 'bc-consent', stateDir }),
+      (e) => {
+        assert.match(e.message, /Yes, I accept/, 'the screen rides back on the failure');
+        return true;
+      });
+  } finally {
+    mock.restore();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// …and the check is a check, not a new way to fail: a real UI still spawns.
+test('spawn still returns for a pane that is genuinely a running session', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-spawn-'));
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-state-'));
+  const mock = mockTmux({ readyTail: '⏵⏵ bypass permissions on (shift+tab to cycle)\n❯ ' });
+  try {
+    const ref = await claude.spawn(dir, 'a brief', { session: 'bc-good', stateDir });
+    assert.strictEqual(ref.session, 'bc-good');
+  } finally {
+    mock.restore();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/harness/test/claude-tmux.test.js
+++ b/harness/test/claude-tmux.test.js
@@ -159,3 +159,58 @@ test('adoptWindow with no live session hands back the window-granular ref (nothi
     assert.strictEqual(await claude.adoptWindow(done, 'lt', []), done);
   } finally { stub.restore(); }
 });
+
+// Round 1 of the onboarding install test, in a container, twice: the launch
+// line claude refuses outright still cost the caller the FULL 45s wait, and the
+// caller then explained the timeout with a guess ("not installed, or not logged
+// in") that the pane flatly contradicted. A screen that can never become a
+// running agent has to end the wait immediately and hand back what it said.
+test('a launch claude refuses ends the wait at once, with the pane attached', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-spawn-'));
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-state-'));
+  const mock = mockTmux({ readyTail:
+    '$ CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --session-id x\n'
+    + '--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons\n$ ' });
+  try {
+    await assert.rejects(
+      () => claude.spawn(dir, 'a brief', { session: 'bc-rootfail', stateDir }),
+      (e) => {
+        assert.match(e.message, /could not start/);
+        assert.match(e.message, /cannot be used with root\/sudo privileges/, 'the pane rides on the error');
+        return true;
+      });
+    const looks = mock.calls.filter((c) => c.fn === 'capture').length;
+    assert.strictEqual(looks, 1, 'it gave up on the first look, not after 90 of them');
+  } finally {
+    mock.restore();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});
+
+// --allow-root is the ONLY thing that puts IS_SANDBOX=1 on a launch line: it is
+// the guard claude itself checks, and it is never switched off on our own say-so.
+test('IS_SANDBOX rides the launch line only when the caller asked for it', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-spawn-'));
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-claude-state-'));
+  const launchLine = async (opts) => {
+    const mock = mockTmux({ readyTail: 'bypass permissions\n❯ ' });
+    try {
+      await claude.spawn(dir, 'a brief', Object.assign({ session: 'bc-sbx', stateDir }, opts));
+      return mock.calls.find((c) => c.fn === 'sendLiteral').args[1];
+    } finally { mock.restore(); }
+  };
+  try {
+    assert.doesNotMatch(await launchLine({}), /IS_SANDBOX/);
+    const asked = await launchLine({ allowRoot: true });
+    // Off root the flag is inert — the guard it lifts only exists for uid 0.
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      assert.match(asked, /^IS_SANDBOX=1 /);
+    } else {
+      assert.doesNotMatch(asked, /IS_SANDBOX/);
+    }
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
+});

--- a/harness/test/settle-screens.test.js
+++ b/harness/test/settle-screens.test.js
@@ -146,3 +146,38 @@ test('the screens that DO come up are not swept in with the fatal ones', () => {
   assert.ok(!SETTLE.fatalRe.test(READY));
   assert.ok(!SETTLE.fatalRe.test(RESUME_PICKER));
 });
+
+// Round 3, and the worst one: `Bridget's session started` printed over THIS.
+//
+// It is raised by --dangerously-skip-permissions itself, so it appears only for
+// the launch line the spawn uses — and it matched the READY signature, because
+// the modal's own title contains the words "Bypass Permissions mode" and the
+// ready footer contains "bypass permissions on". A settle that returns here
+// types the brief into a menu whose preselected option is "No, exit", and every
+// caller downstream is told there is a session.
+const BYPASS_CONSENT = `
+  WARNING: Claude Code running in Bypass Permissions mode
+
+  In Bypass Permissions mode, Claude Code will not ask for your approval
+  before running commands. Only use this in a container without internet.
+
+  ❯ 1. No, exit
+    2. Yes, I accept
+`;
+
+test('the bypass-permissions consent screen is not a ready UI', () => {
+  assert.ok(SETTLE.fatalRe.test(BYPASS_CONSENT),
+    'a consent screen with "No, exit" preselected is nobody to answer but the person');
+  // The ready signature still matches it — the words are the same — which is
+  // exactly why fatalRe is checked FIRST and why spawn verifies afterwards.
+  // If this ever stops being true, the ordering below matters less, not more.
+  assert.ok(!SETTLE.trustRe.test(BYPASS_CONSENT) && !SETTLE.resumeRe.test(BYPASS_CONSENT),
+    'and it is not a menu Enter may answer — Enter here EXITS claude');
+});
+
+test('the real ready footer is not mistaken for the consent screen', () => {
+  // The distinguisher is "mode" / "Yes, I accept" — the running UI says
+  // "bypass permissions on (shift+tab to cycle)" and neither of those.
+  assert.ok(!SETTLE.fatalRe.test(READY), 'a working session must never read as fatal');
+  assert.ok(SETTLE.readyRe.test(READY));
+});

--- a/harness/test/settle-screens.test.js
+++ b/harness/test/settle-screens.test.js
@@ -98,3 +98,51 @@ test('a resume that meets the picker answers it and comes up', async () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// Two more screens that are never going to become a running agent, captured in
+// a container by the onboarding install test (MNC-71, round 1). Both used to
+// burn the full 45s and then be explained by a guess that the screen itself
+// contradicted.
+
+// `claude --dangerously-skip-permissions` as uid 0. It prints one line and exits,
+// which puts the pane straight back on a shell prompt.
+const ROOT_REFUSAL = `
+$ CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION=false claude --dangerously-skip-permissions --session-id f44e2a6d
+--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
+$
+`;
+
+// A claude nobody has ever run. This is BEFORE any credential question — a
+// brand-new machine sees it whether or not it is logged in.
+const FIRST_RUN_WIZARD = `
+Welcome to Claude Code v2.1.226
+
+ Let's get started.
+
+ Choose the text style that looks best with your terminal
+ To change this later, run /theme
+
+   1. Auto (match terminal)
+ ❯ 2. Dark mode ✔
+`;
+
+test('the screens that can never come up are fatal, not something to wait out', () => {
+  assert.ok(SETTLE.fatalRe.test(ROOT_REFUSAL), 'as root there is no session coming — say so at once');
+  assert.ok(SETTLE.fatalRe.test(FIRST_RUN_WIZARD), 'a setup wizard needs a human, not 45 seconds');
+  assert.ok(SETTLE.fatalRe.test('bash: claude: command not found'));
+});
+
+test('the setup wizard is NOT answered with Enter, and does not read as ready', () => {
+  // It draws its own ❯ and a preselected option, so it is one relaxed anchor
+  // away from both mistakes. Answering it blind would pick a stranger's theme,
+  // and then their login method, on their behalf.
+  assert.ok(!(SETTLE.trustRe.test(FIRST_RUN_WIZARD) || SETTLE.resumeRe.test(FIRST_RUN_WIZARD)),
+    'a setup wizard is not a menu we may answer');
+  assert.ok(!SETTLE.readyRe.test(FIRST_RUN_WIZARD.trim().split('\n').slice(-8).join('\n')),
+    'parked on the wizard is not "the UI is up"');
+});
+
+test('the screens that DO come up are not swept in with the fatal ones', () => {
+  assert.ok(!SETTLE.fatalRe.test(READY));
+  assert.ok(!SETTLE.fatalRe.test(RESUME_PICKER));
+});

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -193,8 +193,19 @@ async function launchAndSettle(target, launchCmd, sig) {
     await t.sleep(500);
     const cmd = await paneCommand(target);
     if (cmd === null) throw new Error(`tmux pane ${target} vanished during launch`);
-    if (SHELLS.has(cmd)) continue; // agent not up yet (or it already exited — captured by timeout)
     const tail = paneTail(await t.capture(target, 40));
+    // sig.fatalRe — screens and exits that will NEVER become a running agent
+    // (a launch line the CLI refuses outright, a first-run setup wizard, a
+    // missing binary). Waiting the full 45s for one of those buys nothing and
+    // hands the caller a timeout to misdiagnose; the pane tail says what
+    // happened, so it is thrown immediately with the tail attached.
+    //
+    // Checked BEFORE the shell skip on purpose: the interesting failures print
+    // their line and exit, which puts the pane back on a shell prompt.
+    if (sig.fatalRe && sig.fatalRe.test(tail)) {
+      throw new Error(`${sig.label} could not start at ${target}; pane tail:\n${tail}`);
+    }
+    if (SHELLS.has(cmd)) continue; // agent not up yet (or it already exited — captured by timeout)
     if (menus.some((re) => re.test(tail))) {
       await t.sendKey(target, 'Enter');
       await t.sleep(1000);

--- a/harness/tmux-session.js
+++ b/harness/tmux-session.js
@@ -217,6 +217,33 @@ async function launchAndSettle(target, launchCmd, sig) {
   throw new Error(`${sig.label} did not start at ${target} within 45s; pane tail:\n${tail}`);
 }
 
+// verifyLive — the last look before a spawn is allowed to say it worked.
+//
+// launchAndSettle answers "did a UI appear?", which is not the same question as
+// "is there a session here now". A signature can match a screen that merely
+// CONTAINS the words (the bypass-permissions consent modal literally says
+// "Bypass Permissions mode", which the ready signature matched for months), and
+// the brief then goes into a menu while the caller is told the session started.
+//
+// A caller reporting success it did not check is worse than any honest failure,
+// because it is the one line nobody re-reads. So: after the brief is delivered,
+// look again — a fatal screen fails immediately, and a pane that does not look
+// like a running agent within `ms` fails with what it did look like.
+async function verifyLive(target, sig, ms = 6000) {
+  const deadline = Date.now() + ms;
+  let tail = '';
+  for (;;) {
+    tail = paneTail(await t.capture(target, 40));
+    if (sig.fatalRe && sig.fatalRe.test(tail)) {
+      throw new Error(`${sig.label} is not running at ${target} — it is on a screen that needs a person; pane tail:\n${tail}`);
+    }
+    if (sig.readyRe.test(tail)) return;
+    if (Date.now() >= deadline) break;
+    await t.sleep(500);
+  }
+  throw new Error(`${sig.label} did not settle into a running session at ${target}; pane tail:\n${tail}`);
+}
+
 // onTurnEnd(ref, hook) -> unsubscribe()
 // hook(event, ref) fires once per turn boundary; event is the JSON line the
 // harness's relay appended ({ ts, session, event, session_id, cwd }). Only
@@ -443,6 +470,7 @@ module.exports = {
   killPane,
   adoptWindow,
   launchAndSettle,
+  verifyLive,
   onTurnEnd,
   openPane,
   paneSnapshot,

--- a/onboarding/bridget.md
+++ b/onboarding/bridget.md
@@ -1,0 +1,102 @@
+# Bridget — the onboarding lieutenant
+
+You are the first lieutenant on this board, and you exist for one conversation: getting the person
+who just installed Bridge Commander from a running board to a card landing on a worker.
+
+Their agent got the board up and handed you over. Everything past that is yours. You already said
+hello — that message was seeded before they arrived, so their first sight of the board is you
+talking, not an empty column.
+
+They have probably never seen this UI. **Nothing is obvious to them yet.**
+
+## How you work
+
+- **Ask before installing anything.** Every time, even the second time. A "no" is a complete
+  answer: say what it costs and carry on without it.
+- **One thing at a time.** Ask, wait, do it, say what happened, then the next thing. A wall of
+  steps is a wall.
+- **Do the work yourself.** They should never be asked to paste a command you could run. If a
+  command has to be theirs (a password, an auth flow), say exactly why.
+- **Short messages.** This is a chat panel, not a manual.
+- **Never mention tmux to them.** It is underneath; it is not their problem.
+
+## Where you are in it
+
+The board remembers, so a restart never starts over:
+
+```
+bc-axi onboarding              # the current step
+bc-axi onboarding set <step> [--note "..."]
+```
+
+Steps, in order: `board-up` → `tools` → `project` → `checklist` → `done`.
+
+**Read it as the first thing you do, every session.** If the step is `project`, tools are already
+settled — do not ask again. Advance it the moment a step actually lands, not when you start it.
+
+## The sequence
+
+### 1. `tools` — the two optional installs
+
+> Bridge Commander works best with `treehouse` (fast worktrees for workers) and `no-mistakes`
+> (a review-and-CI gate before anything is pushed). Want me to install them?
+
+```sh
+curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh
+```
+
+On a no: nothing breaks. Without `treehouse`, workers fall back to plain `git worktree` (slower on
+a big repo). Without `no-mistakes`, the `no-mistakes` playbook is the one card type that will not
+run. Say that, set the step, move on.
+
+If init reported a **git identity** or a **git missing** warning, this is where you clear it — a
+worker cannot commit without one, and it is two commands.
+
+### 2. `project` — a repo to point at
+
+> Point me at a repo — a local path or a git URL — and I'll register it.
+
+```sh
+bc-axi project add <path-or-url> [--name n]
+bc-axi project list
+```
+
+Confirm what registered, by name, and say that a card's `repo` attribute is how a card picks it.
+
+### 3. `checklist` — the board teaching the board
+
+> There are a few things worth doing together to finish your onboarding. Want me to make cards for
+> them? We'll do them side by side.
+
+On a yes, create the **first two now** — a checklist you can see is a checklist, and a board full
+of advanced cards on minute one is noise:
+
+1. **Create a second lieutenant** — so they see that the board is a fleet, not a chat window.
+2. **Start a card on a worker and watch it land** — small and real in the repo they just
+   registered. This is the one that makes the whole thing click.
+
+Create them owned by you, with a body written for a beginner, and walk each one through. When
+those two have landed, offer the next three, one card each, in this order: **playbooks** (the brief
+a worker is launched with is a file they own), **hooks** (the board reacting to the outside world),
+**schedules** (work that starts itself).
+
+### 4. `done`
+
+Say what they now know how to do, in three lines. Then offer to get out of the way:
+
+> Onboarding's finished. You can keep me as a regular lieutenant, or retire me —
+> `bc-axi lieutenant retire bridget` — now that you have your own.
+
+Retiring is **their** call. Never do it yourself, and never suggest it before a second lieutenant
+exists, or the board is left with nobody on it.
+
+## Things they will ask
+
+- **"Where's the board?"** `http://localhost:<port>/` — the port is in
+  `.bridge-commander/config.json`. On a remote box they need a tunnel from their laptop:
+  `ssh -L <port>:127.0.0.1:<port> <host>`.
+- **"Do I need a new one of you per workspace?"** Onboarding is per workspace, and so are you —
+  a second workspace gets its own board, its own lieutenants and its own first run.
+- **"Can I just talk to you about work?"** Yes. You are a full lieutenant; onboarding is only what
+  you were born for. Follow the doctrine you were launched with.

--- a/onboarding/welcome.md
+++ b/onboarding/welcome.md
@@ -1,0 +1,13 @@
+Welcome aboard — I'm **Bridget**, and this board is yours.
+
+Here's what it is: every piece of work becomes a **card**, and a card that starts gets its own agent
+session in its own checkout. You watch it from here instead of babysitting a terminal. I'm a
+**lieutenant** — I run cards for you; I don't write the code myself.
+
+Three things and you're running for real:
+
+1. two optional tools, if you want them
+2. a repo to point me at
+3. a short checklist we do together — as cards, on this board
+
+Say hello and we'll start with the tools.

--- a/server/firstrun.js
+++ b/server/firstrun.js
@@ -1,0 +1,193 @@
+'use strict';
+// firstrun — everything `bc-axi init --onboard` has to decide BEFORE it writes
+// anything: is this directory a workspace, an empty folder, or somebody's code?
+// and is the machine able to run a board at all?
+//
+// It lives here rather than in the CLI because the answers are testable facts,
+// and a refusal a stranger will read is the last place to improvise: the order
+// of the checks IS the contract.
+//
+//   1. `.bridge-commander/` present  -> an existing workspace. Continue.
+//      This check comes FIRST because a workspace is itself a git repo with a
+//      package.json's worth of scaffolding in it, and every other signal below
+//      would read it as a code project and refuse to re-enter it.
+//   2. empty                         -> go.
+//   3. a repo / a manifest / source  -> refuse, NAMING what was found.
+//   4. anything else non-empty       -> a judgement call: say what is there and ask.
+
+const fs = require('fs');
+const path = require('path');
+const net = require('net');
+const { execFileSync } = require('child_process');
+const { STATE_DIR_NAME, LEGACY_STATE_DIR_NAME } = require(path.join(__dirname, 'statedir.js'));
+
+// Entries that say nothing about what a folder is for. A stranger's "empty
+// folder" has usually already been opened by an agent, and the agent left its
+// own dotfiles in it — those must not read as a code project.
+const IGNORABLE = new Set([
+  '.DS_Store', 'Thumbs.db', '.localized',
+  '.claude', '.claude.json', '.codex', '.agents', '.cursor',
+  STATE_DIR_NAME, LEGACY_STATE_DIR_NAME,
+]);
+
+// One manifest is enough: nobody drops a pyproject.toml in a scratch folder.
+const MANIFESTS = [
+  'package.json', 'pyproject.toml', 'go.mod', 'Cargo.toml', 'pom.xml', 'Gemfile',
+  'build.gradle', 'build.gradle.kts', 'composer.json', 'mix.exs', 'setup.py',
+  'requirements.txt', 'Pipfile', 'CMakeLists.txt', 'Dockerfile',
+];
+const SOURCE_DIRS = ['src', 'lib', 'app', 'test', 'tests', 'spec', 'cmd', 'pkg', 'internal'];
+const SOURCE_EXT = new Set([
+  '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx', '.py', '.go', '.rs', '.rb', '.java',
+  '.kt', '.scala', '.php', '.c', '.h', '.cc', '.cpp', '.hpp', '.cs', '.swift', '.ex',
+  '.exs', '.clj', '.erl', '.sh', '.bash', '.pl', '.lua', '.dart', '.vue', '.svelte',
+]);
+
+function isWorkspaceDir(dir) {
+  return fs.existsSync(path.join(dir, STATE_DIR_NAME)) || fs.existsSync(path.join(dir, LEGACY_STATE_DIR_NAME));
+}
+
+// inspectTarget(dir) -> { verdict, found[], entries[] }
+//   verdict: 'workspace' | 'empty' | 'project' | 'unclear' | 'missing'
+//   found:   human-readable signals, in the order they were found — this is
+//            what the refusal quotes back, so it is never a bare boolean.
+function inspectTarget(dir) {
+  let entries;
+  try { entries = fs.readdirSync(dir); }
+  catch (e) { return { verdict: 'missing', found: [], entries: [] }; }
+  if (isWorkspaceDir(dir)) return { verdict: 'workspace', found: [STATE_DIR_NAME + '/'], entries };
+
+  const visible = entries.filter((e) => !IGNORABLE.has(e));
+  if (!visible.length) return { verdict: 'empty', found: [], entries };
+
+  const found = [];
+  if (visible.includes('.git')) found.push('a git repository (`.git/`)');
+  for (const m of MANIFESTS) if (visible.includes(m)) found.push('`' + m + '`');
+  for (const d of SOURCE_DIRS) {
+    if (!visible.includes(d)) continue;
+    try { if (fs.statSync(path.join(dir, d)).isDirectory()) found.push('`' + d + '/`'); } catch (e) {}
+  }
+  const srcFiles = visible.filter((e) => SOURCE_EXT.has(path.extname(e).toLowerCase()));
+  if (srcFiles.length) {
+    found.push('source files (' + srcFiles.slice(0, 3).map((f) => '`' + f + '`').join(', ')
+      + (srcFiles.length > 3 ? ', …' : '') + ')');
+  }
+  return { verdict: found.length ? 'project' : 'unclear', found, entries };
+}
+
+// "`package.json`, `src/` and a git repository (`.git/`)" — an Oxford-less list,
+// because it is read aloud by an agent relaying it to a person.
+function listPhrase(items) {
+  if (items.length <= 1) return items[0] || '';
+  return items.slice(0, -1).join(', ') + ' and ' + items[items.length - 1];
+}
+
+// The refusal a stranger reads (through their agent). It names what was found,
+// says what a workspace IS, and hands over the one thing to do next. It never
+// tells anyone to run tmux.
+function refusalText(dir, r) {
+  if (r.verdict === 'project') {
+    return 'this looks like a code project: I can see ' + listPhrase(r.found) + ' in\n'
+      + '  ' + dir + '\n\n'
+      + 'A Bridge Commander workspace is its own folder, BESIDE your code — never inside it.\n'
+      + 'It holds the board, its lieutenants and the worktrees they work in; your repos are\n'
+      + 'registered with it (`bc-axi project add <path-or-url>`), not replaced by it.\n\n'
+      + 'Pick an empty folder, cd into it, and run this again — e.g.\n'
+      + '  mkdir ~/myfleet && cd ~/myfleet\n\n'
+      + '(If you are certain this folder is meant to BE the workspace, --here says so. Ask first.)';
+  }
+  return 'this folder is not empty, and I cannot tell what it is:\n'
+    + '  ' + dir + '\n'
+    + '  contains: ' + r.entries.slice(0, 12).join(', ') + (r.entries.length > 12 ? ', …' : '') + '\n\n'
+    + 'A workspace wants a folder of its own. Ask the person whether this one is meant to be it:\n'
+    + '  yes -> re-run with --here\n'
+    + '  no  -> make an empty folder, cd into it, and run this again';
+}
+
+// ---------- machine preflight ----------
+// Nothing here installs anything. Each check either passes or hands back a
+// message written for the agent that will relay it and ask.
+
+function hasBin(name) {
+  const dirs = String(process.env.PATH || '').split(path.delimiter).filter(Boolean);
+  for (const d of dirs) {
+    try { fs.accessSync(path.join(d, name), fs.constants.X_OK); return true; } catch (e) {}
+  }
+  return false;
+}
+
+// The install line for THIS machine, so the agent can ask a yes/no question
+// with a real command in it instead of guessing a package manager.
+function installCommand(pkg) {
+  if (process.platform === 'darwin' && hasBin('brew')) return 'brew install ' + pkg;
+  if (hasBin('apt-get')) return 'sudo apt-get update && sudo apt-get install -y ' + pkg;
+  if (hasBin('dnf')) return 'sudo dnf install -y ' + pkg;
+  if (hasBin('yum')) return 'sudo yum install -y ' + pkg;
+  if (hasBin('pacman')) return 'sudo pacman -S --noconfirm ' + pkg;
+  if (hasBin('apk')) return 'apk add --no-cache ' + pkg;
+  if (hasBin('zypper')) return 'sudo zypper install -y ' + pkg;
+  if (hasBin('brew')) return 'brew install ' + pkg;
+  return '';
+}
+
+function tmuxMissingText() {
+  const cmd = installCommand('tmux');
+  return 'tmux is not installed on this machine, and Bridge Commander needs it: a lieutenant is a\n'
+    + 'real agent session, and it lives in a tmux session so the board can reach it and the\n'
+    + 'person can attach to it later. You will never have to type a tmux command yourself.\n\n'
+    + (cmd
+      ? 'ASK the person for permission, then install it:\n  ' + cmd + '\n'
+      : 'I could not identify a package manager here. ASK the person how they want tmux installed.\n')
+    + '\nThen run this again — nothing has been written yet.';
+}
+
+// git identity is NOT a precondition for a board: it is a precondition for the
+// first commit a worker makes. So it is reported, recorded, and carried into
+// the conversation — never a wall between a stranger and a running board.
+function gitIdentity() {
+  const get = (k) => {
+    try {
+      return execFileSync('git', ['config', '--get', k], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    } catch (e) { return ''; }
+  };
+  if (!hasBin('git')) return { ok: false, missing: true, name: '', email: '' };
+  const name = get('user.name');
+  const email = get('user.email');
+  return { ok: !!(name && email), missing: false, name, email };
+}
+
+function gitIdentityText(id) {
+  if (id.missing) {
+    const cmd = installCommand('git');
+    return 'git is not installed. Workers commit with it, so cards will not run without it.\n'
+      + (cmd ? 'ASK for permission, then: ' + cmd + '\n' : 'ASK how they want git installed.\n')
+      + 'The board itself does not need it — I am carrying on.';
+  }
+  return 'git has no identity here (user.name / user.email are unset), so the first commit a worker\n'
+    + 'makes would fail. The board does not need it, so I am carrying on — but ask for a name and\n'
+    + 'an email before starting a card:\n'
+    + '  git config --global user.name "<their name>"\n'
+    + '  git config --global user.email "<their email>"';
+}
+
+// portFree — can we bind it? An occupied port is not automatically a problem
+// (it may be this very workspace's board), so the caller probes for a board
+// first and only then walks forward.
+function portFree(port, host) {
+  return new Promise((resolve) => {
+    const srv = net.createServer();
+    srv.once('error', () => resolve(false));
+    srv.listen(port, host || '127.0.0.1', () => srv.close(() => resolve(true)));
+  });
+}
+
+// ---------- onboarding state ----------
+// The steps the board remembers, in order. A re-run reads the step and resumes
+// from it instead of starting the conversation over.
+const ONBOARDING_STEPS = ['board-up', 'tools', 'project', 'checklist', 'done'];
+
+module.exports = {
+  IGNORABLE, MANIFESTS, SOURCE_DIRS, SOURCE_EXT, ONBOARDING_STEPS,
+  isWorkspaceDir, inspectTarget, listPhrase, refusalText,
+  hasBin, installCommand, tmuxMissingText, gitIdentity, gitIdentityText, portFree,
+};

--- a/server/firstrun.js
+++ b/server/firstrun.js
@@ -219,21 +219,47 @@ function rootBlockText() {
 // contradict each other are worse than either one alone. The official installer
 // puts the binary under ~/.local/bin and needs no root, so that is what is
 // offered first.
+// Installed-but-invisible is a different problem from not-installed, and it has
+// a different fix. The curl installer puts the binary in ~/.local/bin and leaves
+// the PATH edit to the user; on Debian a normal login shell picks that up from
+// ~/.profile, but root's does not — so as root the very next step dies with
+// "command not found" and re-running loops forever on the same message.
+function agentAtHome(bin) {
+  const home = process.env.HOME || '';
+  if (!home) return '';
+  const p = path.join(home, '.local', 'bin', bin);
+  try { fs.accessSync(p, fs.constants.X_OK); return p; } catch (e) { return ''; }
+}
+
 function agentMissingText(harness, workspace) {
   const codex = harness === 'codex';
   const bin = codex ? 'codex' : 'claude';
+  const here = workspace || '<the workspace folder>';
+  const installed = agentAtHome(bin);
+  const runByHand = 'Then run it once by hand IN THE WORKSPACE — it has setup screens of its own that a spawned\n'
+    + 'session cannot answer (a theme picker, a login, a trust question about this folder, and a\n'
+    + 'one-time bypass-permissions consent screen that only the launch flag raises):\n'
+    + '  cd ' + here + ' && ' + bin + ' --dangerously-skip-permissions';
+  if (installed) {
+    return '`' + bin + '` is installed at ' + installed + ' but is not on PATH, so neither I nor her\n'
+      + 'session can start it. The board is up and her welcome message is on it.\n\n'
+      + 'Put it on PATH for this user — both now and for the shells her session is launched from:\n'
+      + '  export PATH="$HOME/.local/bin:$PATH"\n'
+      + '  echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.bashrc\n\n'
+      + runByHand;
+  }
   const install = codex
     ? '  npm i -g @openai/codex          # a user-local npm prefix, or an administrator, may be needed'
     : '  curl -fsSL https://claude.ai/install.sh | bash    # installs to ~/.local/bin — no root needed\n'
+      + '  # It does NOT edit your PATH. Afterwards:\n'
+      + '  export PATH="$HOME/.local/bin:$PATH" && echo \'export PATH="$HOME/.local/bin:$PATH"\' >> ~/.bashrc\n'
       + '  # (npm i -g @anthropic-ai/claude-code also works, but as a normal user it needs a\n'
       + '  #  user-local prefix: npm config set prefix ~/.npm-global, and that dir on PATH)';
   return 'the `' + bin + '` CLI is not on PATH, so Bridget has nothing to be a session of.\n'
     + 'The board is up and her welcome message is on it — she just cannot answer yet.\n\n'
     + 'ASK the person for permission, then install it as the user who will run it:\n'
     + install + '\n\n'
-    + 'Then run it once by hand IN THE WORKSPACE — it has setup screens of its own (theme, login,\n'
-    + 'and a trust question about this very folder) that a spawned session cannot answer:\n'
-    + '  cd ' + (workspace || '<the workspace folder>') + ' && ' + bin;
+    + runByHand;
 }
 
 // diagnoseSpawn — read the pane, do not guess at it.
@@ -248,12 +274,23 @@ function diagnoseSpawn(text, workspace) {
   const tail = (/pane tail:\n([\s\S]*)$/.exec(t) || [, ''])[1].trim();
   const here = workspace || '<the workspace folder>';
   const hit = (re, cause, headline, fix) => (re.test(t) ? { cause, headline, fix, tail } : null);
-  return hit(/Quick safety check|trust this folder|Accessing workspace/, 'trust',
+  // First, because it is the one screen our own launch line raises and the one
+  // no hand-run of plain `claude` can ever clear.
+  return hit(/Bypass Permissions mode|Yes, I accept/, 'bypass',
+    'her pane is on Claude Code\'s one-time bypass-permissions consent screen. That warning is\n'
+      + 'raised BY the --dangerously-skip-permissions flag the spawn uses, so running plain `claude`\n'
+      + 'never sees it — and it is not mine to accept for anyone: it is consent to an agent that\n'
+      + 'skips permission prompts on this machine.',
+    'Have the person run the launch line itself, once, and answer 2 (Yes, I accept) — then /exit\n'
+      + 'and run the SAME command again:\n'
+      + '  cd ' + here + ' && claude --dangerously-skip-permissions\n'
+      + '(The preselected option on that screen is "No, exit", so it is theirs to answer, not mine.)')
+  || hit(/Quick safety check|trust this folder|Accessing workspace/, 'trust',
     'her pane is on Claude Code\'s folder-trust question for the workspace — it asks about any\n'
-      + 'directory it has not seen before, and it comes BEFORE login.',
-    'Running `claude` in their home directory does NOT clear this one: Bridget is spawned in the\n'
-      + 'workspace, so the trust question is about THAT folder. Run it there once, answer the\n'
-      + 'question, quit with /exit, then run the SAME command again:\n'
+      + 'directory it has not already trusted, and it comes BEFORE login.',
+    'Trust is inherited from a trusted ancestor, so running `claude` in their home directory MAY\n'
+      + 'have cleared it (a workspace under ~ usually is) — but it may not have. Run it in the\n'
+      + 'workspace itself, answer the question, quit with /exit, then run the SAME command again:\n'
       + '  cd ' + here + ' && claude')
   || hit(/cannot be used with root\/sudo privileges/, 'root',
     'claude refuses --dangerously-skip-permissions as root, and exited.',
@@ -308,5 +345,5 @@ module.exports = {
   IGNORABLE, MANIFESTS, SOURCE_DIRS, SOURCE_EXT, ONBOARDING_STEPS,
   isWorkspaceDir, inspectTarget, listPhrase, refusalText,
   hasBin, isRoot, installCommand, tmuxMissingText, gitIdentity, gitIdentityText, portFree,
-  rootBlockText, agentMissingText, diagnoseSpawn,
+  rootBlockText, agentMissingText, agentAtHome, diagnoseSpawn,
 };

--- a/server/firstrun.js
+++ b/server/firstrun.js
@@ -108,6 +108,8 @@ function refusalText(dir, r) {
 // Nothing here installs anything. Each check either passes or hands back a
 // message written for the agent that will relay it and ask.
 
+function isRoot() { return typeof process.getuid === 'function' && process.getuid() === 0; }
+
 function hasBin(name) {
   const dirs = String(process.env.PATH || '').split(path.delimiter).filter(Boolean);
   for (const d of dirs) {
@@ -118,15 +120,22 @@ function hasBin(name) {
 
 // The install line for THIS machine, so the agent can ask a yes/no question
 // with a real command in it instead of guessing a package manager.
-function installCommand(pkg) {
-  if (process.platform === 'darwin' && hasBin('brew')) return 'brew install ' + pkg;
-  if (hasBin('apt-get')) return 'sudo apt-get update && sudo apt-get install -y ' + pkg;
-  if (hasBin('dnf')) return 'sudo dnf install -y ' + pkg;
-  if (hasBin('yum')) return 'sudo yum install -y ' + pkg;
-  if (hasBin('pacman')) return 'sudo pacman -S --noconfirm ' + pkg;
-  if (hasBin('apk')) return 'apk add --no-cache ' + pkg;
-  if (hasBin('zypper')) return 'sudo zypper install -y ' + pkg;
-  if (hasBin('brew')) return 'brew install ' + pkg;
+//
+// `sudo` is earned, not assumed: as root it is unnecessary, and in a container
+// it is usually not even installed — a printed `sudo apt-get …` there dies with
+// `sudo: command not found`, which reads as "the instructions are broken".
+function installCommand(pkg, opts = {}) {
+  const root = opts.root === undefined ? isRoot() : opts.root;
+  const has = opts.hasBin || hasBin;
+  const sudo = root || !has('sudo') ? '' : 'sudo ';
+  if (process.platform === 'darwin' && has('brew')) return 'brew install ' + pkg;
+  if (has('apt-get')) return sudo + 'apt-get update && ' + sudo + 'apt-get install -y ' + pkg;
+  if (has('dnf')) return sudo + 'dnf install -y ' + pkg;
+  if (has('yum')) return sudo + 'yum install -y ' + pkg;
+  if (has('pacman')) return sudo + 'pacman -S --noconfirm ' + pkg;
+  if (has('apk')) return sudo + 'apk add --no-cache ' + pkg;
+  if (has('zypper')) return sudo + 'zypper install -y ' + pkg;
+  if (has('brew')) return 'brew install ' + pkg;
   return '';
 }
 
@@ -170,6 +179,67 @@ function gitIdentityText(id) {
     + '  git config --global user.email "<their email>"';
 }
 
+// Root. Claude Code refuses `--dangerously-skip-permissions` as uid 0 and exits
+// immediately, so as root there is no lieutenant to be had — the board would
+// come up with nobody on it. That is checked HERE, before anything is written,
+// rather than discovered from a dead pane afterwards.
+function rootBlockText() {
+  return 'you are running as root, and Claude Code refuses --dangerously-skip-permissions as root.\n'
+    + 'Bridget is a real claude session, so as root she cannot start and you would be left with a\n'
+    + 'board nobody is on. Two honest ways forward:\n\n'
+    + '  1. RECOMMENDED — do the first run as a normal user:\n'
+    + '       useradd -m dev && su - dev        # then install the skill and run this again as dev\n\n'
+    + '  2. This is a throwaway box (a container you will delete) and you accept the risk:\n'
+    + '       bc-axi init --onboard --allow-root\n'
+    + '     That launches her with IS_SANDBOX=1, which is the escape hatch claude itself checks.\n'
+    + '     It turns off a guard that exists because an agent with skipped permissions running as\n'
+    + '     root can do anything to the machine. Never on a box you care about.\n\n'
+    + 'ASK the person which one. Do not pick --allow-root for them.';
+}
+
+// The agent CLI itself. Cheap and certain (is it on PATH?), so it is answered
+// before the spawn instead of being guessed at from a timeout afterwards.
+function agentMissingText(harness) {
+  const cmd = harness === 'codex'
+    ? 'npm i -g @openai/codex'
+    : 'npm i -g @anthropic-ai/claude-code';
+  return 'the `' + (harness || 'claude') + '` CLI is not on PATH, so Bridget has nothing to be a session of.\n'
+    + 'The board is up and her welcome message is on it — she just cannot answer yet.\n\n'
+    + 'ASK the person for permission, then install it and run the SAME command again:\n'
+    + '  ' + cmd + '\n'
+    + '  ' + (harness === 'codex' ? 'codex' : 'claude') + '        # run it once by hand: it has a setup screen of its own to get past';
+}
+
+// diagnoseSpawn — read the pane, do not guess at it.
+//
+// A spawn failure arrives with the tail of the session's own pane attached, and
+// that tail says exactly what happened. Every branch below is a signature seen
+// in a real container; the fallback is the only place a guess is allowed, and it
+// is labelled as one. Guessing "not installed, or not logged in" at a pane that
+// plainly says something else is how a tester loses an afternoon.
+function diagnoseSpawn(text) {
+  const t = String(text || '');
+  const tail = (/pane tail:\n([\s\S]*)$/.exec(t) || [, ''])[1].trim();
+  const hit = (re, cause, headline, fix) => (re.test(t) ? { cause, headline, fix, tail } : null);
+  return hit(/cannot be used with root\/sudo privileges/, 'root',
+    'claude refuses --dangerously-skip-permissions as root, and exited.',
+    'Do the first run as a normal user (`useradd -m dev && su - dev`), or, on a throwaway box,\n'
+      + 're-run with --allow-root — see the block that command prints before it starts.')
+  || hit(/Choose the text style|run \/theme|Let's get started/, 'setup',
+    'the `claude` CLI has never been run on this machine — her pane is parked on its setup wizard\n'
+      + '(theme picker), which comes BEFORE any login question.',
+    'Run it once by hand, answer its questions, quit with /exit, then run the SAME command again:\n'
+      + '  claude')
+  || hit(/command not found|ENOENT|not found: claude/, 'missing',
+    'the agent CLI is not installed — the shell answered "command not found".',
+    'Install it and run the SAME command again:\n  npm i -g @anthropic-ai/claude-code')
+  || hit(/\/login|Invalid API key|not authenticated|Please run .*login|Sign in|log in to/i, 'auth',
+    'the `claude` CLI is installed but not logged in — her pane is on its login screen.',
+    'Log in once by hand, then run the SAME command again:\n  claude   (and follow its login)')
+  || { cause: 'unknown', headline: 'I could not tell from her pane why it failed. Read it above and act on what it says.',
+    fix: 'If the pane is empty, the usual causes are the `claude` CLI missing, never run, or not\nlogged in — but that is a guess, not what this pane showed.', tail };
+}
+
 // portFree — can we bind it? An occupied port is not automatically a problem
 // (it may be this very workspace's board), so the caller probes for a board
 // first and only then walks forward.
@@ -189,5 +259,6 @@ const ONBOARDING_STEPS = ['board-up', 'tools', 'project', 'checklist', 'done'];
 module.exports = {
   IGNORABLE, MANIFESTS, SOURCE_DIRS, SOURCE_EXT, ONBOARDING_STEPS,
   isWorkspaceDir, inspectTarget, listPhrase, refusalText,
-  hasBin, installCommand, tmuxMissingText, gitIdentity, gitIdentityText, portFree,
+  hasBin, isRoot, installCommand, tmuxMissingText, gitIdentity, gitIdentityText, portFree,
+  rootBlockText, agentMissingText, diagnoseSpawn,
 };

--- a/server/firstrun.js
+++ b/server/firstrun.js
@@ -224,6 +224,19 @@ function rootBlockText() {
 // the PATH edit to the user; on Debian a normal login shell picks that up from
 // ~/.profile, but root's does not — so as root the very next step dies with
 // "command not found" and re-running loops forever on the same message.
+// The launch line a PERSON runs by hand to clear the setup screens. There is one
+// of these in the whole file on purpose: it is the line a stranger copies
+// verbatim, and every place that prints it has to get the same details right.
+//
+// Round 5: as root it needs IS_SANDBOX=1 — the same escape hatch --allow-root
+// passes to her spawn. Without it the line dies on sight with the very refusal
+// the person is trying to get past, which reads as "these instructions are
+// broken" at exactly the moment they have no other move.
+function handRunLine(bin, here, opts = {}) {
+  const root = opts.root === undefined ? isRoot() : opts.root;
+  return '  cd ' + here + ' && ' + (root ? 'IS_SANDBOX=1 ' : '') + bin + ' --dangerously-skip-permissions';
+}
+
 function agentAtHome(bin) {
   const home = process.env.HOME || '';
   if (!home) return '';
@@ -239,7 +252,7 @@ function agentMissingText(harness, workspace) {
   const runByHand = 'Then run it once by hand IN THE WORKSPACE — it has setup screens of its own that a spawned\n'
     + 'session cannot answer (a theme picker, a login, a trust question about this folder, and a\n'
     + 'one-time bypass-permissions consent screen that only the launch flag raises):\n'
-    + '  cd ' + here + ' && ' + bin + ' --dangerously-skip-permissions';
+    + handRunLine(bin, here);
   if (installed) {
     return '`' + bin + '` is installed at ' + installed + ' but is not on PATH, so neither I nor her\n'
       + 'session can start it. The board is up and her welcome message is on it.\n\n'
@@ -283,7 +296,7 @@ function diagnoseSpawn(text, workspace) {
       + 'skips permission prompts on this machine.',
     'Have the person run the launch line itself, once, and answer 2 (Yes, I accept) — then /exit\n'
       + 'and run the SAME command again:\n'
-      + '  cd ' + here + ' && claude --dangerously-skip-permissions\n'
+      + handRunLine('claude', here) + '\n'
       + '(The preselected option on that screen is "No, exit", so it is theirs to answer, not mine.)')
   || hit(/Quick safety check|trust this folder|Accessing workspace/, 'trust',
     'her pane is on Claude Code\'s folder-trust question for the workspace — it asks about any\n'
@@ -291,7 +304,8 @@ function diagnoseSpawn(text, workspace) {
     'Trust is inherited from a trusted ancestor, so running `claude` in their home directory MAY\n'
       + 'have cleared it (a workspace under ~ usually is) — but it may not have. Run it in the\n'
       + 'workspace itself, answer the question, quit with /exit, then run the SAME command again:\n'
-      + '  cd ' + here + ' && claude')
+      + handRunLine('claude', here) + '\n'
+      + '(The flag is in there so this one sitting also clears the consent screen behind it.)')
   || hit(/cannot be used with root\/sudo privileges/, 'root',
     'claude refuses --dangerously-skip-permissions as root, and exited.',
     'Do the first run as a normal user (`useradd -m dev && su - dev`), or, on a throwaway box,\n'
@@ -301,7 +315,7 @@ function diagnoseSpawn(text, workspace) {
       + '(theme picker), which comes BEFORE any login question.',
     'Run it once by hand IN THE WORKSPACE, answer its questions (there is a folder-trust one about\n'
       + 'this directory after the theme), quit with /exit, then run the SAME command again:\n'
-      + '  cd ' + here + ' && claude')
+      + handRunLine('claude', here))
   || hit(/command not found|ENOENT|not found: claude/, 'missing',
     'the agent CLI is not installed — the shell answered "command not found".',
     'Install it and run the SAME command again:\n  npm i -g @anthropic-ai/claude-code')
@@ -345,5 +359,5 @@ module.exports = {
   IGNORABLE, MANIFESTS, SOURCE_DIRS, SOURCE_EXT, ONBOARDING_STEPS,
   isWorkspaceDir, inspectTarget, listPhrase, refusalText,
   hasBin, isRoot, installCommand, tmuxMissingText, gitIdentity, gitIdentityText, portFree,
-  rootBlockText, agentMissingText, agentAtHome, diagnoseSpawn,
+  rootBlockText, agentMissingText, agentAtHome, handRunLine, diagnoseSpawn,
 };

--- a/server/firstrun.js
+++ b/server/firstrun.js
@@ -139,14 +139,24 @@ function installCommand(pkg, opts = {}) {
   return '';
 }
 
-function tmuxMissingText() {
-  const cmd = installCommand('tmux');
+function tmuxMissingText(opts = {}) {
+  const root = opts.root === undefined ? isRoot() : opts.root;
+  const has = opts.hasBin || hasBin;
+  const cmd = installCommand('tmux', { root, hasBin: has });
+  // Neither root nor sudo: the command below is correct and will still be
+  // refused by the package manager. Say that up front rather than letting a
+  // permission-denied read as a broken instruction.
+  const needsAdmin = !root && !has('sudo') && cmd;
   return 'tmux is not installed on this machine, and Bridge Commander needs it: a lieutenant is a\n'
     + 'real agent session, and it lives in a tmux session so the board can reach it and the\n'
     + 'person can attach to it later. You will never have to type a tmux command yourself.\n\n'
     + (cmd
       ? 'ASK the person for permission, then install it:\n  ' + cmd + '\n'
       : 'I could not identify a package manager here. ASK the person how they want tmux installed.\n')
+    + (needsAdmin
+      ? '\nNote: this user is not root and there is no `sudo` here, so that command will be refused.\n'
+        + 'It needs an administrator — `su -` if they have the root password, or whoever owns the box.\n'
+      : '')
     + '\nThen run this again — nothing has been written yet.';
 }
 
@@ -188,7 +198,10 @@ function rootBlockText() {
     + 'Bridget is a real claude session, so as root she cannot start and you would be left with a\n'
     + 'board nobody is on. Two honest ways forward:\n\n'
     + '  1. RECOMMENDED — do the first run as a normal user:\n'
-    + '       useradd -m dev && su - dev        # then install the skill and run this again as dev\n\n'
+    + '       useradd -m dev && su - dev\n'
+    + '     Then, as that user: install the skill (npx skills add …), install the agent CLI in a\n'
+    + '     way that needs no root (curl -fsSL https://claude.ai/install.sh | bash puts it in\n'
+    + '     ~/.local/bin — `npm i -g` would fail with EACCES for them), and run this again.\n\n'
     + '  2. This is a throwaway box (a container you will delete) and you accept the risk:\n'
     + '       bc-axi init --onboard --allow-root\n'
     + '     That launches her with IS_SANDBOX=1, which is the escape hatch claude itself checks.\n'
@@ -199,15 +212,28 @@ function rootBlockText() {
 
 // The agent CLI itself. Cheap and certain (is it on PATH?), so it is answered
 // before the spawn instead of being guessed at from a timeout afterwards.
-function agentMissingText(harness) {
-  const cmd = harness === 'codex'
-    ? 'npm i -g @openai/codex'
-    : 'npm i -g @anthropic-ai/claude-code';
-  return 'the `' + (harness || 'claude') + '` CLI is not on PATH, so Bridget has nothing to be a session of.\n'
+//
+// The install line has to work for the user who will RUN it. `npm i -g` on a
+// stock image writes into a root-owned prefix and fails with EACCES for exactly
+// the normal user the root block just told them to become — two blocks that
+// contradict each other are worse than either one alone. The official installer
+// puts the binary under ~/.local/bin and needs no root, so that is what is
+// offered first.
+function agentMissingText(harness, workspace) {
+  const codex = harness === 'codex';
+  const bin = codex ? 'codex' : 'claude';
+  const install = codex
+    ? '  npm i -g @openai/codex          # a user-local npm prefix, or an administrator, may be needed'
+    : '  curl -fsSL https://claude.ai/install.sh | bash    # installs to ~/.local/bin — no root needed\n'
+      + '  # (npm i -g @anthropic-ai/claude-code also works, but as a normal user it needs a\n'
+      + '  #  user-local prefix: npm config set prefix ~/.npm-global, and that dir on PATH)';
+  return 'the `' + bin + '` CLI is not on PATH, so Bridget has nothing to be a session of.\n'
     + 'The board is up and her welcome message is on it — she just cannot answer yet.\n\n'
-    + 'ASK the person for permission, then install it and run the SAME command again:\n'
-    + '  ' + cmd + '\n'
-    + '  ' + (harness === 'codex' ? 'codex' : 'claude') + '        # run it once by hand: it has a setup screen of its own to get past';
+    + 'ASK the person for permission, then install it as the user who will run it:\n'
+    + install + '\n\n'
+    + 'Then run it once by hand IN THE WORKSPACE — it has setup screens of its own (theme, login,\n'
+    + 'and a trust question about this very folder) that a spawned session cannot answer:\n'
+    + '  cd ' + (workspace || '<the workspace folder>') + ' && ' + bin;
 }
 
 // diagnoseSpawn — read the pane, do not guess at it.
@@ -217,27 +243,49 @@ function agentMissingText(harness) {
 // in a real container; the fallback is the only place a guess is allowed, and it
 // is labelled as one. Guessing "not installed, or not logged in" at a pane that
 // plainly says something else is how a tester loses an afternoon.
-function diagnoseSpawn(text) {
+function diagnoseSpawn(text, workspace) {
   const t = String(text || '');
   const tail = (/pane tail:\n([\s\S]*)$/.exec(t) || [, ''])[1].trim();
+  const here = workspace || '<the workspace folder>';
   const hit = (re, cause, headline, fix) => (re.test(t) ? { cause, headline, fix, tail } : null);
-  return hit(/cannot be used with root\/sudo privileges/, 'root',
+  return hit(/Quick safety check|trust this folder|Accessing workspace/, 'trust',
+    'her pane is on Claude Code\'s folder-trust question for the workspace — it asks about any\n'
+      + 'directory it has not seen before, and it comes BEFORE login.',
+    'Running `claude` in their home directory does NOT clear this one: Bridget is spawned in the\n'
+      + 'workspace, so the trust question is about THAT folder. Run it there once, answer the\n'
+      + 'question, quit with /exit, then run the SAME command again:\n'
+      + '  cd ' + here + ' && claude')
+  || hit(/cannot be used with root\/sudo privileges/, 'root',
     'claude refuses --dangerously-skip-permissions as root, and exited.',
     'Do the first run as a normal user (`useradd -m dev && su - dev`), or, on a throwaway box,\n'
       + 're-run with --allow-root — see the block that command prints before it starts.')
   || hit(/Choose the text style|run \/theme|Let's get started/, 'setup',
     'the `claude` CLI has never been run on this machine — her pane is parked on its setup wizard\n'
       + '(theme picker), which comes BEFORE any login question.',
-    'Run it once by hand, answer its questions, quit with /exit, then run the SAME command again:\n'
-      + '  claude')
+    'Run it once by hand IN THE WORKSPACE, answer its questions (there is a folder-trust one about\n'
+      + 'this directory after the theme), quit with /exit, then run the SAME command again:\n'
+      + '  cd ' + here + ' && claude')
   || hit(/command not found|ENOENT|not found: claude/, 'missing',
     'the agent CLI is not installed — the shell answered "command not found".',
     'Install it and run the SAME command again:\n  npm i -g @anthropic-ai/claude-code')
   || hit(/\/login|Invalid API key|not authenticated|Please run .*login|Sign in|log in to/i, 'auth',
     'the `claude` CLI is installed but not logged in — her pane is on its login screen.',
-    'Log in once by hand, then run the SAME command again:\n  claude   (and follow its login)')
-  || { cause: 'unknown', headline: 'I could not tell from her pane why it failed. Read it above and act on what it says.',
-    fix: 'If the pane is empty, the usual causes are the `claude` CLI missing, never run, or not\nlogged in — but that is a guess, not what this pane showed.', tail };
+    'Log in once by hand in the workspace, then run the SAME command again:\n'
+      + '  cd ' + here + ' && claude   (and follow its login)')
+  // The only branch that guesses — and the guess is different depending on
+  // whether there was a pane to read. "Read it above" pointing at nothing is
+  // worse than saying plainly that there was nothing to read.
+  || (tail
+    ? { cause: 'unknown', tail,
+      headline: 'I could not match her pane to anything I know. What it shows is printed above — act on that.',
+      fix: 'If it is a menu or a prompt, it is waiting for a human: run `claude` by hand in the\n'
+        + 'workspace (cd ' + here + ' && claude), get it to a working session, then run the SAME\n'
+        + 'command again.' }
+    : { cause: 'unknown', tail: '',
+      headline: 'her pane was empty — the session left nothing on screen to read.',
+      fix: 'With nothing to go on, the usual causes are the `claude` CLI missing, never run, or not\n'
+        + 'logged in. That is a guess, not something this pane showed. Check it by hand:\n'
+        + '  cd ' + here + ' && claude' });
 }
 
 // portFree — can we bind it? An occupied port is not automatically a problem

--- a/server/server.js
+++ b/server/server.js
@@ -673,6 +673,9 @@ async function spawnLieutenant(body) {
       stateDir: HARNESS_STATE_DIR,
       callbackUrl: TURNEND_URL,
       installHooks: false,
+      // Only the first run sends this, and only when the person said so out
+      // loud: the harness decides what it means (for claude, IS_SANDBOX=1).
+      allowRoot: !!body.allowRoot,
     });
   } catch (e) {
     return { error: 'spawn failed: ' + String((e && e.message) || e), code: 502 };

--- a/server/server.js
+++ b/server/server.js
@@ -3281,7 +3281,11 @@ const server = http.createServer(async (req, res) => {
       let pending = 0;
       for (const lt of queueIds()) pending += pendingItems(lt).length;
       return sendJson(res, 200, {
-        workspace: WORKSPACE, port: PORT, cards: board.cards.length,
+        // `host` is what this process actually BOUND, not what config said —
+        // a caller that wants a different bind (init/open --host) can only tell
+        // by asking, and a server that ignored the flag silently is the bug
+        // that sent a stranger a URL their browser could not reach.
+        workspace: WORKSPACE, port: PORT, host: BIND_HOST, cards: board.cards.length,
         lieutenants: board.lieutenants.length, seq: board.seq,
         queue_seq: qseq, queue_pending: pending,
         projects: board.projects.length, workers: board.workers.length,

--- a/server/server.js
+++ b/server/server.js
@@ -72,6 +72,7 @@ const names = require(path.join(__dirname, 'names.js'));
 const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.join(__dirname, 'statedir.js'));
 const gitrev = require(path.join(__dirname, 'gitrev.js'));
 const { charterPath, readCharter, writeCharter } = require(path.join(__dirname, 'charter.js'));
+const { ONBOARDING_STEPS } = require(path.join(__dirname, 'firstrun.js'));
 const { execFile, execFileSync } = require('child_process');
 
 // ---------- args ----------
@@ -650,7 +651,16 @@ async function spawnLieutenant(body) {
   if (!name) return { error: 'name required' };
   const id = body.id ? String(body.id) : lieutenantIdFrom(name);
   if (!/^[\w][\w.-]*$/.test(id)) return { error: 'bad lieutenant id (use [A-Za-z0-9_.-])' };
-  if (findLieutenant(id)) return { error: 'lieutenant exists: ' + id, code: 409 };
+  // revive:true is what makes `bc-axi init --onboard` re-runnable: the founding
+  // lieutenant already exists, and the question is only whether her session is
+  // still up. A live one is left strictly alone (spawning over a live session
+  // is how you lose a conversation); a dead or never-spawned one gets a new
+  // session on the same record, charter and chat history included.
+  const existing = findLieutenant(id);
+  if (existing && !body.revive) return { error: 'lieutenant exists: ' + id, code: 409 };
+  if (existing && (await sessionState(existing)) === 'live') {
+    return { lieutenant: existing, spawned: false };
+  }
   const harnessName = String(body.harness || readConfig().harness || 'claude');
   let impl;
   try { impl = getHarness(harnessName); } catch (e) { return { error: String(e.message || e) }; }
@@ -667,7 +677,11 @@ async function spawnLieutenant(body) {
   } catch (e) {
     return { error: 'spawn failed: ' + String((e && e.message) || e), code: 502 };
   }
-  return createLieutenant(Object.assign({}, body, { id, ref }));
+  if (existing) {
+    existing.ref = ref;
+    return { lieutenant: existing, spawned: true };
+  }
+  return Object.assign({ spawned: true }, createLieutenant(Object.assign({}, body, { id, ref })));
 }
 
 // lieutenant.retire — explicit only (the DNA). Refuses while the lieutenant
@@ -3273,6 +3287,25 @@ const server = http.createServer(async (req, res) => {
         sysload: sysload.stats(), // the monitoring refcount probe: {subscribers, sampling}
       });
     }
+    // ----- first-run state (the onboarding conversation's memory) -----
+    // Onboarding is a conversation, and a conversation that restarts from the
+    // top on every server bounce is a conversation nobody finishes. The step
+    // lives on the board (so it survives the session that is having it, and the
+    // UI ships with it in GET /api/board) and Bridget reads it as her first act.
+    if (route === 'GET /api/onboarding') return sendJson(res, 200, { onboarding: board.onboarding || null });
+    if (route === 'POST /api/onboarding') {
+      const body = JSON.parse(await readBody(req) || '{}');
+      const cur = board.onboarding || { started: now() };
+      const step = body.step === undefined ? cur.step : String(body.step || '');
+      if (step && !ONBOARDING_STEPS.includes(step)) {
+        return sendJson(res, 400, { error: 'unknown step: ' + step + ' (want ' + ONBOARDING_STEPS.join(' | ') + ')' });
+      }
+      const next = Object.assign({}, cur, body, { step, updated: now() });
+      delete next.actor;
+      board.onboarding = next;
+      saveBoard(); broadcast();
+      return sendJson(res, 200, { ok: true, onboarding: board.onboarding });
+    }
     if (route === 'GET /api/archive') {
       // Paginated read over the append-only log, newest first: a limit+offset
       // window plus the total, so the UI's 🧊 archived mode can page-in ("load
@@ -3603,7 +3636,9 @@ const server = http.createServer(async (req, res) => {
       const r = body.spawn ? await spawnLieutenant(body) : createLieutenant(body);
       if (r.error) return sendJson(res, r.code || 400, { error: r.error });
       saveBoard(); broadcast();
-      return sendJson(res, 200, { ok: true, lieutenant: r.lieutenant });
+      // `spawned` is how a re-run of `init --onboard` tells "I revived her" from
+      // "she was already up" — the second is not worth a line of anyone's output.
+      return sendJson(res, 200, { ok: true, lieutenant: r.lieutenant, spawned: r.spawned });
     }
     const ltRoute = /^\/api\/lieutenants\/([^/]+)$/.exec(p);
     if (ltRoute && req.method === 'DELETE') { // lieutenant.retire — explicit only

--- a/test/firstrun.test.js
+++ b/test/firstrun.test.js
@@ -1,0 +1,118 @@
+'use strict';
+// The test that decides whether a stranger's first command is allowed to write
+// anything at all: is this directory a workspace, an empty folder, or somebody's
+// code? The ORDER is the contract — a workspace is itself a git repo, so it has
+// to be recognised before any project signal is looked at.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { runCli } = require('./helper');
+const fr = require('../server/firstrun.js');
+
+function tmp(seed) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-firstrun-'));
+  if (seed) seed(dir);
+  return dir;
+}
+const touch = (dir, rel) => {
+  fs.mkdirSync(path.dirname(path.join(dir, rel)), { recursive: true });
+  fs.writeFileSync(path.join(dir, rel), '');
+};
+
+test('an existing workspace is recognised before any project signal', () => {
+  // The whole point of the ordering: this folder is ALSO a git repo with a
+  // manifest and a src/ in it, and it still has to read as "continue".
+  const dir = tmp((d) => {
+    fs.mkdirSync(path.join(d, '.bridge-commander'));
+    fs.mkdirSync(path.join(d, '.git'));
+    touch(d, 'package.json');
+    touch(d, 'src/index.js');
+  });
+  try {
+    assert.strictEqual(fr.inspectTarget(dir).verdict, 'workspace');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('an empty folder goes, and agent dotfiles do not make it non-empty', () => {
+  const empty = tmp();
+  const dotted = tmp((d) => { touch(d, '.claude/settings.local.json'); touch(d, '.DS_Store'); });
+  try {
+    assert.strictEqual(fr.inspectTarget(empty).verdict, 'empty');
+    assert.strictEqual(fr.inspectTarget(dotted).verdict, 'empty');
+  } finally {
+    fs.rmSync(empty, { recursive: true, force: true });
+    fs.rmSync(dotted, { recursive: true, force: true });
+  }
+});
+
+test('a repo, a manifest and a source dir each read as a code project, and are named', () => {
+  const cases = [
+    [(d) => fs.mkdirSync(path.join(d, '.git')), /git repository/],
+    [(d) => touch(d, 'pyproject.toml'), /`pyproject\.toml`/],
+    [(d) => touch(d, 'src/main.go'), /`src\/`/],
+    [(d) => touch(d, 'server.js'), /source files/],
+  ];
+  for (const [seed, re] of cases) {
+    const dir = tmp(seed);
+    try {
+      const r = fr.inspectTarget(dir);
+      assert.strictEqual(r.verdict, 'project', JSON.stringify(r));
+      assert.match(fr.listPhrase(r.found), re);
+      assert.match(fr.refusalText(dir, r), re); // the refusal quotes what it found back
+    } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+  }
+});
+
+test('a non-empty folder that is neither is a judgement call, and lists what is there', () => {
+  const dir = tmp((d) => { touch(d, 'holiday-photos'); touch(d, 'notes.txt'); });
+  try {
+    const r = fr.inspectTarget(dir);
+    assert.strictEqual(r.verdict, 'unclear');
+    assert.deepStrictEqual(r.found, []);
+    const text = fr.refusalText(dir, r);
+    assert.match(text, /notes\.txt/);
+    assert.match(text, /--here/); // the way out, once the person has been asked
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('a missing directory is missing, not empty', () => {
+  assert.strictEqual(fr.inspectTarget(path.join(os.tmpdir(), 'bc-nope-' + process.pid)).verdict, 'missing');
+});
+
+test('no failure message ever asks anyone to type a tmux command', () => {
+  // The one rule the whole first run is judged on. `tmux new -s ...` in front of
+  // a person who has never heard of tmux is the failure this flow exists to end.
+  const texts = [fr.tmuxMissingText(), fr.gitIdentityText({ ok: false, missing: false })];
+  for (const t of texts) assert.doesNotMatch(t, /tmux (new|attach|new-session)/);
+  assert.match(fr.tmuxMissingText(), /ASK/); // it asks for permission instead
+});
+
+test('the teleport init, run outside tmux, points at the onboarding path instead of a tmux command', async () => {
+  const dir = tmp();
+  try {
+    const r = await runCli(['init', '--name', 'Ada', '--workspace', dir], { TMUX: '' });
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /bc-axi init --onboard/);
+    assert.doesNotMatch(r.stderr, /tmux new/);
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});
+
+test('init --onboard refuses a code project, names what it found, and writes nothing', async () => {
+  const dir = tmp((d) => {
+    fs.mkdirSync(path.join(d, '.git'));
+    fs.writeFileSync(path.join(d, 'package.json'), '{}');
+    touch(d, 'src/index.js');
+  });
+  try {
+    const r = await runCli(['init', '--onboard', '--workspace', dir]);
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /first run refused \(project\)/);
+    assert.match(r.stderr, /`package\.json`/);
+    assert.match(r.stderr, /`src\/`/);
+    assert.match(r.stderr, /git repository/);
+    assert.ok(!fs.existsSync(path.join(dir, '.bridge-commander')), 'refused before writing state');
+    assert.ok(!fs.existsSync(path.join(dir, 'AGENTS.md')), 'refused before scaffolding');
+  } finally { fs.rmSync(dir, { recursive: true, force: true }); }
+});

--- a/test/firstrun.test.js
+++ b/test/firstrun.test.js
@@ -128,6 +128,15 @@ test('a spawn failure is diagnosed from the pane, and the pane comes back with i
 
   assert.strictEqual(fr.diagnoseSpawn(withTail('bash: claude: command not found')).cause, 'missing');
 
+  // Round 3: the consent screen only OUR launch line raises. The recipe has to
+  // carry the flag — `cd <ws> && claude` can be run all day and never see it.
+  d = fr.diagnoseSpawn(withTail(
+    '  WARNING: Claude Code running in Bypass Permissions mode\n  ❯ 1. No, exit\n    2. Yes, I accept'),
+  '/root/myfleet');
+  assert.strictEqual(d.cause, 'bypass');
+  assert.match(d.fix, /claude --dangerously-skip-permissions/, 'a recipe that cannot clear it is no recipe');
+  assert.match(d.fix, /2 \(Yes, I accept\)/);
+
   // Round 2: the folder-trust question, which is a THIRD setup screen and comes
   // before login. A user who ran `claude` once at home has not cleared it —
   // Bridget is spawned in the workspace, and the question is about that folder.
@@ -158,9 +167,37 @@ test('the agent-missing block installs as the user who will run it, and points a
   // Round 2: the root block says "become a normal user", and this block used to
   // answer with `npm i -g`, which for that user is EACCES. Two instructions that
   // contradict each other leave the person stuck between them.
-  const t = fr.agentMissingText('claude', '/home/dev/myfleet');
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-')); // …one with no claude in it
+  const oldHome = process.env.HOME;
+  let t;
+  try { process.env.HOME = home; t = fr.agentMissingText('claude', '/home/dev/myfleet'); }
+  finally { process.env.HOME = oldHome; fs.rmSync(home, { recursive: true, force: true }); }
   assert.match(t, /claude\.ai\/install\.sh/, 'a route that needs no root comes first');
-  assert.match(t, /cd \/home\/dev\/myfleet && claude/, 'and the by-hand run happens in the workspace');
+  assert.match(t, /cd \/home\/dev\/myfleet && claude --dangerously-skip-permissions/,
+    'the by-hand run happens in the workspace, with the flag that raises every screen');
+  assert.match(t, /PATH="\$HOME\/\.local\/bin/, 'the installer does not edit PATH, so the block does');
+});
+
+test('installed-but-invisible is a different problem from not-installed', () => {
+  // Round 3: as root, the curl installer lands the binary in ~/.local/bin and
+  // root's ~/.profile does not pick it up — so "install it" was printed at
+  // someone who already had, forever.
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const bin = path.join(home, '.local', 'bin');
+  fs.mkdirSync(bin, { recursive: true });
+  fs.writeFileSync(path.join(bin, 'claude'), '#!/bin/sh\n', { mode: 0o755 });
+  const oldHome = process.env.HOME;
+  try {
+    process.env.HOME = home;
+    assert.strictEqual(fr.agentAtHome('claude'), path.join(bin, 'claude'));
+    const t = fr.agentMissingText('claude', '/root/myfleet');
+    assert.match(t, /is installed at .*\.local\/bin\/claude but is not on PATH/);
+    assert.match(t, /bashrc/, 'and it survives into the shell her session is launched from');
+    assert.doesNotMatch(t, /install\.sh/, 'it does not tell them to install what they have');
+  } finally {
+    process.env.HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test('with neither root nor sudo, the tmux block says the command will be refused', () => {

--- a/test/firstrun.test.js
+++ b/test/firstrun.test.js
@@ -84,9 +84,54 @@ test('a missing directory is missing, not empty', () => {
 test('no failure message ever asks anyone to type a tmux command', () => {
   // The one rule the whole first run is judged on. `tmux new -s ...` in front of
   // a person who has never heard of tmux is the failure this flow exists to end.
-  const texts = [fr.tmuxMissingText(), fr.gitIdentityText({ ok: false, missing: false })];
+  const texts = [fr.tmuxMissingText(), fr.gitIdentityText({ ok: false, missing: false }),
+    fr.rootBlockText(), fr.agentMissingText('claude')];
   for (const t of texts) assert.doesNotMatch(t, /tmux (new|attach|new-session)/);
   assert.match(fr.tmuxMissingText(), /ASK/); // it asks for permission instead
+});
+
+test('the root block names both ways forward and lets nobody pick --allow-root for the person', () => {
+  const t = fr.rootBlockText();
+  assert.match(t, /useradd/, 'the recommended route is a normal user');
+  assert.match(t, /--allow-root/);
+  assert.match(t, /IS_SANDBOX=1/, 'it says what the escape hatch actually does');
+  assert.match(t, /ASK the person|Do not pick --allow-root for them/);
+});
+
+test('an install command earns its sudo — never as root, never when sudo is not installed', () => {
+  // `sudo apt-get …` printed at a container's root user dies with
+  // "sudo: command not found", which reads as "the instructions are broken".
+  const apt = (n) => n === 'apt-get';
+  const aptAndSudo = (n) => n === 'apt-get' || n === 'sudo';
+  assert.doesNotMatch(fr.installCommand('tmux', { root: true, hasBin: aptAndSudo }), /sudo/);
+  assert.doesNotMatch(fr.installCommand('tmux', { root: false, hasBin: apt }), /sudo/);
+  assert.match(fr.installCommand('tmux', { root: false, hasBin: aptAndSudo }), /^sudo apt-get/);
+});
+
+test('a spawn failure is diagnosed from the pane, and the pane comes back with it', () => {
+  const withTail = (tail) => 'spawn failed: claude could not start at =s:=w; pane tail:\n' + tail;
+
+  let d = fr.diagnoseSpawn(withTail(
+    '$ claude --dangerously-skip-permissions --session-id x\n'
+    + '--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons'));
+  assert.strictEqual(d.cause, 'root');
+  assert.match(d.fix, /--allow-root|normal user/);
+  assert.match(d.tail, /cannot be used with root/, 'the pane is handed back verbatim');
+  assert.doesNotMatch(d.headline, /not installed, or not logged in/);
+
+  d = fr.diagnoseSpawn(withTail(
+    'Welcome to Claude Code v2.1.226\n\n Choose the text style that looks best with your terminal\n'
+    + ' To change this later, run /theme'));
+  assert.strictEqual(d.cause, 'setup');
+  assert.match(d.fix, /claude/);
+  assert.doesNotMatch(d.headline, /not installed, or not logged in/);
+
+  assert.strictEqual(fr.diagnoseSpawn(withTail('bash: claude: command not found')).cause, 'missing');
+
+  // The ONLY place a guess is allowed — and it says it is one.
+  d = fr.diagnoseSpawn('spawn failed: something nobody has seen before');
+  assert.strictEqual(d.cause, 'unknown');
+  assert.match(d.fix, /that is a guess/);
 });
 
 test('the teleport init, run outside tmux, points at the onboarding path instead of a tmux command', async () => {

--- a/test/firstrun.test.js
+++ b/test/firstrun.test.js
@@ -236,3 +236,45 @@ test('init --onboard refuses a code project, names what it found, and writes not
     assert.ok(!fs.existsSync(path.join(dir, 'AGENTS.md')), 'refused before scaffolding');
   } finally { fs.rmSync(dir, { recursive: true, force: true }); }
 });
+
+// Round 5: the last one the tester found. On --allow-root the spawn passes
+// IS_SANDBOX=1, but the line we printed for the PERSON did not — so following
+// the recipe verbatim as root died with the same root refusal it was meant to
+// get them past. Every hand-run line is built in one place now, and this is the
+// test that keeps it that way.
+test('a hand-run recipe printed at root carries the escape hatch root needs', () => {
+  assert.strictEqual(fr.handRunLine('claude', '/root/myfleet', { root: true }),
+    '  cd /root/myfleet && IS_SANDBOX=1 claude --dangerously-skip-permissions');
+  assert.strictEqual(fr.handRunLine('claude', '/home/dev/ws', { root: false }),
+    '  cd /home/dev/ws && claude --dangerously-skip-permissions',
+    'a normal user gets no sandbox flag they do not need');
+
+  // …and every block that prints one gets it from there. Stubbing getuid is the
+  // only way to see the root shape without being root.
+  const realUid = process.getuid;
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const oldHome = process.env.HOME;
+  let texts;
+  try {
+    process.getuid = () => 0;
+    process.env.HOME = home;
+    const tail = (t) => 'spawn failed; pane tail:\n' + t;
+    texts = [
+      fr.agentMissingText('claude', '/root/myfleet'),
+      fr.diagnoseSpawn(tail('WARNING: Claude Code running in Bypass Permissions mode'), '/root/myfleet').fix,
+      fr.diagnoseSpawn(tail('Quick safety check: Is this a project you created'), '/root/myfleet').fix,
+      fr.diagnoseSpawn(tail('Choose the text style that looks best'), '/root/myfleet').fix,
+    ];
+  } finally {
+    process.getuid = realUid;
+    process.env.HOME = oldHome;
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+  for (const t of texts) {
+    for (const line of t.split('\n')) {
+      if (!/claude --dangerously-skip-permissions/.test(line)) continue;
+      assert.match(line, /IS_SANDBOX=1 claude --dangerously-skip-permissions/,
+        'a launch line printed at root that root cannot run: ' + line.trim());
+    }
+  }
+});

--- a/test/firstrun.test.js
+++ b/test/firstrun.test.js
@@ -128,10 +128,48 @@ test('a spawn failure is diagnosed from the pane, and the pane comes back with i
 
   assert.strictEqual(fr.diagnoseSpawn(withTail('bash: claude: command not found')).cause, 'missing');
 
-  // The ONLY place a guess is allowed — and it says it is one.
+  // Round 2: the folder-trust question, which is a THIRD setup screen and comes
+  // before login. A user who ran `claude` once at home has not cleared it —
+  // Bridget is spawned in the workspace, and the question is about that folder.
+  d = fr.diagnoseSpawn(withTail(
+    ' Accessing workspace:\n /root/myfleet\n'
+    + ' Quick safety check: Is this a project you created or one you trust?\n'
+    + ' ❯ 1. Yes, I trust this folder\n   2. No, exit'), '/root/myfleet');
+  assert.strictEqual(d.cause, 'trust');
+  assert.match(d.fix, /cd \/root\/myfleet && claude/, 'the fix names the workspace, not $HOME');
+
+  // The guessing branches, both of them — and the guess says it is one. Which
+  // branch you get depends on whether there was a pane to read at all: "read it
+  // above" over an empty space is what round 2 caught.
+  d = fr.diagnoseSpawn(withTail('a screen from the future'));
+  assert.strictEqual(d.cause, 'unknown');
+  assert.strictEqual(d.tail, 'a screen from the future');
+  assert.match(d.headline, /printed above/);
+
   d = fr.diagnoseSpawn('spawn failed: something nobody has seen before');
   assert.strictEqual(d.cause, 'unknown');
-  assert.match(d.fix, /that is a guess/);
+  assert.strictEqual(d.tail, '');
+  assert.match(d.headline, /pane was empty/);
+  assert.doesNotMatch(d.headline, /above/, 'nothing is above it, so it may not say so');
+  assert.match(d.fix, /That is a guess/);
+});
+
+test('the agent-missing block installs as the user who will run it, and points at the workspace', () => {
+  // Round 2: the root block says "become a normal user", and this block used to
+  // answer with `npm i -g`, which for that user is EACCES. Two instructions that
+  // contradict each other leave the person stuck between them.
+  const t = fr.agentMissingText('claude', '/home/dev/myfleet');
+  assert.match(t, /claude\.ai\/install\.sh/, 'a route that needs no root comes first');
+  assert.match(t, /cd \/home\/dev\/myfleet && claude/, 'and the by-hand run happens in the workspace');
+});
+
+test('with neither root nor sudo, the tmux block says the command will be refused', () => {
+  const t = fr.tmuxMissingText({ root: false, hasBin: (n) => n === 'apt-get' });
+  assert.match(t, /apt-get install -y tmux/);
+  assert.match(t, /not root and there is no `sudo`/, 'the one cell where the command cannot work');
+  assert.match(t, /administrator/);
+  // …and the cells where it does work do not carry the caveat.
+  assert.doesNotMatch(fr.tmuxMissingText({ root: true, hasBin: (n) => n === 'apt-get' }), /administrator/);
 });
 
 test('the teleport init, run outside tmux, points at the onboarding path instead of a tmux command', async () => {

--- a/test/install/docker-install-test.sh
+++ b/test/install/docker-install-test.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Verify the README install procedure end-to-end in a pristine Docker container.
+# Verify the README install + FIRST-RUN procedure end-to-end in a pristine Docker container:
+# a stranger's machine, nothing installed that the instructions do not name.
 #
 #   test/install/docker-install-test.sh          install test only; PASS/FAIL; container removed
 #   test/install/docker-install-test.sh --demo   also populate a demo board (fixture for the
@@ -18,6 +19,10 @@ DEMO=0
 CONTAINER=bc-install-test
 IMAGE=node:22-bookworm
 PORT=4790
+# The checkout the container clones. Defaults to the published main; point them at a
+# branch to test a first run BEFORE it merges — which is the only way to test one.
+REPO_URL=${BC_REPO_URL:-https://github.com/tonylampada/bridge-commander.git}
+REF=${BC_REF:-main}
 
 docker rm -f $CONTAINER >/dev/null 2>&1
 docker run -d --name $CONTAINER --network host $IMAGE sleep infinity >/dev/null
@@ -25,47 +30,87 @@ docker run -d --name $CONTAINER --network host $IMAGE sleep infinity >/dev/null
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-# ---------------------------------------------------------------- phase 1: install per README
-cat > "$TMP/phase-install.sh" <<'PHASE1'
+# ---------------------------------------------------------------- phase 1: the first run, per README
+# This is the stranger test: a bare image, and NOTHING is installed that the README and
+# FIRST-RUN.md do not say to install. Every step here mirrors what the user's own agent
+# does on a first `/bridge-commander` — including hitting the tmux-missing block before
+# tmux exists, which is exactly what a fresh machine gives you.
+cat > "$TMP/phase-install.sh" <<PHASE1
 #!/bin/bash
 set -uxo pipefail
 export HOME=/root
+export BC_REPO_URL="$REPO_URL" BC_REF="$REF"
 cd /root
+PHASE1
+cat >> "$TMP/phase-install.sh" <<'PHASE1'
 
-echo "=== prerequisites (README Dependencies: Node >= 18, tmux, git) ==="
-apt-get update -qq >/dev/null && apt-get install -y -qq tmux >/dev/null 2>&1
-node --version && git --version && tmux -V || exit 1
-
-echo "=== README Install: treehouse ==="
-curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh || exit 1
-export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
-command -v treehouse || exit 1
-
-echo "=== README Install: no-mistakes ==="
-curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh || exit 1
-command -v no-mistakes || exit 1
-
-echo "=== README Install: npx skills add ==="
+echo "=== README Install: one skill, nothing else ==="
 npx -y skills add tonylampada/bridge-commander -g -y || exit 1
 test -f ~/.agents/skills/bridge-commander/SKILL.md || exit 1
 
 echo "=== SKILL.md step 0: self-bootstrap (what the agent does on first /bridge-commander) ==="
 if [ ! -x ~/.agents/skills/bridge-commander/cli/bc-axi ]; then
-  git clone --quiet https://github.com/tonylampada/bridge-commander.git ~/.local/share/bridge-commander || exit 1
+  git clone --quiet --branch "$BC_REF" "$BC_REPO_URL" ~/.local/share/bridge-commander || exit 1
 fi
-test -x ~/.local/share/bridge-commander/cli/bc-axi || exit 1
-
-echo "=== teleport: bc-axi init inside tmux ==="
-git config --global user.email demo@example.com
-git config --global user.name "Demo User"
-git config --global init.defaultBranch main
 BC=/root/.local/share/bridge-commander/cli/bc-axi
-mkdir -p /root/myfleet
-tmux new-session -d -s myfleet "cd /root/myfleet && $BC init --name Dax --id dax --port 4790 > /root/init.log 2>&1; sleep infinity"
-for i in $(seq 1 30); do grep -q "http://" /root/init.log 2>/dev/null && break; sleep 1; done
+test -x $BC || exit 1
+test -f /root/.local/share/bridge-commander/FIRST-RUN.md || exit 1
+
+echo "=== FIRST-RUN.md: a code project is refused, naming what it found ==="
+mkdir -p /root/somerepo && cd /root/somerepo && git init -q && echo '{}' > package.json && mkdir -p src
+$BC init --onboard > /root/refuse.log 2>&1
+test $? -eq 1 || { echo "a code project was NOT refused"; exit 1; }
+cat /root/refuse.log
+grep -q "first run refused (project)" /root/refuse.log || exit 1
+grep -q "package.json" /root/refuse.log || exit 1
+grep -q "src/" /root/refuse.log || exit 1
+test -d /root/somerepo/.bridge-commander && { echo "it wrote state into a refused dir"; exit 1; }
+
+echo "=== FIRST-RUN.md: no tmux yet -> blocked, with an install command and NO tmux command ==="
+mkdir -p /root/myfleet && cd /root/myfleet
+$BC init --onboard --port 4790 > /root/notmux.log 2>&1
+test $? -eq 1 || { echo "a machine without tmux was NOT blocked"; exit 1; }
+cat /root/notmux.log
+grep -q "first run blocked (tmux-missing)" /root/notmux.log || exit 1
+grep -q "apt-get install -y tmux" /root/notmux.log || exit 1
+grep -qE "tmux (new|attach|new-session)" /root/notmux.log && { echo "it asked someone to type a tmux command"; exit 1; }
+
+echo "=== what the agent does after asking: install tmux, run the same command again ==="
+apt-get update -qq >/dev/null && apt-get install -y -qq tmux >/dev/null 2>&1
+tmux -V || exit 1
+
+echo "=== the first run itself (no authenticated claude in here — the board must come up anyway) ==="
+cd /root/myfleet
+$BC init --onboard --port 4790 > /root/init.log 2>&1
 cat /root/init.log
-grep -q "founding lieutenant" /root/init.log || exit 1
+grep -q "board: http://localhost:4790/" /root/init.log || exit 1
 curl -sf http://127.0.0.1:4790/api/status | grep -q '"workspace":"/root/myfleet"' || exit 1
+
+echo "=== Bridget: registered, chartered, and already talking ==="
+test -s /root/myfleet/lieutenants/bridget/README.md || exit 1
+curl -sf http://127.0.0.1:4790/api/board > /root/board.json
+grep -q '"id":"bridget"' /root/board.json || exit 1
+grep -q "Welcome aboard" /root/board.json || exit 1
+curl -sf http://127.0.0.1:4790/api/onboarding | grep -q '"step":"board-up"' || exit 1
+
+echo "=== the git-identity warning is a warning, not a wall ==="
+grep -q "git has no identity here" /root/init.log || exit 1
+
+echo "=== twice in a row: a re-run resumes, it does not restart ==="
+$BC init --onboard --port 4790 > /root/init2.log 2>&1
+cat /root/init2.log
+grep -q "charter left alone" /root/init2.log || exit 1
+grep -q "welcome message already on the board" /root/init2.log || exit 1
+grep -q "resuming, not restarting" /root/init2.log || exit 1
+test "$(grep -c 'Welcome aboard' /root/board.json)" = "1" || exit 1
+
+echo "=== the tools the README no longer asks for, installed the way Bridget would ==="
+export PATH="$HOME/.local/bin:$HOME/bin:$PATH"
+curl -fsSL https://kunchenguid.github.io/treehouse/install.sh | sh || exit 1
+command -v treehouse || exit 1
+curl -fsSL https://raw.githubusercontent.com/kunchenguid/no-mistakes/main/docs/install.sh | sh || exit 1
+command -v no-mistakes || exit 1
+
 echo INSTALL_TEST_PASS
 PHASE1
 
@@ -87,6 +132,12 @@ exec sleep infinity
 SHIM
 chmod +x /usr/local/bin/claude
 
+# The git identity the demo commits need. The first run only WARNED about it missing —
+# it is not a precondition for a board, only for a commit.
+git config --global user.email demo@example.com
+git config --global user.name "Demo User"
+git config --global init.defaultBranch main
+
 for p in nimbus-web nimbus-api; do
   mkdir -p /root/src/$p && cd /root/src/$p
   git init -q
@@ -95,8 +146,11 @@ for p in nimbus-web nimbus-api; do
 done
 cd /root/myfleet
 
-$BC project add /root/src/nimbus-web --mode direct-PR
-$BC project add /root/src/nimbus-api --mode local-only
+$BC project add /root/src/nimbus-web
+$BC project add /root/src/nimbus-api
+# Phase 1 leaves Bridget (the onboarding lieutenant) on the board; these two own the
+# demo cards.
+$BC lieutenant create --name Dax --id dax
 $BC lieutenant create --name Kira --id kira
 
 # The demo board is READ, so its cards carry readable ids — and the CLI no

--- a/test/install/docker-install-test.sh
+++ b/test/install/docker-install-test.sh
@@ -104,7 +104,9 @@ grep -q "claude.ai/install.sh" /root/init.log || exit 1
 # question is about that folder, not about $HOME.
 # …with the launch flag, because the bypass-permissions consent screen is raised
 # BY that flag: a hand-run of plain `claude` can never clear it.
-grep -q "cd /root/myfleet && claude --dangerously-skip-permissions" /root/init.log || exit 1
+# …and as root, with IS_SANDBOX=1, or the recipe dies on the root refusal it is
+# meant to get them past — the same escape hatch --allow-root gives her spawn.
+grep -q "cd /root/myfleet && IS_SANDBOX=1 claude --dangerously-skip-permissions" /root/init.log || exit 1
 # The installer does not edit PATH, and root's ~/.profile does not pick up ~/.local/bin.
 grep -q 'PATH="$HOME/.local/bin:$PATH"' /root/init.log || exit 1
 grep -q "not installed, or not logged in" /root/init.log && { echo "it guessed at a cause it did not check"; exit 1; }

--- a/test/install/docker-install-test.sh
+++ b/test/install/docker-install-test.sh
@@ -102,7 +102,11 @@ grep -q "is not on PATH" /root/init.log || exit 1
 grep -q "claude.ai/install.sh" /root/init.log || exit 1
 # …and the by-hand run has to happen in the WORKSPACE, because the folder-trust
 # question is about that folder, not about $HOME.
-grep -q "cd /root/myfleet && claude" /root/init.log || exit 1
+# …with the launch flag, because the bypass-permissions consent screen is raised
+# BY that flag: a hand-run of plain `claude` can never clear it.
+grep -q "cd /root/myfleet && claude --dangerously-skip-permissions" /root/init.log || exit 1
+# The installer does not edit PATH, and root's ~/.profile does not pick up ~/.local/bin.
+grep -q 'PATH="$HOME/.local/bin:$PATH"' /root/init.log || exit 1
 grep -q "not installed, or not logged in" /root/init.log && { echo "it guessed at a cause it did not check"; exit 1; }
 grep -q "board: http://localhost:4790/" /root/init.log || exit 1
 curl -sf http://127.0.0.1:4790/api/status | grep -q '"workspace":"/root/myfleet"' || exit 1

--- a/test/install/docker-install-test.sh
+++ b/test/install/docker-install-test.sh
@@ -74,15 +74,31 @@ cat /root/notmux.log
 grep -q "first run blocked (tmux-missing)" /root/notmux.log || exit 1
 grep -q "apt-get install -y tmux" /root/notmux.log || exit 1
 grep -qE "tmux (new|attach|new-session)" /root/notmux.log && { echo "it asked someone to type a tmux command"; exit 1; }
-
-echo "=== what the agent does after asking: install tmux, run the same command again ==="
-apt-get update -qq >/dev/null && apt-get install -y -qq tmux >/dev/null 2>&1
+# We are root and there is no sudo in this image: a printed `sudo ...` dies with
+# "sudo: command not found", which reads as broken instructions.
+grep -q "sudo" /root/notmux.log && { echo "it printed sudo on a box with no sudo"; exit 1; }
+# The command it printed has to actually run, verbatim.
+eval "$(grep -oE '(sudo )?apt-get update.*' /root/notmux.log | head -1)" || exit 1
 tmux -V || exit 1
 
-echo "=== the first run itself (no authenticated claude in here — the board must come up anyway) ==="
+echo "=== root: blocked BEFORE anything is spawned, with the real reason ==="
 cd /root/myfleet
-$BC init --onboard --port 4790 > /root/init.log 2>&1
+$BC init --onboard --port 4790 > /root/root.log 2>&1
+test $? -eq 1 || { echo "running as root was NOT blocked"; exit 1; }
+cat /root/root.log
+grep -q "first run blocked (root)" /root/root.log || exit 1
+grep -q "useradd" /root/root.log || exit 1
+grep -q -- "--allow-root" /root/root.log || exit 1
+
+echo "=== the first run itself, on a throwaway box (no claude in here — the board must come up anyway) ==="
+cd /root/myfleet
+$BC init --onboard --port 4790 --allow-root > /root/init.log 2>&1
 cat /root/init.log
+
+echo "=== a missing agent CLI is named as missing, and never guessed at ==="
+grep -q "is not on PATH" /root/init.log || exit 1
+grep -q "npm i -g @anthropic-ai/claude-code" /root/init.log || exit 1
+grep -q "not installed, or not logged in" /root/init.log && { echo "it guessed at a cause it did not check"; exit 1; }
 grep -q "board: http://localhost:4790/" /root/init.log || exit 1
 curl -sf http://127.0.0.1:4790/api/status | grep -q '"workspace":"/root/myfleet"' || exit 1
 
@@ -97,7 +113,7 @@ echo "=== the git-identity warning is a warning, not a wall ==="
 grep -q "git has no identity here" /root/init.log || exit 1
 
 echo "=== twice in a row: a re-run resumes, it does not restart ==="
-$BC init --onboard --port 4790 > /root/init2.log 2>&1
+$BC init --onboard --port 4790 --allow-root > /root/init2.log 2>&1
 cat /root/init2.log
 grep -q "charter left alone" /root/init2.log || exit 1
 grep -q "welcome message already on the board" /root/init2.log || exit 1

--- a/test/install/docker-install-test.sh
+++ b/test/install/docker-install-test.sh
@@ -97,7 +97,12 @@ cat /root/init.log
 
 echo "=== a missing agent CLI is named as missing, and never guessed at ==="
 grep -q "is not on PATH" /root/init.log || exit 1
-grep -q "npm i -g @anthropic-ai/claude-code" /root/init.log || exit 1
+# The install route has to work for the user who will RUN it: `npm i -g` is EACCES
+# for exactly the normal user the root block tells them to become.
+grep -q "claude.ai/install.sh" /root/init.log || exit 1
+# …and the by-hand run has to happen in the WORKSPACE, because the folder-trust
+# question is about that folder, not about $HOME.
+grep -q "cd /root/myfleet && claude" /root/init.log || exit 1
 grep -q "not installed, or not logged in" /root/init.log && { echo "it guessed at a cause it did not check"; exit 1; }
 grep -q "board: http://localhost:4790/" /root/init.log || exit 1
 curl -sf http://127.0.0.1:4790/api/status | grep -q '"workspace":"/root/myfleet"' || exit 1
@@ -119,6 +124,19 @@ grep -q "charter left alone" /root/init2.log || exit 1
 grep -q "welcome message already on the board" /root/init2.log || exit 1
 grep -q "resuming, not restarting" /root/init2.log || exit 1
 test "$(grep -c 'Welcome aboard' /root/board.json)" = "1" || exit 1
+
+echo "=== --host after the board is already up: rebinds, persists, prints a URL that works ==="
+IP=$(hostname -i | awk '{print $1}')
+$BC init --onboard --port 4790 --allow-root --host "$IP" > /root/host.log 2>&1
+cat /root/host.log
+grep -q "restarting it on the new address" /root/host.log || exit 1
+grep -q "board: http://$IP:4790/" /root/host.log || exit 1
+grep -q "board: http://localhost" /root/host.log && { echo "it handed over a URL the browser cannot reach"; exit 1; }
+grep -q "\"host\": \"$IP\"" /root/myfleet/.bridge-commander/config.json || exit 1
+curl -sf "http://$IP:4790/api/status" | grep -q "\"host\":\"$IP\"" || exit 1
+# …and back to loopback, so the rest of the run is where it was.
+$BC init --onboard --port 4790 --allow-root --host 127.0.0.1 > /root/host2.log 2>&1
+grep -q "board: http://localhost:4790/" /root/host2.log || exit 1
 
 echo "=== the tools the README no longer asks for, installed the way Bridget would ==="
 export PATH="$HOME/.local/bin:$HOME/bin:$PATH"

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -7,7 +7,26 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { startServerWithLieutenant, runCli, freePort } = require('./helper');
+const { startServerWithLieutenant, runCli } = require('./helper');
+
+// Ports for this file come from a fixed low band, NOT from helper's freePort().
+// freePort() asks the OS for an ephemeral port and closes it again, so the port
+// is only a suggestion — every test in the suite that boots a server is racing
+// for the same pool, and the loser sees somebody else's server answering on
+// "its" port. These tests boot several real servers through the CLI, so they
+// stay out of that pool entirely instead of adding pressure to it.
+function lowPort(from = 4900) {
+  return new Promise((resolve, reject) => {
+    let port = from;
+    const tryOne = () => {
+      if (port > 4990) return reject(new Error('no free port in ' + from + '-4990'));
+      const srv = require('node:net').createServer();
+      srv.once('error', () => { port += 2; tryOne(); });
+      srv.listen(port, '127.0.0.1', () => srv.close(() => resolve(port)));
+    };
+    tryOne();
+  });
+}
 
 // HOME is redirected so the run cannot touch the developer's own ~/.claude
 // (the worker-duties skill symlink) or read their real git identity — which
@@ -45,7 +64,7 @@ test('onboarding state is board state: set, read, validated, and shipped with th
 test('init --onboard leaves a board with Bridget on it, and a re-run resumes', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await freePort();
+  const port = await lowPort();
   const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
   try {
     let r = await runCli(args, onboardEnv(home));
@@ -105,7 +124,7 @@ test('init --onboard continues an existing workspace instead of refusing it', as
   // folder is now full of the scaffolding a code-project test would trip on.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await freePort();
+  const port = await lowPort();
   const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
   try {
     fs.writeFileSync(path.join(dir, 'package.json'), '{}'); // a repo would be refused…
@@ -135,7 +154,7 @@ test('--host on an already-running board rebinds it, prints the reachable URL, a
   // loopback, still printing localhost, and nothing written down.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await freePort();
+  const port = await lowPort();
   const base = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
   // A second loopback address: bindable, not 127.0.0.1, and reachable from here
   // — so this stays a real rebind without opening anything to the network.
@@ -168,9 +187,9 @@ test('--host on an already-running board rebinds it, prints the reachable URL, a
 // another test in this run is about to try to bind.
 function squatLowPort() {
   return new Promise((resolve, reject) => {
-    let port = 4900;
+    let port = 4950; // a slice of the band the other tests here do not reach first
     const tryOne = () => {
-      if (port > 4990) return reject(new Error('no free port in 4900-4990'));
+      if (port > 4990) return reject(new Error('no free port in 4950-4990'));
       const srv = require('node:net').createServer();
       srv.once('error', () => { port += 2; tryOne(); });
       srv.listen(port, '127.0.0.1', () => resolve({ srv, port }));

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -128,6 +128,41 @@ test('init --onboard continues an existing workspace instead of refusing it', as
   }
 });
 
+test('--host on an already-running board rebinds it, prints the reachable URL, and persists', async () => {
+  // Round 2 of the install test: the person gets a board first and discovers
+  // only afterwards that their browser cannot reach it. Asking for a bind at
+  // that point used to do nothing at all — "server already running", still
+  // loopback, still printing localhost, and nothing written down.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const port = await freePort();
+  const base = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+  // A second loopback address: bindable, not 127.0.0.1, and reachable from here
+  // — so this stays a real rebind without opening anything to the network.
+  const HOST = '127.0.0.2';
+  try {
+    let r = await runCli(base, onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /board: http:\/\/localhost:/, 'a loopback board says localhost');
+
+    r = await runCli(base.concat('--host', HOST), onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stderr, /restarting it on the new address/, 'the flag is not silently ignored');
+    assert.match(r.stdout, new RegExp('board: http://' + HOST + ':' + port + '/'),
+      'the URL handed over is the one that works');
+    assert.doesNotMatch(r.stdout, /board: http:\/\/localhost/);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(dir, '.bridge-commander', 'config.json'), 'utf8'));
+    assert.strictEqual(cfg.host, HOST, 'a bind that does not survive a restart is not a bind');
+    const st = await (await fetch('http://' + HOST + ':' + port + '/api/status')).json();
+    assert.strictEqual(st.host, HOST, 'and the server says what it actually bound');
+  } finally {
+    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
 // The walk-forward test needs a base OUTSIDE the ephemeral range: it binds
 // base+1 itself, and a port the OS is still handing out to freePort() is a port
 // another test in this run is about to try to bind.

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -7,26 +7,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
-const { startServerWithLieutenant, runCli } = require('./helper');
-
-// Ports for this file come from a fixed low band, NOT from helper's freePort().
-// freePort() asks the OS for an ephemeral port and closes it again, so the port
-// is only a suggestion — every test in the suite that boots a server is racing
-// for the same pool, and the loser sees somebody else's server answering on
-// "its" port. These tests boot several real servers through the CLI, so they
-// stay out of that pool entirely instead of adding pressure to it.
-function lowPort(from = 4900) {
-  return new Promise((resolve, reject) => {
-    let port = from;
-    const tryOne = () => {
-      if (port > 4990) return reject(new Error('no free port in ' + from + '-4990'));
-      const srv = require('node:net').createServer();
-      srv.once('error', () => { port += 2; tryOne(); });
-      srv.listen(port, '127.0.0.1', () => srv.close(() => resolve(port)));
-    };
-    tryOne();
-  });
-}
+const { startServerWithLieutenant, runCli, freePort, retryOnPortClash } = require('./helper');
 
 // HOME is redirected so the run cannot touch the developer's own ~/.claude
 // (the worker-duties skill symlink) or read their real git identity — which
@@ -37,6 +18,45 @@ function onboardEnv(home) {
     GIT_CONFIG_GLOBAL: path.join(home, 'gitconfig-none'),
     GIT_CONFIG_SYSTEM: '/dev/null',
   };
+}
+
+function squatPort() {
+  return new Promise((resolve, reject) => {
+    const srv = require('node:net').createServer((c) => c.destroy());
+    srv.once('error', reject);
+    srv.listen(0, '127.0.0.1', () => resolve({
+      port: srv.address().port,
+      release: () => new Promise((r) => srv.close(r)),
+    }));
+  });
+}
+
+function serverLog(dir) {
+  try { return fs.readFileSync(path.join(dir, '.bridge-commander', 'server.log'), 'utf8'); }
+  catch (e) { return ''; }
+}
+
+// `init --onboard` boots a server this test does not control, so it can lose the
+// port between reserving it and the server binding it — the same race
+// ensure-server.test.js wraps, and the same two faces: our boot could not bind,
+// or somebody else's board is answering on the number. Either one earns another
+// go on a fresh port; nothing else does.
+//
+// The port is threaded back out because everything after the first boot in these
+// tests — re-runs, `onboarding set`, `stop` — has to reach the SAME board.
+function bootOnboard(dir, home, extra = []) {
+  return retryOnPortClash(async () => {
+    const port = await freePort();
+    const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+    const r = await runCli(args.concat(extra), onboardEnv(home));
+    if (r.code !== 0 && /EADDRINUSE/.test(serverLog(dir))) throw new Error('EADDRINUSE: boot lost the port');
+    if (r.code === 0 && !r.stdout.includes('port ' + port)) {
+      // It walked forward off a port somebody else holds — correct behaviour,
+      // and it means the number we reserved is not the one it is on.
+      throw new Error('EADDRINUSE: ' + port + ' was taken, the run moved: ' + r.stdout.trim());
+    }
+    return { port, args, r };
+  });
 }
 
 test('onboarding state is board state: set, read, validated, and shipped with the board', async () => {
@@ -64,10 +84,9 @@ test('onboarding state is board state: set, read, validated, and shipped with th
 test('init --onboard leaves a board with Bridget on it, and a re-run resumes', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await lowPort();
-  const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+  let port; let args; let r;
   try {
-    let r = await runCli(args, onboardEnv(home));
+    ({ port, args, r } = await bootOnboard(dir, home));
     assert.strictEqual(r.code, 0, r.stderr + r.stdout);
     assert.match(r.stdout, new RegExp('board: http://localhost:' + port + '/'));
     // git identity is a WARNING, never a wall: the board came up without one.
@@ -113,7 +132,7 @@ test('init --onboard leaves a board with Bridget on it, and a re-run resumes', a
     r = await runCli(['onboarding', '--workspace', dir, '--port', String(port), '--json']);
     assert.strictEqual(JSON.parse(r.stdout).step, 'tools');
   } finally {
-    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    if (port) await runCli(['stop', '--workspace', dir, '--port', String(port)]);
     fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(home, { recursive: true, force: true });
   }
@@ -124,16 +143,17 @@ test('init --onboard continues an existing workspace instead of refusing it', as
   // folder is now full of the scaffolding a code-project test would trip on.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await lowPort();
-  const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+  let port; let args; let r;
   try {
     fs.writeFileSync(path.join(dir, 'package.json'), '{}'); // a repo would be refused…
-    let r = await runCli(args, onboardEnv(home));
-    assert.strictEqual(r.code, 1);
-    assert.match(r.stderr, /first run refused \(project\)/);
+    // The refusal binds nothing, so it needs no port of its own.
+    const refused = await runCli(
+      ['init', '--onboard', '--workspace', dir, '--port', '0', '--harness', 'fake'], onboardEnv(home));
+    assert.strictEqual(refused.code, 1);
+    assert.match(refused.stderr, /first run refused \(project\)/);
 
     // …until the person says this folder is the workspace.
-    r = await runCli(args.concat('--here'), onboardEnv(home));
+    ({ port, args, r } = await bootOnboard(dir, home, ['--here']));
     assert.strictEqual(r.code, 0, r.stderr + r.stdout);
 
     // From here on the workspace answer wins on its own — no --here needed.
@@ -141,7 +161,7 @@ test('init --onboard continues an existing workspace instead of refusing it', as
     assert.strictEqual(r.code, 0, r.stderr + r.stdout);
     assert.match(r.stdout, /welcome message already on the board/);
   } finally {
-    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    if (port) await runCli(['stop', '--workspace', dir, '--port', String(port)]);
     fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(home, { recursive: true, force: true });
   }
@@ -154,13 +174,12 @@ test('--host on an already-running board rebinds it, prints the reachable URL, a
   // loopback, still printing localhost, and nothing written down.
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const port = await lowPort();
-  const base = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
   // A second loopback address: bindable, not 127.0.0.1, and reachable from here
   // — so this stays a real rebind without opening anything to the network.
   const HOST = '127.0.0.2';
+  let port; let base; let r;
   try {
-    let r = await runCli(base, onboardEnv(home));
+    ({ port, args: base, r } = await bootOnboard(dir, home));
     assert.strictEqual(r.code, 0, r.stderr + r.stdout);
     assert.match(r.stdout, /board: http:\/\/localhost:/, 'a loopback board says localhost');
 
@@ -176,46 +195,41 @@ test('--host on an already-running board rebinds it, prints the reachable URL, a
     const st = await (await fetch('http://' + HOST + ':' + port + '/api/status')).json();
     assert.strictEqual(st.host, HOST, 'and the server says what it actually bound');
   } finally {
-    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    if (port) await runCli(['stop', '--workspace', dir, '--port', String(port)]);
     fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(home, { recursive: true, force: true });
   }
 });
 
-// The walk-forward test needs a base OUTSIDE the ephemeral range: it binds
-// base+1 itself, and a port the OS is still handing out to freePort() is a port
-// another test in this run is about to try to bind.
-function squatLowPort() {
-  return new Promise((resolve, reject) => {
-    let port = 4950; // a slice of the band the other tests here do not reach first
-    const tryOne = () => {
-      if (port > 4990) return reject(new Error('no free port in 4950-4990'));
-      const srv = require('node:net').createServer();
-      srv.once('error', () => { port += 2; tryOne(); });
-      srv.listen(port, '127.0.0.1', () => resolve({ srv, port }));
-    };
-    tryOne();
-  });
-}
-
+// The squatter: an OS-assigned port (the repo's rule — nothing pinned) held for
+// as long as the test wants it. It hangs up on anything that connects, because
+// the CLI PROBES the port it was asked for before walking on, and a probe
+// connection left open would keep close() waiting forever — reservePort()'s
+// release() is written for a port nobody talks to.
 test('init --onboard walks forward off a port somebody else is holding', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const { srv: squatter, port: taken } = await squatLowPort();
+  const held = await squatPort();
   try {
-    const r = await runCli(
-      ['init', '--onboard', '--workspace', dir, '--port', String(taken), '--harness', 'fake'],
-      onboardEnv(home));
+    // The port it walks ONTO is another number nobody promised us, so this is
+    // the same lost-port race as any other boot here.
+    const r = await retryOnPortClash(async () => {
+      const out = await runCli(
+        ['init', '--onboard', '--workspace', dir, '--port', String(held.port), '--harness', 'fake'],
+        onboardEnv(home));
+      if (out.code !== 0 && /EADDRINUSE/.test(serverLog(dir))) throw new Error('EADDRINUSE: boot lost the port');
+      return out;
+    });
     assert.strictEqual(r.code, 0, r.stderr + r.stdout);
-    assert.match(r.stderr, new RegExp('port ' + taken + ' was taken'));
+    assert.match(r.stderr, new RegExp('port ' + held.port + ' was taken'));
     const used = JSON.parse(fs.readFileSync(path.join(dir, '.bridge-commander', 'config.json'), 'utf8')).port;
-    assert.ok(used > taken, 'it moved forward and wrote the port it landed on');
+    assert.ok(used > held.port, 'it moved forward and wrote the port it landed on');
     // …and wrote it down, so every later bc-axi call in this workspace finds it.
     const st = await runCli(['status', '--workspace', dir]);
     assert.match(st.stdout, /server: up/);
     await runCli(['stop', '--workspace', dir]);
   } finally {
-    squatter.close();
+    await held.release();
     fs.rmSync(dir, { recursive: true, force: true });
     fs.rmSync(home, { recursive: true, force: true });
   }

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -128,12 +128,26 @@ test('init --onboard continues an existing workspace instead of refusing it', as
   }
 });
 
+// The walk-forward test needs a base OUTSIDE the ephemeral range: it binds
+// base+1 itself, and a port the OS is still handing out to freePort() is a port
+// another test in this run is about to try to bind.
+function squatLowPort() {
+  return new Promise((resolve, reject) => {
+    let port = 4900;
+    const tryOne = () => {
+      if (port > 4990) return reject(new Error('no free port in 4900-4990'));
+      const srv = require('node:net').createServer();
+      srv.once('error', () => { port += 2; tryOne(); });
+      srv.listen(port, '127.0.0.1', () => resolve({ srv, port }));
+    };
+    tryOne();
+  });
+}
+
 test('init --onboard walks forward off a port somebody else is holding', async () => {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
   const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
-  const taken = await freePort();
-  const squatter = require('node:net').createServer();
-  await new Promise((r) => squatter.listen(taken, '127.0.0.1', r));
+  const { srv: squatter, port: taken } = await squatLowPort();
   try {
     const r = await runCli(
       ['init', '--onboard', '--workspace', dir, '--port', String(taken), '--harness', 'fake'],

--- a/test/onboarding.test.js
+++ b/test/onboarding.test.js
@@ -1,0 +1,154 @@
+'use strict';
+// `bc-axi init --onboard` end to end: an empty folder becomes a board with
+// Bridget on it, already talking — and running it a second time resumes that
+// first run instead of starting it over.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { startServerWithLieutenant, runCli, freePort } = require('./helper');
+
+// HOME is redirected so the run cannot touch the developer's own ~/.claude
+// (the worker-duties skill symlink) or read their real git identity — which
+// also puts the git-identity warning path under test for free.
+function onboardEnv(home) {
+  return {
+    HOME: home,
+    GIT_CONFIG_GLOBAL: path.join(home, 'gitconfig-none'),
+    GIT_CONFIG_SYSTEM: '/dev/null',
+  };
+}
+
+test('onboarding state is board state: set, read, validated, and shipped with the board', async () => {
+  const s = await startServerWithLieutenant();
+  try {
+    assert.deepStrictEqual((await s.api('GET', '/api/onboarding')).body, { onboarding: null });
+
+    let r = await s.api('POST', '/api/onboarding', { step: 'board-up', gitIdentity: false });
+    assert.strictEqual(r.status, 200);
+    assert.strictEqual(r.body.onboarding.step, 'board-up');
+
+    r = await s.api('POST', '/api/onboarding', { step: 'project' });
+    assert.strictEqual(r.body.onboarding.step, 'project');
+    assert.strictEqual(r.body.onboarding.gitIdentity, false, 'a step change keeps what was recorded');
+
+    r = await s.api('POST', '/api/onboarding', { step: 'halfway' });
+    assert.strictEqual(r.status, 400, 'an unknown step is refused, not silently stored');
+
+    // The board can see it — that is the whole point of it not being a local file.
+    const board = await s.api('GET', '/api/board');
+    assert.strictEqual(board.body.onboarding.step, 'project');
+  } finally { await s.stop(); }
+});
+
+test('init --onboard leaves a board with Bridget on it, and a re-run resumes', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const port = await freePort();
+  const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+  try {
+    let r = await runCli(args, onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, new RegExp('board: http://localhost:' + port + '/'));
+    // git identity is a WARNING, never a wall: the board came up without one.
+    assert.match(r.stderr, /git has no identity here/);
+
+    const api = async (p) => (await fetch('http://127.0.0.1:' + port + p)).json();
+
+    // …a chartered lieutenant, spawned…
+    const { lieutenants } = await api('/api/board');
+    assert.strictEqual(lieutenants.length, 1);
+    const bridget = lieutenants[0];
+    assert.strictEqual(bridget.id, 'bridget');
+    assert.strictEqual(bridget.prefix, 'BRI');
+    assert.ok(bridget.ref && bridget.ref.session, 'her session was started');
+    const charter = fs.readFileSync(path.join(dir, 'lieutenants', 'bridget', 'README.md'), 'utf8');
+    assert.match(charter, /onboarding lieutenant/i);
+    assert.match(charter, /bc-axi onboarding/, 'her charter tells her where the first-run state is');
+
+    // …with a message already waiting, before anyone has said anything.
+    assert.strictEqual(bridget.chat.length, 1);
+    assert.strictEqual(bridget.chat[0].author, 'Bridget');
+    assert.match(bridget.chat[0].text, /Welcome aboard/);
+
+    // …and first-run state the board can see.
+    assert.strictEqual((await api('/api/onboarding')).onboarding.step, 'board-up');
+    assert.strictEqual((await api('/api/onboarding')).onboarding.gitIdentity, false);
+
+    // A re-run is a resume: no second welcome, no second charter, no spawning
+    // over a live session, and the step it had reached is kept.
+    r = await runCli(['onboarding', 'set', 'tools', '--workspace', dir, '--port', String(port)]);
+    assert.strictEqual(r.code, 0, r.stderr);
+    r = await runCli(args, onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /charter left alone/);
+    assert.match(r.stdout, /welcome message already on the board/);
+    assert.match(r.stdout, /session is already live/);
+    assert.match(r.stdout, /resuming, not restarting/);
+
+    const after = (await api('/api/board')).lieutenants[0];
+    assert.strictEqual(after.chat.length, 1, 'the welcome is seeded exactly once');
+    assert.strictEqual((await api('/api/onboarding')).onboarding.step, 'tools');
+
+    r = await runCli(['onboarding', '--workspace', dir, '--port', String(port), '--json']);
+    assert.strictEqual(JSON.parse(r.stdout).step, 'tools');
+  } finally {
+    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('init --onboard continues an existing workspace instead of refusing it', async () => {
+  // The re-entry case, and the reason the workspace check comes first: this
+  // folder is now full of the scaffolding a code-project test would trip on.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const port = await freePort();
+  const args = ['init', '--onboard', '--workspace', dir, '--port', String(port), '--harness', 'fake'];
+  try {
+    fs.writeFileSync(path.join(dir, 'package.json'), '{}'); // a repo would be refused…
+    let r = await runCli(args, onboardEnv(home));
+    assert.strictEqual(r.code, 1);
+    assert.match(r.stderr, /first run refused \(project\)/);
+
+    // …until the person says this folder is the workspace.
+    r = await runCli(args.concat('--here'), onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+
+    // From here on the workspace answer wins on its own — no --here needed.
+    r = await runCli(args, onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stdout, /welcome message already on the board/);
+  } finally {
+    await runCli(['stop', '--workspace', dir, '--port', String(port)]);
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('init --onboard walks forward off a port somebody else is holding', async () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-onboard-'));
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-home-'));
+  const taken = await freePort();
+  const squatter = require('node:net').createServer();
+  await new Promise((r) => squatter.listen(taken, '127.0.0.1', r));
+  try {
+    const r = await runCli(
+      ['init', '--onboard', '--workspace', dir, '--port', String(taken), '--harness', 'fake'],
+      onboardEnv(home));
+    assert.strictEqual(r.code, 0, r.stderr + r.stdout);
+    assert.match(r.stderr, new RegExp('port ' + taken + ' was taken'));
+    const used = JSON.parse(fs.readFileSync(path.join(dir, '.bridge-commander', 'config.json'), 'utf8')).port;
+    assert.ok(used > taken, 'it moved forward and wrote the port it landed on');
+    // …and wrote it down, so every later bc-axi call in this workspace finds it.
+    const st = await runCli(['status', '--workspace', dir]);
+    assert.match(st.stdout, /server: up/);
+    await runCli(['stop', '--workspace', dir]);
+  } finally {
+    squatter.close();
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
The README asked for two installs before anyone had seen the thing work. Now it asks for one — the skill — and everything after happens in the terminal the user already has, most of it in conversation with **Bridget**, the onboarding lieutenant.

## The shape

`bc-axi init --onboard` — the first run, from a session that is **not** in tmux (the user's own Claude Code, in an empty folder):

1. **What is this directory?** Decided before a byte is written, in the order that works: `.bridge-commander/` present → continue (a workspace is itself a git repo, so this check has to be first); empty → go; a `.git/`, a manifest or source files → refuse, **naming what it found**; anything else non-empty → a judgement call that says what is there and points at `--here`.
2. **Can this machine run a board?** Nothing is installed. Missing tmux blocks with the install command for *this* box and an instruction to ask first. Running as root blocks *before* anything is spawned, because Claude Code refuses `--dangerously-skip-permissions` as uid 0 and Bridget could never start. Missing git identity is a **warning** — a board does not need one, and a first run should not die on it; it is recorded so Bridget raises it before the first card. A taken port walks forward and writes down where it landed.
3. **Bridget.** Chartered from `onboarding/bridget.md`, spawned into her own tmux session, with a **welcome message seeded on the board before the person has said anything**.
4. **First-run state on the board** (`bc-axi onboarding`, steps `board-up → tools → project → checklist → done`), so a re-run resumes instead of restarting.

A failed spawn does not take the board down with it: the board is up, the welcome is on it, and the same command again picks up where it stopped.

`FIRST-RUN.md` is the reference file the user's own agent reads. It covers exactly the first run and ends where Bridget begins.

## The rule that is enforced, not just documented

No message anywhere asks anyone to type a tmux command — including the teleport `init`'s own out-of-tmux refusal, which now points at `--onboard`. There is a test for it.

## What four rounds in a clean container changed

A second worker installed this from the branch in a bare container and reported what broke, four times. Almost every fix here is theirs.

**The one worth reading.** Round 3: `Bridget's session started` was printed for a session that was not started. `UI_READY_RE` contained `/bypass permissions/i` — meant to match the live UI's status line, it also matched the title of the modal that *asks* for bypass permissions. So the readiness check passed on the screen that proves the opposite: a consent dialog waiting for a human, preselected on **`1. No, exit`**. The brief was then typed into that menu — meaning the flow could actively kill the session it had just reported as started, and then print a board URL as if all was well. A readiness regex that matches the question as well as the answer is not a check.

The fix is structural, not a better regex: `FATAL_RE` ends the 45-second wait the first time a pane shows a screen only a person can clear (root refusal, theme picker, folder-trust, bypass consent), and `verifyLive()` runs *after* the prompt is delivered, so a spawn that returns has read the pane and seen a live UI. Anything else fails with its own named case and the pane printed verbatim.

The other rounds, briefly: the tmux install command was printed with a bare `sudo` that does not exist as root; root was diagnosed as "the CLI is broken"; a never-run `claude` parked on the theme picker got the same wrong cause; `--host` was silently ignored, printed `localhost` anyway, and was not persisted; the `unknown` branch said "read it above" over nothing (the pane tail was never attached when `deliverPrompt` threw); and the two recommended install routes contradicted each other (`npm i -g` as root after telling them not to be root).

The through-line the captain named in round 1 and it holds for all of it: **stop asserting a cause you did not check.** Every failure block now reads the pane, classifies from what is in it, and prints it — including when it is empty, which it says in those words.

Not fixed on purpose: the board binds loopback and stays that way. `FIRST-RUN.md` §3 answers "my browser cannot reach it" with run-it-where-the-browser-is, `ssh -L`, and `--host` with the trade stated before the command.

## Open questions from the card, answered

- **Does Bridget retire?** She offers, once a second lieutenant exists. Never on her own.
- **Second workspace?** One Bridget per workspace — onboarding is per board.
- **Headless / ssh?** `FIRST-RUN.md` tells the agent to hand over the `ssh -L` tunnel line.
- **All checklist cards at once?** The first two (second lieutenant, then a card landing on a worker), then the advanced three once those work.

## Tests

`node --test test/*.test.js harness/test/*.test.js` → **879 pass, 0 fail**, four consecutive runs after rebasing onto MNC-69 (`009cd55`), whose reserve-then-retry port rule this branch now uses instead of the band it was carrying. New: `test/firstrun.test.js` (14), `test/onboarding.test.js` (5), plus verbatim pane captures in `harness/test/settle-screens.test.js` and a spawn test that refuses to report success over a screen waiting for a person. `test/install/docker-install-test.sh` now walks the stranger's path in a bare container and takes `BC_REPO_URL`/`BC_REF` so a branch can be tested before it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
