### PR TITLE
The clock gets a screen: a schedules tab beside hooks

### DIFF
--- a/test/hooks-tab.test.js
+++ b/test/hooks-tab.test.js
@@ -31,11 +31,15 @@ test('the hooks section is a section of the config screen, with the list it pain
   // list on every repaint, so the note cannot live inside it.
   assert.ok(html.includes('id="hk-note"'), 'the note the ▶ and the ✎ answer in');
   assert.ok(html.indexOf('id="hk-note"') > html.indexOf('id="hk-list"'), 'outside the list, after it');
-  assert.ok(!/listEl\.appendChild\(el\)|listEl\.textContent = '⚠ cannot open/.test(src),
-    'and neither a run outcome nor a failed open is written into the list');
-  // the tab is last — the four that were there keep their order
+  // …and both answers a press can give land in it, rather than in the list the
+  // next repaint clears
+  assert.match(src, /noteEl\.textContent = h\.name \+ ': ' \+ note/, 'the run outcome');
+  assert.match(src, /noteEl\.textContent = '⚠ cannot open/, 'and a failed open');
+  assert.ok(!/listEl\.textContent = '⚠ cannot open/.test(src), 'neither of them into the list');
+  // hooks is where it was — every tab added since goes after it, so the ones
+  // that were here keep their order and nothing moves under a finger
   const tabs = [...html.matchAll(/data-tab="([^"]+)"/g)].map((m) => m[1]);
-  assert.deepStrictEqual(tabs, ['labels', 'playbooks', 'projects', 'lieutenants', 'hooks']);
+  assert.deepStrictEqual(tabs, ['labels', 'playbooks', 'projects', 'lieutenants', 'hooks', 'schedules']);
 });
 
 test('a row is ONE line at a phone width: the name ellipses, the facts run stays whole', () => {
@@ -110,7 +114,7 @@ test('▶ and ✎ reuse the doors that exist — no hook API of their own', () =
 
 test('the section is wired into the screen the way every other one is', () => {
   const main = fs.readFileSync(ui('js', 'main.js'), 'utf8');
-  assert.match(main, /import \{ renderHooks \} from '\.\/hkmanager\.js'/);
+  assert.match(main, /import \{ renderHooks[^}]*\} from '\.\/hkmanager\.js'/);
   assert.match(main, /hooks: renderHooks/, 'one WS_RENDER entry, nothing else');
   assert.match(src, /export async function renderHooks\(reload\)/);
 });

--- a/test/schedules-tab.test.js
+++ b/test/schedules-tab.test.js
@@ -1,0 +1,203 @@
+'use strict';
+// The config screen's schedules tab — the clock MNC-25 shipped without a screen.
+//
+//   ▸ gh-watch  → gh-watch                              ⏸ ✕
+//     every 5m · in 3m · fired 2m ago · exit 0 · tonylampada
+//
+// scmanager.js binds DOM at import, so the parts that decide what a row SAYS
+// are lifted out of the source and run against stubs — the same spirit as
+// hooks-tab.test.js. What is pinned here: the markup lives in index.html, the
+// row speaks the CLI's own words, PAUSED is a state rather than a shade, a
+// `problem` is shown in full and in red, the server's refusal survives verbatim,
+// and nothing here grew an endpoint of its own.
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ui = (...p) => path.join(__dirname, '..', 'ui', ...p);
+const html = fs.readFileSync(ui('index.html'), 'utf8');
+const css = fs.readFileSync(ui('app.css'), 'utf8');
+const src = fs.readFileSync(ui('js', 'scmanager.js'), 'utf8');
+const apiSrc = fs.readFileSync(ui('js', 'api.js'), 'utf8');
+
+test('the schedules section is a section of the config screen, beside hooks', () => {
+  assert.ok(html.includes('data-tab="schedules"'), 'a tab for it');
+  assert.ok(html.includes('id="ss-schedules"'), 'and the section it names');
+  assert.ok(html.includes('data-sec="schedules"'));
+  assert.ok(html.includes('id="sc-list"'), 'the list');
+  // A press's only answer must outlive the next board event: paint() clears the
+  // list on every repaint, so the note cannot live inside it.
+  assert.ok(html.includes('id="sc-note"'), 'the note a press answers in');
+  assert.ok(html.indexOf('id="sc-note"') > html.indexOf('id="sc-list"'), 'outside the list, after it');
+  assert.ok(html.indexOf('data-tab="schedules"') > html.indexOf('data-tab="hooks"'),
+    'the clock reads next to the hooks it fires');
+});
+
+// The two decisions a row makes, lifted and run against records shaped like
+// GET /api/schedules answers.
+function loadRowText() {
+  const at = src.indexOf('function until');
+  const end = src.indexOf('\nfunction problem');
+  assert.ok(at > -1 && end > at, 'the wording helpers found in scmanager.js');
+  const document = { createElement: () => {
+    const parts = [];
+    const e = { parts, className: '', title: '', textContent: '', append: (...xs) => parts.push(...xs) };
+    Object.defineProperty(e, 'text', { get() {
+      return e.parts.map((p) => (typeof p === 'string' ? p : p.textContent)).join('');
+    } });
+    return e;
+  } };
+  const make = new Function('document', src.slice(at, end)
+    + '\nreturn { until, since, howRunEnded, fireOutcome, outcomeClass, facts };');
+  return make(document);
+}
+const iso = (deltaSec) => new Date(Date.now() + deltaSec * 1000).toISOString();
+
+test('next fire and last fire are relative, in the words the CLI prints', () => {
+  const { until, since, fireOutcome } = loadRowText();
+  assert.strictEqual(until(iso(180)), 'in 3m');
+  assert.strictEqual(until(iso(2 * 3600)), 'in 2h');
+  assert.strictEqual(until(iso(-5)), 'due now');
+  assert.strictEqual(until(null), 'never', 'a `when` that no longer parses has no next fire');
+  assert.strictEqual(since(iso(-120)), '2m ago');
+  assert.strictEqual(since(iso(-5)), '5s ago', 'a past firing is never "now"');
+  assert.strictEqual(fireOutcome(null), 'never fired', 'a schedule that never fired says so');
+  assert.strictEqual(fireOutcome({ started: iso(-120), code: 0, ok: true }), 'fired 2m ago · exit 0');
+  assert.strictEqual(fireOutcome({ started: iso(-3600), code: 3 }), 'fired 1h ago · exit 3');
+  // A skip IS a firing — a schedule whose every window is skipped must not read
+  // like one that is quietly working.
+  assert.strictEqual(fireOutcome({ started: iso(-120), skipped: true }),
+    'skipped 2m ago (previous firing still going)');
+});
+
+test('how a firing ended is said the one way the CLI says it', () => {
+  const { howRunEnded } = loadRowText();
+  assert.strictEqual(howRunEnded({ code: 0 }), 'exit 0');
+  assert.strictEqual(howRunEnded({ timedOut: true }), 'timed out');
+  assert.strictEqual(howRunEnded({ error: 'ENOENT' }), 'failed to start');
+  assert.strictEqual(howRunEnded({ canceled: true, code: null }), 'restarted mid-run');
+  assert.strictEqual(howRunEnded({ code: null }), 'killed');
+  assert.strictEqual(howRunEnded({ skipped: true }), 'skipped');
+});
+
+test('a row carries when, next fire, last fire and owner as one run', () => {
+  const { facts } = loadRowText();
+  assert.strictEqual(facts({ describe: 'every 5m', next: iso(180), owner: 'tonylampada',
+    last: { started: iso(-120), code: 0, ok: true } }).text,
+  'every 5m · in 3m · fired 2m ago · exit 0 · tonylampada');
+  // Paused replaces the next fire, because there is not one — printing a
+  // plausible "in 3m" for a clock that fires nothing is the lie the chip exists
+  // to stop.
+  assert.strictEqual(facts({ describe: 'cron 0 9 * * mon', next: iso(180), owner: 'tonylampada',
+    paused: true, last: null }).text,
+  'cron 0 9 * * mon · paused · never fired · tonylampada');
+  // A schedule with a problem HAS a next window and the tick will refuse it, so
+  // "in 3m" would be exactly the plausible-looking lie `problem` exists to
+  // replace.
+  assert.strictEqual(facts({ describe: 'every 5m', next: iso(180), owner: 'tonylampada',
+    problem: 'hook "doomed" is gone', last: null }).text,
+  'every 5m · fires nothing · never fired · tonylampada');
+});
+
+test('the last fire wears a colour, so a red schedule is what the eye lands on', () => {
+  const { outcomeClass } = loadRowText();
+  assert.strictEqual(outcomeClass(null), 'sc-never');
+  assert.strictEqual(outcomeClass({ ok: true }), 'sc-ok');
+  assert.strictEqual(outcomeClass({ ok: false }), 'sc-bad');
+  assert.strictEqual(outcomeClass({ skipped: true }), 'sc-skip');
+  assert.match(css, /\.sc-bad \{ color: var\(--danger\); \}/);
+});
+
+// The whole reason this tab is worth having: a schedule whose hook was deleted,
+// or whose `when` stopped parsing, fires nothing forever and looks exactly like
+// a working one.
+test('a problem is unmissable — the whole sentence, in red, on a red row', () => {
+  assert.match(src, /el\.textContent = '⚠ ' \+ s\.problem/, 'in full: never truncated, never a title');
+  assert.ok(!/s\.problem\.slice|s\.problem\.split/.test(src), 'and never cut down');
+  assert.match(src, /'sc-row' \+ \(s\.problem \? ' sc-broken' : ''\)/, 'the row itself is flagged');
+  assert.match(css, /\.sc-problem \{[^}]*color: var\(--danger\)/);
+  assert.match(css, /\.sc-row\.sc-broken \{ border-left-color: var\(--danger\); \}/);
+  assert.match(css, /\.sc-problem \{[^}]*overflow-wrap: anywhere/, 'a whole sentence wraps rather than clips');
+});
+
+test('paused is a state at a glance, not an inference from a greyed row', () => {
+  assert.match(src, /chip\.textContent = 'PAUSED'/);
+  assert.match(css, /\.sc-chip \{[^}]*color: var\(--warn\)/);
+  assert.match(css, /\.sc-row\.sc-off \{ border-left-color: var\(--warn\); \}/);
+});
+
+test('the hook name is the way to that hook — the tab switching stays main.js\'s', () => {
+  assert.match(src, /export function onOpenHook\(fn\)/);
+  assert.match(src, /b\.textContent = '→ ' \+ s\.hook/);
+  const main = fs.readFileSync(ui('js', 'main.js'), 'utf8');
+  assert.match(main, /onOpenHook\(\(name\) => \{ setWsTab\('hooks'\); focusHook\(name\); \}\)/);
+  const hk = fs.readFileSync(ui('js', 'hkmanager.js'), 'utf8');
+  assert.match(hk, /export function focusHook\(name\)/);
+  assert.match(hk, /marked\.scrollIntoView/, 'and the row it lands on is marked');
+  assert.match(css, /\.hk-focus \{/);
+});
+
+test('pause, resume and remove go through the CLI\'s own doors', () => {
+  assert.match(apiSrc, /pauseSchedule: \(name, paused\) => j\('PATCH', '\/api\/schedules\/' \+ encodeURIComponent\(name\), \{ paused \}\)/);
+  assert.match(apiSrc, /removeSchedule: \(name\) => j\('DELETE', '\/api\/schedules\/' \+ encodeURIComponent\(name\)\)/);
+  // Removing is destructive and asymmetric — the hook survives, and that is the
+  // part he cannot see from this screen.
+  assert.match(src, /confirm\('Remove the schedule/);
+  // "untouched", not "still there": the schedule most likely to be removed here
+  // is one whose hook is already gone.
+  assert.match(src, /is untouched — only the clock entry goes/);
+});
+
+test('add picks its hook and its owner rather than asking him to spell them', () => {
+  assert.ok(html.includes('id="sc-hook"') && html.includes('<select id="sc-hook"'), 'the hook is a picker');
+  assert.ok(html.includes('<select id="sc-owner"'), 'and so is the owner');
+  assert.match(src, /\.filter\(\(x\) => !x\.event\)/, 'over the NAMED hooks — a lifecycle hook is fired by its event');
+  assert.match(src, /api\.lieutenants\(\)/, 'and over the registered lieutenants');
+  // A repaint arrives on every board event; a picker rebuilt under his finger
+  // would lose the choice he just made.
+  assert.match(src, /if \(sel\.dataset\.filled === want\) return/);
+});
+
+test('the server\'s refusal is shown verbatim — it names the offending text', () => {
+  assert.match(src, /say\('⚠ ' \+ err\.message\)/);
+  // …and it reads as a refusal rather than as faint chatter
+  assert.match(src, /noteEl\.classList\.toggle\('sc-warn', text\.startsWith\('⚠'\)\)/);
+  assert.match(css, /#sc-note\.sc-warn \{ color: var\(--danger\); \}/);
+  assert.ok(!/'invalid'|'bad when'/.test(src), 'nothing here replaces the message with a word');
+});
+
+test('no new endpoints — every door is one bc-axi schedule already posts to', () => {
+  assert.match(apiSrc, /schedules: \(\) => j\('GET', '\/api\/schedules'\)/);
+  assert.match(apiSrc, /schedule: \(name\) => j\('GET', '\/api\/schedules\/' \+ encodeURIComponent\(name\)\)/);
+  assert.match(apiSrc, /addSchedule: \(s\) => j\('POST', '\/api\/schedules'/);
+  // The firings come off the trace through GET /api/schedules/<name>, filtered
+  // to this schedule's trigger server-side — no second copy, no second route.
+  assert.match(src, /api\.schedule\(s\.name\)\)\.runs/);
+  const calls = [...src.matchAll(/api\.(\w+)\(/g)].map((m) => m[1]).sort();
+  assert.deepStrictEqual([...new Set(calls)].sort(),
+    ['addSchedule', 'hooks', 'lieutenants', 'pauseSchedule', 'removeSchedule', 'schedule', 'schedules'],
+    'and the section calls nothing else');
+});
+
+test('the section is wired into the screen the way every other one is', () => {
+  const main = fs.readFileSync(ui('js', 'main.js'), 'utf8');
+  assert.match(main, /import \{ renderSchedules, onOpenHook \} from '\.\/scmanager\.js'/);
+  assert.match(main, /schedules: renderSchedules/, 'one WS_RENDER entry, nothing else');
+  assert.match(src, /export async function renderSchedules\(reload\)/);
+});
+
+// The tab's only nudge is the board event that already arrives — a schedule
+// fires, or is paused from the CLI, and a row must not go on lying about it.
+test('every render asks the server, and an in-flight press outlives the repaint', () => {
+  assert.ok(!/if \(items\) return paint\(\)/.test(src), 'a list read last time is not the answer');
+  assert.match(src, /const busy = new Set\(\)/, 'the press is state, not a mutated button');
+  assert.match(src, /busy\.add\(s\.name\)/);
+  assert.match(src, /busy\.delete\(s\.name\)/);
+  assert.ok(!/btn\.disabled|btn\.textContent/.test(src),
+    'nothing writes to a button a repaint may already have thrown away');
+  assert.ok(!/setInterval|setTimeout/.test(src), 'no polling — the board events are the nudge');
+  // Only what he opened is re-read: the firings on screen must stay current,
+  // and a panel nobody opened must cost nothing.
+  assert.match(src, /for \(const name of \[\.\.\.open\]\)/);
+});

--- a/test/settings-screen.test.js
+++ b/test/settings-screen.test.js
@@ -80,7 +80,7 @@ test('the config row hands off to the screen the way monitoring hands off to the
 // section visible. The pairing is data-tab ⇄ data-sec, so a fourth section
 // (lieutenants) — or a fifth (hooks) — is markup plus one WS_RENDER entry: the
 // switching below never learns its name.
-const SECTIONS = ['labels', 'playbooks', 'projects', 'lieutenants', 'hooks'];
+const SECTIONS = ['labels', 'playbooks', 'projects', 'lieutenants', 'hooks', 'schedules'];
 test('the heading row carries a tab per section', () => {
   const screen = element('settings-screen');
   const tabs = element('ss-tabs');
@@ -115,8 +115,10 @@ function loadSetWsTab() {
   const painted = [];
   const stub = (name) => (reload) => painted.push([name, reload]);
   const make = new Function('document', 'renderLabelManager', 'renderPlaybooks', 'renderProjects',
-    'renderLieutenants', 'renderHooks', mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
-  const api = make(document, stub('labels'), stub('playbooks'), stub('projects'), stub('lieutenants'), stub('hooks'));
+    'renderLieutenants', 'renderHooks', 'renderSchedules',
+    mainSrc.slice(start, end) + '\nreturn { setWsTab, wsTab: () => wsTab };');
+  const api = make(document, stub('labels'), stub('playbooks'), stub('projects'), stub('lieutenants'),
+    stub('hooks'), stub('schedules'));
   return { secs, tabs, painted, ...api };
 }
 

--- a/ui/app.css
+++ b/ui/app.css
@@ -694,6 +694,62 @@ body.resizing { user-select: none; cursor: col-resize; }
 .hk-act:hover:not(:disabled) { color: var(--accent); border-color: var(--accent2); }
 .hk-act:disabled { opacity: 0.35; }
 .hk-note { color: var(--faint); font-size: 11px; font-family: var(--mono); overflow-wrap: anywhere; }
+/* the row a schedule's hook name sent us to — marked until the tab is entered
+   fresh, so it is still marked when he looks up from the tap */
+.hk-focus { background: var(--accent-soft); border-radius: 5px; }
+
+/* schedules: the board's own clock, beside the hooks it fires. Two lines per
+   schedule rather than the hooks tab's one — there are six facts, and the
+   `problem` is a whole sentence that must not be clipped. Otherwise the same
+   density and the same act buttons. */
+#sc-list { display: flex; flex-direction: column; gap: 8px; }
+.sc-row { display: flex; flex-direction: column; gap: 2px; padding-left: 7px;
+  border-left: 2px solid var(--line); }
+/* a broken schedule fires nothing, forever, and looks exactly like a working
+   one — so it is a red bar and a red sentence, not a subtler shade */
+.sc-row.sc-broken { border-left-color: var(--danger); }
+.sc-row.sc-off { border-left-color: var(--warn); }
+.sc-head { display: flex; gap: 8px; align-items: center; cursor: pointer; }
+.sc-name { flex: 0 1 auto; min-width: 0; color: var(--text); font-size: 12.5px; font-weight: 650;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sc-hook { flex: none; color: var(--dim); font-size: 11px; font-family: var(--mono);
+  max-width: 45%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sc-hook:hover { color: var(--accent); }
+.sc-chip { flex: none; color: var(--warn); font-size: 9.5px; font-weight: 700; letter-spacing: 0.8px;
+  border: 1px solid var(--warn); border-radius: 4px; padding: 0 4px; line-height: 15px; }
+.sc-facts { color: var(--faint); font-size: 11px; font-family: var(--mono); overflow-wrap: anywhere; }
+.sc-ok { color: var(--ok); }
+.sc-bad { color: var(--danger); }
+.sc-skip { color: var(--warn); }
+.sc-never { color: var(--faint); }
+/* in full, wrapping, and loud: the whole sentence is the useful part */
+.sc-problem { color: var(--danger); font-size: 11px; line-height: 1.4; overflow-wrap: anywhere; }
+.sc-acts { flex: none; display: flex; gap: 4px; margin-left: auto; }
+.sc-act { color: var(--dim); font-size: 12px; line-height: 1; padding: 3px 7px;
+  border: 1px solid var(--line); border-radius: 5px; }
+.sc-act:hover:not(:disabled) { color: var(--accent); border-color: var(--accent2); }
+.sc-act:disabled { opacity: 0.35; }
+/* the firings, off the same trace `bc-axi schedule show` reads */
+.sc-runs { display: flex; flex-direction: column; gap: 6px; margin: 4px 0 2px;
+  color: var(--faint); font-size: 11px; font-family: var(--mono); }
+.sc-run-head { color: var(--dim); }
+.sc-out { color: var(--dim); font-size: 10.5px; font-family: var(--mono); line-height: 1.35;
+  white-space: pre-wrap; overflow-wrap: anywhere; max-height: 26vh; overflow-y: auto;
+  border-left: 1px solid var(--line); padding-left: 6px; margin-top: 2px; }
+/* a refusal reads as one — every failure in this section leads with a ⚠ */
+#sc-note.sc-warn { color: var(--danger); }
+/* the add form: closed by default — the list is what the tab is for */
+#sc-add > summary { color: var(--dim); font-size: 11px; cursor: pointer; }
+#sc-add > summary:hover { color: var(--accent); }
+#sc-form { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
+#sc-form input, #sc-form select {
+  background: var(--panel); border: 1px solid var(--line); border-radius: 5px; color: var(--text);
+  font: 12px var(--sans); padding: 3px 7px; outline: none; min-width: 0;
+}
+#sc-form #sc-name, #sc-form #sc-when { flex: 1 1 130px; }
+#sc-form input:focus, #sc-form select:focus { border-color: var(--accent2); }
+#sc-form button { background: var(--accent2); border-radius: 5px; color: #eaf6ff; font-size: 12px; padding: 3px 10px; }
+#sc-form button:hover { background: var(--accent); color: #06222f; }
 
 #lm-list { display: flex; flex-direction: column; gap: 6px; max-height: 40vh; overflow-y: auto; }
 .lm-row { display: flex; gap: 6px; align-items: center; }
@@ -1546,6 +1602,11 @@ table.tv { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 8
      opens the #mode-menu dropdown (main.js) */
   #view-seg button { display: none; }
   #view-seg button.on { display: inline-flex; padding: 5px 9px; font-size: 13px; border-left: none; }
+  /* Six config tabs are wider than a phone, and `flex: none` + `overflow:
+     hidden` clipped the last one where no gesture could reach it — a tab that
+     exists and cannot be tapped. The strip scrolls sideways instead; the buttons
+     keep their size, so the thumb targets do not shrink as tabs are added. */
+  #ss-tabs { max-width: 100%; overflow-x: auto; }
 }
 
 /* mobile board-mode dropdown — the move menu's look, anchored under the switcher */

--- a/ui/index.html
+++ b/ui/index.html
@@ -174,6 +174,7 @@
           <button type="button" data-tab="projects">projects</button>
           <button type="button" data-tab="lieutenants">lieutenants</button>
           <button type="button" data-tab="hooks">hooks</button>
+          <button type="button" data-tab="schedules">schedules</button>
         </span>
       </div>
       <section class="ss-sec on" id="ss-labels" data-sec="labels">
@@ -228,6 +229,44 @@
              swallow the only answer a press gives. -->
         <div id="hk-note" class="hk-note"></div>
         <div id="hk-dir" class="ss-note"></div>
+      </section>
+      <!-- schedules: the board's own clock, beside the hooks it fires. One block
+           per schedule — what it fires (the hook name jumps to its row on the
+           hooks tab), when, next fire, last fire, owner, and PAUSED where it
+           cannot be mistaken for a greyed row. A schedule with a `problem` says
+           it in full and in red: a hook deleted out from under a schedule is the
+           exact silent failure the clock exists to end. Clicking a block opens
+           its recent firings. The form is here rather than terminal-only because
+           the pickers are the point: a hook that exists and an owner who is
+           registered are the two refusals `add` spends most of its time on. -->
+      <section class="ss-sec" id="ss-schedules" data-sec="schedules">
+        <div class="ss-title">schedules</div>
+        <div id="sc-list"></div>
+        <!-- outside the list on purpose, like the hooks note: paint() clears the
+             list on every board event and would swallow a press's only answer.
+             The server's refusal is shown VERBATIM here — it names the offending
+             `when`, which "invalid" would throw away. -->
+        <div id="sc-note" class="hk-note"></div>
+        <details id="sc-add">
+          <summary>add a schedule</summary>
+          <form id="sc-form">
+            <input id="sc-name" placeholder="name" autocomplete="off">
+            <select id="sc-hook" title="the named hook this fires"></select>
+            <input id="sc-when" placeholder="when — 5m, or 0 9 * * mon" autocomplete="off">
+            <select id="sc-owner" title="the lieutenant a failed firing wakes"></select>
+            <select id="sc-overlap" title="what a firing does when the previous one is still running">
+              <option value="skip">overlap: skip</option>
+              <option value="queue">overlap: queue</option>
+              <option value="restart">overlap: restart</option>
+            </select>
+            <select id="sc-catchup" title="what to do with windows that came due while the board was down">
+              <option value="latest">catch-up: latest</option>
+              <option value="all">catch-up: all</option>
+              <option value="none">catch-up: none</option>
+            </select>
+            <button type="submit">add</button>
+          </form>
+        </details>
       </section>
     </div>
   </section>

--- a/ui/js/api.js
+++ b/ui/js/api.js
@@ -106,6 +106,14 @@ export const api = {
   // ▶ — the same door `bc-axi hook run` posts to; `trigger` is what the trace
   // line records, so a board run reads as a board run forever after
   runHook: (name) => j('POST', '/api/hooks/run', { name, trigger: 'board' }),
+  // the board's own clock. Every one of these is a door `bc-axi schedule …`
+  // already posts to — the screen grew, the API did not.
+  schedules: () => j('GET', '/api/schedules'),
+  // one schedule plus its recent FIRINGS, filtered to its own trigger server-side
+  schedule: (name) => j('GET', '/api/schedules/' + encodeURIComponent(name)),
+  addSchedule: (s) => j('POST', '/api/schedules', Object.assign({ actor: 'user' }, s)),
+  pauseSchedule: (name, paused) => j('PATCH', '/api/schedules/' + encodeURIComponent(name), { paused }),
+  removeSchedule: (name) => j('DELETE', '/api/schedules/' + encodeURIComponent(name)),
   // slash commands the current chat target's harness answers (composer autocomplete)
   commands: (target) => j('GET', '/api/commands?target=' + encodeURIComponent(target)),
 };

--- a/ui/js/hkmanager.js
+++ b/ui/js/hkmanager.js
@@ -39,6 +39,7 @@ let dir = '';
 let loading = false;
 let stale = false; // a render arrived while a read was in flight
 const running = new Set(); // hook names whose ▶ was pressed HERE — state, not a mutated button
+let focus = ''; // a hook the schedules tab sent us to — highlighted until this tab is re-entered
 
 // Same contract as the playbooks and lieutenants sections: `reload` is what the
 // tab passes on the way in. Every render ASKS, though, not just the entering
@@ -47,7 +48,7 @@ const running = new Set(); // hook names whose ▶ was pressed HERE — state, n
 // nudge this tab gets. That is also why there is no polling — nothing runs at
 // all while another tab is up.
 export async function renderHooks(reload) {
-  if (reload) noteEl.textContent = ''; // entering is a fresh look, not last visit's answer
+  if (reload) { noteEl.textContent = ''; focus = ''; } // entering is a fresh look, not last visit's answer
   if (loading) { stale = true; return; } // the read in flight answers for both askers
   loading = true;
   try {
@@ -67,17 +68,40 @@ export async function renderHooks(reload) {
   paint();
 }
 
+// The other half of the schedules tab's hook link: land on the hooks tab with
+// the hook it named marked, so "which one is nightly-digest firing" is answered
+// by looking rather than by reading a list. main.js switches the tab first, so
+// this only has to say which row — and the highlight lasts until the tab is
+// entered fresh, because a mark that vanished on the next board event would be
+// gone before he looked up.
+export function focusHook(name) {
+  focus = name;
+  renderHooks();
+}
+
 function paint() {
   if (!items) return;
   listEl.textContent = '';
-  for (const h of items) listEl.appendChild(row(h));
+  let marked = null;
+  for (const h of items) {
+    const el = row(h);
+    if (h.name === focus) marked = el;
+    listEl.appendChild(el);
+  }
   if (!items.length) listEl.textContent = 'no hooks';
+  // A hook a schedule names and this list does not have is the deleted-hook
+  // case, and the schedule's own row already says so in full — so the note says
+  // it here too rather than leaving a jump that silently did nothing.
+  if (focus) {
+    if (marked) marked.scrollIntoView({ block: 'nearest' });
+    else noteEl.textContent = 'no hook "' + focus + '" here — the schedule that fires it says so on its row';
+  }
   dirEl.textContent = dir + ' — a file here is a named hook; a directory is a lifecycle event';
 }
 
 function row(h) {
   const el = document.createElement('div');
-  el.className = 'hk-row';
+  el.className = 'hk-row' + (h.name === focus ? ' hk-focus' : '');
   const busy = running.has(h.name);
   el.append(name(h), facts(h, busy), actions(h, busy));
   return el;

--- a/ui/js/main.js
+++ b/ui/js/main.js
@@ -22,7 +22,8 @@ import { renderLabelManager, renderPicker, pickerIsOpen, closeLabelPicker } from
 import { renderPlaybooks } from './pbmanager.js';
 import { renderProjects } from './projmanager.js';
 import { renderLieutenants } from './ltmanager.js';
-import { renderHooks } from './hkmanager.js';
+import { renderHooks, focusHook } from './hkmanager.js';
+import { renderSchedules, onOpenHook } from './scmanager.js';
 import './resize.js'; // draggable side-panel widths
 import './keepalivesettings.js'; // the pocket switch: hold the audio session open
 
@@ -110,7 +111,7 @@ document.getElementById('config-open').onclick = () => {
 // section is a <section data-sec>, a <button data-tab> and one entry here; the
 // switching below never learns its name.
 const WS_RENDER = { labels: renderLabelManager, playbooks: renderPlaybooks, projects: renderProjects,
-  lieutenants: renderLieutenants, hooks: renderHooks };
+  lieutenants: renderLieutenants, hooks: renderHooks, schedules: renderSchedules };
 let wsTab = 'labels';
 function setWsTab(tab) {
   wsTab = tab;
@@ -125,6 +126,10 @@ function setWsTab(tab) {
 for (const b of document.querySelectorAll('#ss-tabs button')) {
   b.onclick = () => setWsTab(b.dataset.tab);
 }
+// A schedule fires a hook, so its row names one — and the name is a way there.
+// The tab switching is this file's, so the schedules section is handed the
+// action instead of reaching for it (the shape filepane's onModeSwitch uses).
+onOpenHook((name) => { setWsTab('hooks'); focusHook(name); });
 
 // ---------- board region mode: kanban ⇄ table ⇄ archived ⇄ file ⇄ settings ----
 // Board and table are two views over the LIVE cards; 🧊 is the archived

--- a/ui/js/scmanager.js
+++ b/ui/js/scmanager.js
@@ -1,0 +1,391 @@
+// The config screen's schedules section: the board's own clock, beside the
+// hooks it fires.
+//
+// MNC-25 shipped the clock and gave it no screen, so the board could be
+// scheduled and nothing on the board said so. This is the said-so half — one
+// block per schedule, the facts the CLI prints, in the words the CLI prints
+// them in:
+//
+//   ▸ gh-watch  → gh-watch                              ⏸ ✕
+//     every 5m · in 3m · fired 2m ago · exit 0 · tonylampada
+//
+//   ▸ nightly   → digest            PAUSED              ▶ ✕
+//     cron 0 9 * * mon · paused · never fired · tonylampada
+//
+// The `problem` is why this section is worth having at all. A schedule whose
+// hook was deleted, or whose `when` stopped parsing, fires nothing forever and
+// looks exactly like one that is working — that is the silent failure the clock
+// exists to end, so a broken row is a red bar and the server's whole sentence,
+// never a subtly greyed line and the word "invalid".
+//
+// Same rule for the add form's refusals: the server names the offending text
+// ("bad schedule expression \"*/5 * * *\": a cron expression has 5 fields…"),
+// and that message is shown VERBATIM. Replacing it with "invalid" would throw
+// away the only part of it that helps.
+//
+// No endpoint was added for any of this. Every read and every write here is a
+// door `bc-axi schedule …` already posts to, including the firings: they come
+// off hookruns.jsonl, filtered to this schedule's trigger server-side, so the
+// screen and the CLI read one truth.
+import { api } from './api.js';
+import { ansiToHtml } from './ansi.js';
+import { hhmm } from './util.js';
+
+const listEl = document.getElementById('sc-list');
+const noteEl = document.getElementById('sc-note');
+const addEl = document.getElementById('sc-add');
+const formEl = document.getElementById('sc-form');
+const nameEl = document.getElementById('sc-name');
+const hookEl = document.getElementById('sc-hook');
+const whenEl = document.getElementById('sc-when');
+const ownerEl = document.getElementById('sc-owner');
+const overlapEl = document.getElementById('sc-overlap');
+const catchupEl = document.getElementById('sc-catchup');
+
+// The one place the note is written, so a refusal always reads like one: every
+// failure here leads with a ⚠, and that is what colours it. A refusal in the
+// same faint grey as "added" is how a screen teaches him not to read it.
+function say(text) {
+  noteEl.textContent = text;
+  noteEl.classList.toggle('sc-warn', text.startsWith('⚠'));
+}
+
+let items = null; // the last GET /api/schedules answer
+let loading = false;
+let stale = false; // a render arrived while a read was in flight
+const open = new Set(); // schedules whose firings are showing
+const runs = new Map(); // name -> its firings, as last read
+const busy = new Set(); // names with a press still in flight — state, not a mutated button
+
+// The hook name jumps to that hook's row on the hooks tab. main.js owns the tab
+// switching, so it hands the action down here rather than this module reaching
+// up for it — the same shape filepane uses for onModeSwitch.
+let openHookFn = null;
+export function onOpenHook(fn) { openHookFn = fn; }
+
+// Same contract as its neighbours: `reload` is what the tab passes on the way
+// in. Every render ASKS, though, not just the entering one — a schedule fires,
+// is paused from the CLI, or has its hook deleted out from under it, and the
+// board event that brought us here is the only nudge this tab gets. Which is
+// also why there is no polling: nothing runs while another tab is up.
+export async function renderSchedules(reload) {
+  if (reload) say(''); // entering is a fresh look, not last visit's answer
+  if (loading) { stale = true; return; } // the read in flight answers for both askers
+  loading = true;
+  try {
+    do {
+      stale = false;
+      items = (await api.schedules()).schedules || [];
+      // Only what he opened is re-read — the firings on screen must not go on
+      // saying a firing ago is the newest one, and a panel nobody opened costs
+      // nothing.
+      for (const name of [...open]) {
+        try { runs.set(name, (await api.schedule(name)).runs || []); }
+        catch (e) { open.delete(name); runs.delete(name); }
+      }
+    } while (stale);
+  } catch (e) {
+    // A read that failed says so where a press says so — blanking a list that is
+    // still true on screen would be the worse lie.
+    if (items) say('⚠ ' + e.message);
+    else listEl.textContent = '⚠ ' + e.message;
+    return;
+  } finally { loading = false; }
+  if (reload) loadPickers();
+  paint();
+}
+
+function paint() {
+  if (!items) return;
+  listEl.textContent = '';
+  for (const s of items) listEl.appendChild(row(s));
+  if (!items.length) listEl.textContent = 'no schedules';
+}
+
+function row(s) {
+  const el = document.createElement('div');
+  el.className = 'sc-row' + (s.problem ? ' sc-broken' : '') + (s.paused ? ' sc-off' : '');
+  el.append(head(s), facts(s));
+  // In full and above the fold: a problem is the reason to look at this tab, so
+  // it is not a title attribute and it is not truncated.
+  if (s.problem) el.append(problem(s));
+  if (open.has(s.name)) el.append(firings(s));
+  return el;
+}
+
+function head(s) {
+  const el = document.createElement('div');
+  el.className = 'sc-head';
+  el.title = open.has(s.name) ? 'hide the firings' : 'the recent firings — time, how each ended, and the output';
+  el.onclick = () => toggle(s);
+  const nm = document.createElement('span');
+  nm.className = 'sc-name';
+  nm.textContent = (open.has(s.name) ? '▾ ' : '▸ ') + s.name;
+  el.append(nm, hookLink(s));
+  // Paused is a state, not a shade: a greyed row and a row on a dim screen look
+  // the same, and "why did this stop firing" is the question the tab answers.
+  if (s.paused) {
+    const chip = document.createElement('span');
+    chip.className = 'sc-chip';
+    chip.textContent = 'PAUSED';
+    chip.title = 'this schedule fires nothing until it is resumed';
+    el.append(chip);
+  }
+  el.append(acts(s));
+  return el;
+}
+
+function hookLink(s) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'sc-hook';
+  b.textContent = '→ ' + s.hook;
+  b.title = 'the hook this fires — show it on the hooks tab';
+  b.onclick = (e) => { e.stopPropagation(); if (openHookFn) openHookFn(s.hook); };
+  return b;
+}
+
+function acts(s) {
+  const el = document.createElement('span');
+  el.className = 'sc-acts';
+  el.onclick = (e) => e.stopPropagation(); // the head toggles the firings; these do not
+  const b = busy.has(s.name);
+  // '‖' rather than the pause pictograph: U+23F8 has no glyph in the fonts this
+  // board ships with and renders as a box, which is not a button anyone presses.
+  el.append(
+    act(b ? '…' : s.paused ? '▶' : '‖', b,
+      s.paused ? 'resume — the cursor re-arms at now, so it wakes up owing no windows'
+        : 'pause — it fires nothing until resumed',
+      () => setPaused(s, !s.paused)),
+    act('✕', b, 'remove this schedule — the hook itself survives', () => remove(s)),
+  );
+  return el;
+}
+
+function act(label, disabled, title, onClick) {
+  const b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'sc-act';
+  b.textContent = label;
+  b.title = title;
+  b.disabled = disabled;
+  b.onclick = onClick;
+  return b;
+}
+
+// ---------- the words, exactly the ones `schedule list` says ----------
+// A screen and a CLI describing the same clock in two vocabularies is two
+// things to learn, so these are the CLI's own phrasings.
+
+// 'in 3m' — how far off the next fire is.
+function until(iso) {
+  const t = Date.parse(iso || '');
+  if (!t) return 'never';
+  const s = Math.round((t - Date.now()) / 1000);
+  if (s <= 0) return 'due now';
+  if (s < 60) return 'in ' + s + 's';
+  if (s < 3600) return 'in ' + Math.round(s / 60) + 'm';
+  if (s < 86400) return 'in ' + Math.round(s / 3600) + 'h';
+  return 'in ' + Math.round(s / 86400) + 'd';
+}
+
+// 'now' is not a thing a past event is, so the smallest unit here is seconds —
+// util's ago() rounds the first minute to "now", which would read "fired now".
+function since(iso) {
+  const t = Date.parse(iso || '');
+  if (!t) return '';
+  const s = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (s < 60) return s + 's ago';
+  if (s < 3600) return Math.round(s / 60) + 'm ago';
+  if (s < 86400) return Math.round(s / 3600) + 'h ago';
+  return Math.round(s / 86400) + 'd ago';
+}
+
+function howRunEnded(r) {
+  return r.skipped ? 'skipped' : r.timedOut ? 'timed out' : r.error ? 'failed to start'
+    : r.canceled ? 'restarted mid-run' : r.code === null ? 'killed' : 'exit ' + r.code;
+}
+
+// A SKIP is a firing too — that is the whole point of recording it — so it reads
+// as one rather than as silence.
+function fireOutcome(r) {
+  if (!r) return 'never fired';
+  if (r.skipped) return 'skipped ' + since(r.started) + ' (previous firing still going)';
+  return 'fired ' + since(r.started) + ' · ' + howRunEnded(r);
+}
+
+function outcomeClass(r) {
+  if (!r) return 'sc-never';
+  return r.skipped ? 'sc-skip' : r.ok ? 'sc-ok' : 'sc-bad';
+}
+
+// when · next fire · last fire · owner, as one dim run. Separators, not labels:
+// the title says what they are once, so ten rows do not each spell it out. The
+// last fire keeps a colour of its own, because a red one has to be what the eye
+// lands on.
+function facts(s) {
+  const el = document.createElement('div');
+  el.className = 'sc-facts';
+  el.title = 'when it fires · next fire · last fire · owner';
+  // A schedule with a problem has a next window and will not take it — the tick
+  // refuses to fire it — so "in 4m" would be the plausible-looking lie the
+  // problem is there to replace. Paused is the same shape of not-coming.
+  el.append(s.describe + ' · ' + (s.paused ? 'paused' : s.problem ? 'fires nothing' : until(s.next)) + ' · ');
+  const last = document.createElement('span');
+  last.className = outcomeClass(s.last);
+  last.textContent = fireOutcome(s.last);
+  el.append(last, ' · ' + s.owner);
+  return el;
+}
+
+function problem(s) {
+  const el = document.createElement('div');
+  el.className = 'sc-problem';
+  el.textContent = '⚠ ' + s.problem;
+  return el;
+}
+
+// The firings, newest first — the trace's own records, not a second copy kept
+// on the schedule.
+function firings(s) {
+  const el = document.createElement('div');
+  el.className = 'sc-runs';
+  const list = runs.get(s.name);
+  if (!list) { el.textContent = 'reading the firings…'; return el; }
+  if (!list.length) { el.textContent = 'no firings recorded'; return el; }
+  for (const r of list) el.append(firing(r));
+  return el;
+}
+
+function firing(r) {
+  const el = document.createElement('div');
+  el.className = 'sc-run';
+  const line = document.createElement('div');
+  line.className = 'sc-run-head';
+  const how = document.createElement('span');
+  how.className = outcomeClass(r);
+  how.textContent = howRunEnded(r);
+  line.append(hhmm(r.started) + '  ', how, '  ' + r.ms + 'ms');
+  el.append(line);
+  if (r.output) {
+    const pre = document.createElement('pre');
+    pre.className = 'sc-out';
+    // The output of a hook is a terminal's output — ansiToHtml escapes the text
+    // before it adds any markup, the same way the live pane reads a frame.
+    pre.innerHTML = ansiToHtml(r.output);
+    el.append(pre);
+  }
+  return el;
+}
+
+// ---------- the presses ----------
+
+async function toggle(s) {
+  if (open.has(s.name)) { open.delete(s.name); runs.delete(s.name); return paint(); }
+  open.add(s.name);
+  paint(); // the panel opens now and says it is reading — the fetch fills it in
+  try {
+    runs.set(s.name, (await api.schedule(s.name)).runs || []);
+  } catch (e) {
+    open.delete(s.name);
+    say('⚠ ' + s.name + ': ' + e.message);
+  }
+  paint();
+}
+
+// The press is held HERE and not on the button, because a board event repaints
+// every row mid-request: a button that came back enabled under his thumb would
+// be a second write the server then has to sort out.
+async function setPaused(s, paused) {
+  if (busy.has(s.name)) return;
+  busy.add(s.name);
+  paint();
+  let note;
+  try {
+    const r = await api.pauseSchedule(s.name, paused);
+    note = s.name + (paused ? ' paused — it fires nothing until resumed'
+      : ' resumed — next fire ' + until(r.schedule && r.schedule.next));
+  } catch (e) { note = '⚠ ' + s.name + ': ' + e.message; }
+  busy.delete(s.name);
+  await renderSchedules();
+  say(note);
+}
+
+// The confirm says what removal does NOT do, because that is the part he cannot
+// see from here: it forgets a clock entry, it does not delete a script. It says
+// "untouched" rather than "still there" — the schedule most likely to be removed
+// from this screen is one whose hook is already gone, and that is exactly the row
+// a promise about the file still existing would be a lie on.
+async function remove(s) {
+  if (busy.has(s.name)) return;
+  if (!confirm('Remove the schedule "' + s.name + '"?\n\n'
+    + 'The hook ' + s.hook + ' is untouched — only the clock entry goes, so nothing fires it any more.')) return;
+  busy.add(s.name);
+  paint();
+  let note;
+  try {
+    await api.removeSchedule(s.name);
+    note = s.name + ' removed — the hook ' + s.hook + ' is untouched';
+  } catch (e) { note = '⚠ ' + s.name + ': ' + e.message; }
+  busy.delete(s.name);
+  open.delete(s.name);
+  runs.delete(s.name);
+  await renderSchedules();
+  say(note);
+}
+
+// ---------- add ----------
+// The two pickers are the point of having a form at all: a hook that exists and
+// an owner who is registered are the two refusals `add` spends most of its time
+// on, and a free-text box would earn both of them again every time.
+async function loadPickers() {
+  try {
+    const [h, l] = await Promise.all([api.hooks(), api.lieutenants()]);
+    // A schedule fires a NAMED hook — a lifecycle hook is fired by the event
+    // that owns it, so it is not on this list.
+    fill(hookEl, (h.hooks || []).filter((x) => !x.event).map((x) => x.name), 'no named hooks');
+    fill(ownerEl, (l.lieutenants || []).map((x) => x.id), 'no lieutenants');
+  } catch (e) { say('⚠ ' + e.message); }
+}
+
+// Rebuilt only when the set actually changed: a repaint that reset a picker
+// under his finger would be the same bug as one that ate what he typed.
+function fill(sel, values, empty) {
+  const want = values.join('\n');
+  if (sel.dataset.filled === want) return;
+  sel.dataset.filled = want;
+  const had = sel.value;
+  sel.textContent = '';
+  for (const v of (values.length ? values : [''])) {
+    const o = document.createElement('option');
+    o.value = values.length ? v : '';
+    o.textContent = values.length ? v : empty;
+    sel.append(o);
+  }
+  if (values.includes(had)) sel.value = had;
+}
+
+// Opening the form is the moment its pickers have to be right — a hook dropped
+// in a minute ago belongs on the list he is about to choose from.
+addEl.ontoggle = () => { if (addEl.open) loadPickers(); };
+
+formEl.onsubmit = async (e) => {
+  e.preventDefault();
+  say('');
+  try {
+    const r = await api.addSchedule({
+      name: nameEl.value.trim(), hook: hookEl.value, when: whenEl.value.trim(),
+      owner: ownerEl.value, overlap: overlapEl.value, catchup: catchupEl.value,
+    });
+    nameEl.value = '';
+    whenEl.value = '';
+    addEl.open = false;
+    await renderSchedules();
+    say(r.schedule.name + ' added — ' + r.schedule.hook + ' ' + r.schedule.describe
+      + ', owner ' + r.schedule.owner + '; next fire ' + until(r.schedule.next));
+  } catch (err) {
+    // VERBATIM. The refusal names the offending text — which `when` did not
+    // parse, which hook is not there — and "invalid" would throw all of it away.
+    say('⚠ ' + err.message);
+  }
+};


### PR DESCRIPTION
MNC-25 shipped the board's own clock and gave it no screen — the board could be scheduled and nothing on the board said so. This adds the schedules tab beside hooks: one `<section data-sec>`, one `<button data-tab>`, one `WS_RENDER` entry, `ui/js/scmanager.js`, and **no new endpoint** — every read and write is a door `bc-axi schedule …` already posts to, firings included (`GET /api/schedules/<name>` already filters the trace to that schedule's trigger).

A row says what `schedule list` says, in the same words: the hook it fires (the name jumps to that hook's row on the hooks tab and marks it), `every 5m` / `cron 0 9 * * mon`, `in 3m`, `fired 2m ago · exit 0`, the owner, and PAUSED as a chip rather than a greyed row. Clicking a row opens the recent firings — time, exit code, duration, output. `‖`/`▶` pause and resume, `✕` removes behind a confirm that says the hook is **untouched** (not "still there" — the schedule most likely to be removed here is one whose hook is already gone). Add is a form with pickers over the named hooks and the registered lieutenants, because those are the two refusals `add` spends most of its time on.

Two decisions worth naming. A `problem` is the server's whole sentence, in red, on a red row, and its next-fire slot reads `fires nothing` rather than a plausible `in 4m` the tick will never take — a schedule whose hook was deleted is the silent failure the clock exists to end. And the refusal from `POST /api/schedules` is shown **verbatim**; it names the offending `when`, which "invalid" would throw away.

One fix outside the feature: the sixth config tab was wider than a phone and `#ss-tabs { overflow: hidden }` clipped it where no gesture could reach it. The strip scrolls now.

## What I saw on screen

Real board (this branch's server, own workspace, three hooks), driven in Chrome:

- **live** — `heartbeat → heartbeat`, `every 30s · in 24s · fired 0s ago · exit 0 · monica`, exit code green. Expanded: eight firings, each `20:13  exit 0  4ms` over its indented output.
- **paused** — `nightly → nightly-digest` with the PAUSED chip and an amber left bar; `cron 0 9 * * mon · paused · never fired · monica`. `▶` resumed it (`nightly resumed — next fire in 13h`), `‖` paused it back.
- **hook deleted underneath it** — `orphan-watch → doomed`, red left bar, `every 5m · fires nothing · never fired · monica`, then the server's full sentence in red: `⚠ hook "doomed" is gone from …/hooks — this schedule fires nothing`.
- **the hook link** — `→ heartbeat` landed on the hooks tab with that row highlighted; `→ doomed` landed there and the note said `no hook "doomed" here — the schedule that fires it says so on its row`.
- **add** — `*/5 * * *` came back as `⚠ bad schedule expression "*/5 * * *": a cron expression has 5 fields (this has 4) — …`, in red, with the form's contents kept. A good add closed the form and reported `orphan-watch added — doomed every 5m, owner monica; next fire in 5m`.
- **remove** — confirm read `The hook doomed is untouched — only the clock entry goes…`; after it the schedule was gone and `GET /api/hooks` still listed the hook.
- **390px** — all three schedules on one screen, facts wrapping, problem in full, tab strip scrolling to `schedules`.

`node --test test/*.test.js harness/test/*.test.js` — 922 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
