### PR TITLE
feat(server): serve the TTS engine from the board's own origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Per-workspace config lives in `.bridge-commander/config.json`:
 | `host` | `127.0.0.1` | bind address — see network exposure below |
 | `harness` | `claude` | default agent harness (`claude` \| `codex`) |
 | `voices` | — | UI text-to-speech voice filter |
-| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the browser's own voice; any engine failure falls back to it. The **browser** calls the engine, so the url must be reachable from wherever the board is open and the engine must allow that origin (CORS) |
+| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the board stays silent. The **server** reaches the engine: the browser talks to `/api/tts/*` on the board's own origin and the url only has to be reachable from the machine running the server (no CORS, no tailnet on the phone) |
 
 Env knobs (set on the server process):
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Env knobs (set on the server process):
 | `BC_SEND_RETRIES` / `BC_SEND_SLEEP_MS` | `3` / `400` | verified-submit tuning for `harness.send` |
 | `BC_HOOK_TIMEOUT_MS` | `120000` | per-script timeout for workspace hooks, lifecycle and named alike |
 | `BC_TEARDOWN_TIMEOUT_MS` | `300000` / `60000` | timeout for a playbook's `teardown` command — 5 min at the handoff and archive (un-awaited), 60s at a rework restart (awaited inside `card start`); set, it overrides both |
+| `BC_TTS_IDLE_MS` | `20000` | how long the TTS passthrough waits for the next byte from the engine before hanging up — a gap between bytes, not a cap on the request |
 | `BC_SYSLOAD_MS` | `2000` | monitoring panel (⚙️ → machine load) sample interval; the sampler runs only while the panel is open |
 
 ### Hooks

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Per-workspace config lives in `.bridge-commander/config.json`:
 | `host` | `127.0.0.1` | bind address — see network exposure below |
 | `harness` | `claude` | default agent harness (`claude` \| `codex`) |
 | `voices` | — | UI text-to-speech voice filter |
-| `tts` | — | speak through an external TTS engine instead of the browser: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the board stays silent. The **server** reaches the engine: the browser talks to `/api/tts/*` on the board's own origin and the url only has to be reachable from the machine running the server (no CORS, no tailnet on the phone) |
+| `tts` | — | speak agent messages through an external TTS engine: `{"url": "http://127.0.0.1:8883", "lang": "pt", "voice": null, "params": {}}` (voxbench API). Absent = the board stays silent. The **server** reaches the engine: the browser talks to `/api/tts/*` on the board's own origin and the url only has to be reachable from the machine running the server (no CORS, no tailnet on the phone) |
 
 Env knobs (set on the server process):
 

--- a/dev/ui-server.js
+++ b/dev/ui-server.js
@@ -428,6 +428,10 @@ function createDevServer(opts) {
       if (route === 'GET /api/board') return sendJson(res, 200, publicBoard());
       // Same shape the real server sends (server.js ttsConfig): no tts key at
       // all when there is no engine, so the UI sees exactly what it sees today.
+      // One difference on purpose: the real server hands the browser its own
+      // proxy prefix (/api/tts) and reaches the engine itself; the playground
+      // has no proxy and hands over the engine address raw, so the engine has
+      // to allow this origin (CORS).
       if (route === 'GET /api/config') {
         const cfg = { voices: null };
         if (ttsUrl) cfg.tts = { enabled: true, url: ttsUrl, lang: 'pt', voice: null, params: {} };

--- a/server/server.js
+++ b/server/server.js
@@ -76,6 +76,7 @@ const { STATE_DIR_NAME, migrateStateDir, migrateHomeStateDir } = require(path.jo
 const gitrev = require(path.join(__dirname, 'gitrev.js'));
 const { charterPath, readCharter, writeCharter } = require(path.join(__dirname, 'charter.js'));
 const { ONBOARDING_STEPS } = require(path.join(__dirname, 'firstrun.js'));
+const { proxyTts } = require(path.join(__dirname, 'ttsproxy.js'));
 const { execFile, execFileSync } = require('child_process');
 
 // ---------- args ----------
@@ -176,11 +177,9 @@ const ARTIFACT_MIME = {
 };
 
 const DEFAULT_PORT = 4780;
-// External TTS proxy timeouts — a hanging engine must never hang the board.
-// The speech deadline is on SILENCE, never on the whole request: audio streams in
-// for as long as synthesis runs (~34 s for the 1200 characters the UI sends), so a
-// cap on the total would truncate every long message. This is the gap allowed
-// before the first chunk and between any two after it.
+// The one prefix the TTS engine is served under, both ends of it: what the
+// browser is handed as its engine address, and what the proxy strips.
+const TTS_PREFIX = '/api/tts';
 // ---------- workspace config (.bridge-commander/config.json) ----------
 function readConfig() {
   try {
@@ -196,11 +195,14 @@ function userConfig() {
     const voices = c.voices.filter((v) => typeof v === 'string' && v.trim()).map((v) => v.trim());
     if (voices.length) out.voices = voices;
   }
-  // The browser IS the engine's client — url and defaults go to it whole. No tts
-  // config => no tts key => the UI is byte-for-byte what it was before this
-  // feature existed.
+  // The browser is the engine's client, through us: it gets the defaults whole
+  // and, for the address, the board's own proxy prefix. A relative base resolves
+  // against whatever origin the page came from, so the phone off the tailnet and
+  // the https page both reach the engine, and the real engine address stays the
+  // server's business. No tts config => no tts key => the UI is byte-for-byte
+  // what it was before this feature existed.
   const t = ttsConfig();
-  if (t) out.tts = Object.assign({ enabled: true }, t);
+  if (t) out.tts = Object.assign({ enabled: true }, t, { url: TTS_PREFIX });
   return out;
 }
 // External TTS engine (voxbench API), optional: config.json
@@ -3713,6 +3715,15 @@ const server = http.createServer(async (req, res) => {
     // ----- reads -----
     if (route === 'GET /api/board') return sendJson(res, 200, publicBoard(url.searchParams.get('user') || 'user'));
     if (route === 'GET /api/config') return sendJson(res, 200, userConfig());
+    // ----- the TTS engine, on the board's own origin -----
+    // Any method, any path under the prefix, streamed both ways. No engine
+    // configured means no route at all: this falls through to the ordinary 404
+    // and the board is as silent as it is with no tts block.
+    if (p === TTS_PREFIX || p.startsWith(TTS_PREFIX + '/')) {
+      const t = ttsConfig();
+      // p, not a decoded path: what the browser encoded is what the engine gets.
+      if (t) return proxyTts(req, res, t.url, p.slice(TTS_PREFIX.length) + url.search);
+    }
     if (route === 'GET /api/status') {
       let pending = 0;
       for (const lt of queueIds()) pending += pendingItems(lt).length;

--- a/server/ttsproxy.js
+++ b/server/ttsproxy.js
@@ -1,0 +1,47 @@
+'use strict';
+// The TTS engine, served from the board's own origin.
+//
+// `/api/tts/<rest>` goes to `<engine>/<rest>` and nothing else happens: same
+// method, same path, same query, same headers, same status, same bytes. No
+// cache, no retry, no defaults filled in, no knowledge of which paths the
+// engine has. A condition on a path or a body in this file is a bug.
+//
+// Both directions STREAM. Audio starts playing while synthesis is still
+// running, so buffering a response here would put the whole 30-second wait back.
+//
+// A client that hangs up kills the upstream request. That is load-bearing, not
+// tidiness: the browser aborts a fetch precisely so the ENGINE stops
+// synthesizing, and an abandoned synthesis that overlaps the next request takes
+// voxcpm2's CUDA context down with it (see ui/js/speech.js).
+const http = require('http');
+const https = require('https');
+
+// engine: the base url from config (no trailing slash). rest: everything after
+// the prefix, already including its leading slash and query string, still
+// percent-encoded exactly as the browser sent it.
+function proxyTts(req, res, engine, rest) {
+  const target = engine + rest;
+  const mod = target.startsWith('https:') ? https : http;
+  const headers = Object.assign({}, req.headers);
+  delete headers.host; // the engine's host, not the board's — everything else rides along
+  const up = mod.request(target, { method: req.method, headers }, (r) => {
+    res.writeHead(r.statusCode, r.headers);
+    r.pipe(res);
+  });
+  // Upstream is done the moment its response ends; only a hangup BEFORE that is
+  // worth aborting, and aborting after it would take a pooled socket with it.
+  let done = false;
+  up.on('response', (r) => r.once('end', () => { done = true; }));
+  // Nothing to say once the status line is out (or once the client is gone —
+  // which is how a deliberate abort comes back here): drop the connection and
+  // let the browser see the truncation, the same as talking to the engine direct.
+  up.on('error', (e) => {
+    if (res.headersSent || res.destroyed) return res.destroy();
+    res.writeHead(502, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ error: String((e && e.message) || e) }));
+  });
+  res.on('close', () => { if (!done) up.destroy(); });
+  req.pipe(up);
+}
+
+module.exports = { proxyTts };

--- a/server/ttsproxy.js
+++ b/server/ttsproxy.js
@@ -13,8 +13,18 @@
 // tidiness: the browser aborts a fetch precisely so the ENGINE stops
 // synthesizing, and an abandoned synthesis that overlaps the next request takes
 // voxcpm2's CUDA context down with it (see ui/js/speech.js).
+//
+// The one deadline: an idle-byte-gap hangup, and nothing else. It knows nothing
+// about audio, speech, synthesis, or which path is in flight — it is the gap
+// between two bytes from upstream, armed before the first one and re-armed by
+// every one after it. A request may legitimately run for minutes as long as
+// bytes keep arriving; a total-time cap would truncate every long response and
+// is exactly the wrong shape here.
 const http = require('http');
 const https = require('https');
+
+const IDLE_MS = parseInt(process.env.BC_TTS_IDLE_MS, 10) > 0
+  ? parseInt(process.env.BC_TTS_IDLE_MS, 10) : 20000;
 
 // engine: the base url from config (no trailing slash). rest: everything after
 // the prefix, already including its leading slash and query string, still
@@ -24,23 +34,35 @@ function proxyTts(req, res, engine, rest) {
   const mod = target.startsWith('https:') ? https : http;
   const headers = Object.assign({}, req.headers);
   delete headers.host; // the engine's host, not the board's — everything else rides along
-  const up = mod.request(target, { method: req.method, headers }, (r) => {
-    res.writeHead(r.statusCode, r.headers);
-    r.pipe(res);
-  });
   // Upstream is done the moment its response ends; only a hangup BEFORE that is
   // worth aborting, and aborting after it would take a pooled socket with it.
   let done = false;
-  up.on('response', (r) => r.once('end', () => { done = true; }));
+  let timer = null;
+  const disarm = () => { if (timer) { clearTimeout(timer); timer = null; } };
   // Nothing to say once the status line is out (or once the client is gone —
   // which is how a deliberate abort comes back here): drop the connection and
   // let the browser see the truncation, the same as talking to the engine direct.
-  up.on('error', (e) => {
+  const fail = (e) => {
+    disarm();
+    up.destroy();
     if (res.headersSent || res.destroyed) return res.destroy();
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: String((e && e.message) || e) }));
+  };
+  const arm = () => {
+    disarm();
+    timer = setTimeout(() => fail(new Error('no bytes from upstream for ' + IDLE_MS + 'ms')), IDLE_MS);
+  };
+  const up = mod.request(target, { method: req.method, headers }, (r) => {
+    res.writeHead(r.statusCode, r.headers);
+    r.on('data', arm);
+    r.once('end', () => { done = true; disarm(); });
+    r.on('error', () => { disarm(); res.destroy(); });
+    r.pipe(res);
   });
-  res.on('close', () => { if (!done) up.destroy(); });
+  up.on('error', fail);
+  res.on('close', () => { disarm(); if (!done) up.destroy(); });
+  arm();
   req.pipe(up);
 }
 

--- a/server/ttsproxy.js
+++ b/server/ttsproxy.js
@@ -20,6 +20,13 @@
 // every one after it. A request may legitimately run for minutes as long as
 // bytes keep arriving; a total-time cap would truncate every long response and
 // is exactly the wrong shape here.
+//
+// It measures ONE thing: the upstream has gone quiet. It deliberately does not
+// measure a slow CLIENT. A client behind on its reading pauses the upstream
+// stream (backpressure), and a client still uploading its request has not asked
+// the upstream for anything yet — in both cases the silence is ours, not the
+// engine's, so the deadline re-arms instead of firing. The connection is cut
+// only when the upstream is quiet AND the client is keeping up.
 const http = require('http');
 const https = require('https');
 
@@ -49,9 +56,13 @@ function proxyTts(req, res, engine, rest) {
     res.writeHead(502, { 'Content-Type': 'application/json' });
     res.end(JSON.stringify({ error: String((e && e.message) || e) }));
   };
+  const ourSilence = () => !req.readableEnded || res.writableNeedDrain || res.writableLength > 0;
   const arm = () => {
     disarm();
-    timer = setTimeout(() => fail(new Error('no bytes from upstream for ' + IDLE_MS + 'ms')), IDLE_MS);
+    timer = setTimeout(() => {
+      if (ourSilence()) return arm();
+      fail(new Error('no bytes from upstream for ' + IDLE_MS + 'ms'));
+    }, IDLE_MS);
   };
   const up = mod.request(target, { method: req.method, headers }, (r) => {
     res.writeHead(r.statusCode, r.headers);

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -167,6 +167,70 @@ test('a client abort reaches the engine', async () => {
   } finally { await s.stop(); await engine.stop(); }
 });
 
+// An engine that dies mid-response is a truncation, not a hang: the error lands
+// on the upstream RESPONSE, not on the request, and the browser has to see it —
+// a stuck fetch would leave the speech queue draining forever.
+test('an engine that dies after the headers truncates the client, it does not hang it', async () => {
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    res.write('first');
+    setTimeout(() => req.socket.destroy(), 100);        // synthesis dies mid-stream
+  });
+  const s = await startServer({ seed: seedConfig({ tts: { url: engine.url } }) });
+  try {
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
+    const reader = r.body.getReader();
+    assert.equal(Buffer.from((await reader.read()).value).toString(), 'first');
+    const ended = reader.read().then(() => 'closed', () => 'errored');
+    assert.notEqual(await Promise.race([ended, sleep(3000).then(() => 'hung')]), 'hung');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// The gap is between BYTES, never a cap on the whole request.
+test('an engine that goes quiet past the gap is hung up on', async () => {
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    res.write('first');                                  // ...and then nothing, ever
+  });
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: engine.url } }),
+    env: { BC_TTS_IDLE_MS: '400' },
+  });
+  try {
+    const t0 = Date.now();
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
+    const reader = r.body.getReader();
+    assert.equal(Buffer.from((await reader.read()).value).toString(), 'first');
+    const ended = reader.read().then(() => 'closed', () => 'errored');
+    assert.notEqual(await Promise.race([ended, sleep(5000).then(() => 'hung')]), 'hung');
+    assert.ok(Date.now() - t0 >= 400, 'hung up before the gap had elapsed');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// The other half of the same rule: a slow engine that keeps trickling runs well
+// past the gap and is left alone. A total-time cap would cut this one off.
+test('an engine that keeps trickling past the gap is not cut off', async () => {
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    let n = 0;
+    const timer = setInterval(() => {
+      if (++n > 10) { clearInterval(timer); return res.end('done'); }
+      res.write('.');                                    // every 150ms, for 1.5s
+    }, 150);
+    res.on('close', () => clearInterval(timer));
+  });
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: engine.url } }),
+    env: { BC_TTS_IDLE_MS: '400' },
+  });
+  try {
+    const t0 = Date.now();
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
+    assert.equal(await r.text(), '..........done');
+    assert.ok(Date.now() - t0 > 400, 'the engine did not actually outlast the gap');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
 // No engine, no route: the board is exactly as silent as it is today.
 test('no tts block: the proxy path is a plain 404', async () => {
   const s = await startServer({ seed: seedConfig({ voices: ['Luciana'] }) });

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -1,13 +1,15 @@
 'use strict';
-// External TTS: all the server does now is parse the tts block and hand it to the
-// browser through /api/config. The browser talks to the engine itself, so the
-// only contracts here are "absent tts = today's behaviour" and "a configured
-// engine reaches the client whole, url included".
+// External TTS: the engine is served from the board's own origin. /api/config
+// hands the browser the proxy prefix instead of the engine's address, and
+// /api/tts/<rest> is a dumb passthrough to <engine>/<rest> — same method, same
+// path, same headers, same status, same bytes, streamed both ways, and a client
+// that hangs up hangs up on the engine.
 const { test } = require('node:test');
 const assert = require('node:assert');
 const fs = require('node:fs');
+const http = require('node:http');
 const path = require('node:path');
-const { startServer } = require('./helper');
+const { startServer, sleep } = require('./helper');
 
 // Seed <dir>/.bridge-commander/config.json before the server boots.
 function seedConfig(cfg) {
@@ -16,6 +18,17 @@ function seedConfig(cfg) {
     fs.mkdirSync(sd, { recursive: true });
     fs.writeFileSync(path.join(sd, 'config.json'), JSON.stringify(cfg));
   };
+}
+
+// A stand-in engine: whatever the handler does is what the board must relay.
+function startEngine(handler) {
+  return new Promise((resolve) => {
+    const srv = http.createServer(handler);
+    srv.listen(0, '127.0.0.1', () => resolve({
+      url: 'http://127.0.0.1:' + srv.address().port,
+      stop: () => new Promise((r) => srv.close(r)),
+    }));
+  });
 }
 
 test('no tts in config: /api/config is unchanged', async () => {
@@ -28,9 +41,10 @@ test('no tts in config: /api/config is unchanged', async () => {
   } finally { await s.stop(); }
 });
 
-// The url used to be withheld deliberately. That reverses: the browser is the
-// engine's client now, and a client without an address cannot call anyone.
-test('tts in config: the whole block reaches the browser, url and defaults included', async () => {
+// The engine's address is the server's business now. The browser gets a path,
+// which resolves against the origin the page came from — the whole point: an
+// https page, or a phone off the tailnet, can reach it.
+test('tts in config: the browser is handed the proxy prefix, defaults and all', async () => {
   const s = await startServer({
     seed: seedConfig({ tts: { url: 'http://127.0.0.1:8883/', lang: 'pt', voice: null, params: { speed: 1.2 } } }),
   });
@@ -38,7 +52,7 @@ test('tts in config: the whole block reaches the browser, url and defaults inclu
     const r = await s.api('GET', '/api/config');
     assert.deepEqual(r.body.tts, {
       enabled: true,
-      url: 'http://127.0.0.1:8883',              // trailing slash trimmed: the browser appends /v1/...
+      url: '/api/tts',                            // never the tailnet address
       lang: 'pt',
       voice: null,
       params: { speed: 1.2 },
@@ -56,12 +70,109 @@ test('malformed tts config reads as not configured', async () => {
   }
 });
 
-// The proxy is gone. Nothing should answer where it used to live — a route that
-// half-exists is worse than one that does not.
-test('the proxy routes are gone', async () => {
-  const s = await startServer({ seed: seedConfig({ tts: { url: 'http://127.0.0.1:8883', lang: 'pt' } }) });
+// Method, path, query, headers and body go up; status, headers and body come
+// back. The proxy knows none of the names involved.
+test('the passthrough relays the request up and the answer back, whole', async () => {
+  let seen = null;
+  const engine = await startEngine((req, res) => {
+    let body = '';
+    req.on('data', (c) => (body += c));
+    req.on('end', () => {
+      seen = { method: req.method, url: req.url, ctype: req.headers['content-type'], mark: req.headers['x-mark'], body };
+      res.writeHead(418, { 'Content-Type': 'audio/wav', 'x-sample-rate': '24000' });
+      res.end('AUDIO');
+    });
+  });
+  const s = await startServer({ seed: seedConfig({ tts: { url: engine.url, lang: 'pt' } }) });
   try {
-    assert.equal((await s.api('GET', '/api/tts/voices')).status, 404);
-    assert.equal((await s.api('POST', '/api/tts/speech', { input: 'olá' })).status, 404);
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech?fast=1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-mark': 'up' },
+      body: JSON.stringify({ input: 'olá' }),
+    });
+    assert.deepEqual(seen, {
+      method: 'POST',
+      url: '/v1/audio/speech?fast=1',
+      ctype: 'application/json',
+      mark: 'up',
+      body: '{"input":"olá"}',
+    });
+    assert.equal(r.status, 418);                       // the engine's status, not ours
+    assert.equal(r.headers.get('content-type'), 'audio/wav');
+    assert.equal(r.headers.get('x-sample-rate'), '24000');
+    assert.equal(await r.text(), 'AUDIO');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// Any path, any method, and an engine error is an engine error — the proxy does
+// not turn a 500 into something friendlier.
+test('an unknown path and a failing engine both pass straight through', async () => {
+  const engine = await startEngine((req, res) => {
+    res.writeHead(500, { 'Content-Type': 'text/plain' });
+    res.end('boom ' + req.method + ' ' + req.url);
+  });
+  const s = await startServer({ seed: seedConfig({ tts: { url: engine.url } }) });
+  try {
+    const r = await fetch(s.base + '/api/tts/anything/at/all', { method: 'DELETE' });
+    assert.equal(r.status, 500);
+    assert.equal(await r.text(), 'boom DELETE /anything/at/all');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// Sound has to start while synthesis is still running. If the proxy buffered,
+// both chunks would land together at the end.
+test('the response streams: the first chunk arrives before the second is written', async () => {
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    res.write('first');
+    setTimeout(() => res.end('second'), 300);
+  });
+  const s = await startServer({ seed: seedConfig({ tts: { url: engine.url } }) });
+  try {
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
+    const reader = r.body.getReader();
+    const t0 = Date.now();
+    const chunks = [];
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      chunks.push({ text: Buffer.from(value).toString(), at: Date.now() - t0 });
+    }
+    assert.ok(chunks.length >= 2, 'arrived in one lump: ' + JSON.stringify(chunks));
+    assert.ok(chunks[0].at < 150, 'first chunk waited for the rest: ' + JSON.stringify(chunks));
+    assert.equal(chunks.map((c) => c.text).join(''), 'firstsecond');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// The load-bearing one. speech.js aborts its fetch so the ENGINE stops
+// synthesizing — an abandoned synthesis overlapping the next request takes
+// voxcpm2's CUDA context down with it.
+test('a client abort reaches the engine', async () => {
+  let hangup = null;
+  const seenHangup = new Promise((r) => (hangup = r));
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    res.write('first');
+    const timer = setInterval(() => res.write('.'), 50); // synthesis, still going
+    res.on('close', () => { clearInterval(timer); hangup(res.writableFinished); });
+  });
+  const s = await startServer({ seed: seedConfig({ tts: { url: engine.url } }) });
+  try {
+    const ac = new AbortController();
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}', signal: ac.signal });
+    await r.body.getReader().read();          // sound is playing
+    ac.abort();
+    const finished = await Promise.race([seenHangup, sleep(3000).then(() => 'timeout')]);
+    assert.equal(finished, false, 'the engine kept synthesizing after the client hung up');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// No engine, no route: the board is exactly as silent as it is today.
+test('no tts block: the proxy path is a plain 404', async () => {
+  const s = await startServer({ seed: seedConfig({ voices: ['Luciana'] }) });
+  try {
+    assert.equal((await s.api('GET', '/api/tts/v1/voices')).status, 404);
+    assert.equal((await s.api('POST', '/api/tts/v1/audio/speech', { input: 'olá' })).status, 404);
+    assert.equal((await s.api('GET', '/api/tts')).status, 404);
   } finally { await s.stop(); }
 });

--- a/test/tts.test.js
+++ b/test/tts.test.js
@@ -221,13 +221,47 @@ test('an engine that keeps trickling past the gap is not cut off', async () => {
   });
   const s = await startServer({
     seed: seedConfig({ tts: { url: engine.url } }),
-    env: { BC_TTS_IDLE_MS: '400' },
+    env: { BC_TTS_IDLE_MS: '1000' },
   });
   try {
     const t0 = Date.now();
     const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
     assert.equal(await r.text(), '..........done');
-    assert.ok(Date.now() - t0 > 400, 'the engine did not actually outlast the gap');
+    assert.ok(Date.now() - t0 > 1000, 'the engine did not actually outlast the gap');
+  } finally { await s.stop(); await engine.stop(); }
+});
+
+// The deadline is about the ENGINE going quiet, never about a slow client. A
+// phone on a thin link stops draining, backpressure pauses the upstream stream,
+// and no bytes arrive for seconds — that is our silence, not the engine's, and
+// hanging up on it would kill exactly the case this proxy exists for.
+test('a client that stops draining is not mistaken for a quiet engine', async () => {
+  const CHUNK = 64 * 1024;
+  const CHUNKS = 128;
+  const engine = await startEngine((req, res) => {
+    res.writeHead(200, { 'Content-Type': 'audio/wav' });
+    let n = 0;
+    const timer = setInterval(() => {
+      if (++n > CHUNKS) { clearInterval(timer); return res.end(); }
+      res.write(Buffer.alloc(CHUNK, 'a'));               // still synthesizing, happily
+    }, 2);
+    res.on('close', () => clearInterval(timer));
+  });
+  const s = await startServer({
+    seed: seedConfig({ tts: { url: engine.url } }),
+    env: { BC_TTS_IDLE_MS: '500' },
+  });
+  try {
+    const r = await fetch(s.base + '/api/tts/v1/audio/speech', { method: 'POST', body: '{}' });
+    const reader = r.body.getReader();
+    let got = (await reader.read()).value.length;
+    await sleep(2000);                                   // four gaps, reading nothing
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      got += value.length;
+    }
+    assert.equal(got, CHUNK * CHUNKS);
   } finally { await s.stop(); await engine.stop(); }
 });
 


### PR DESCRIPTION
## Intent

MNC-82: serve the TTS engine from the board's own origin. The board handed the browser a raw tailnet http address (100.114.197.65:8883) — unreachable from an https page or off-tailnet. Added server/ttsproxy.js: a path-preserving passthrough, <method> /api/tts/<rest> -> <engine>/<rest> where engine is tts.url from config.json. Deliberately dumb: no cache, no retry, no auth, no default-filling, no path knowledge, headers and status relayed untouched, request and response streamed both ways (never buffered). Decisions: used node http/https.request rather than fetch so both directions pipe natively and header passthrough is verbatim; only host is dropped (it must be the engine's). A client hangup destroys the upstream request — load-bearing, since speech.js aborts its fetch so the ENGINE stops synthesizing (an abandoned synthesis overlapping the next kills voxcpm2's CUDA context); guarded with a done flag so a normally-completed response does not destroy a pooled socket. Upstream error before headers -> 502 JSON; after headers -> destroy the response, the same truncation the browser would see talking to the engine direct. /api/config now serves tts.url = '/api/tts' (the rest of the block whole), so ui/js/voice.js and ui/js/voices.js resolve a relative base against the board's own origin and neither file changed; config.json keeps the real engine address. No tts block -> no route -> the ordinary 404. ui/js/speech.js untouched (explicitly out of scope per the card). README config table updated (it claimed the browser calls the engine, and that engine failures fall back to the browser voice — the latter has been false since PR #75). Tests rewritten in test/tts.test.js: status/header/body passthrough with method+path+query+headers+body verified upstream, unknown path and 500 relayed, streamed response arriving in chunks, client abort reaching the engine (verified to fail without the abort plumbing), 404 with no engine. Full suite 818/818 green. Exercised in a real browser (chrome-devtools-axi) against the live engine on a throwaway board at 127.0.0.1:4863: voice picker populated from GET /api/tts/v1/voices, the voice-test button and a real Portuguese lieutenant message both synthesized through POST /api/tts/v1/audio/speech (200, chunked, x-sample-rate: 48000 relayed), speech transport visible for the duration, no console errors. Headless box has no audio device so I could not literally hear it; the WAV pulled through the proxy is valid 48 kHz mono PCM. Branch bc/MNC-82, PR only — the captain merges it himself after testing tomorrow.

**Amended during review, on the lieutenant's ruling:** the card asked for no timeouts at all. Review pointed out that dropped a guarantee this server had already learned — a wedged engine holding a browser socket open forever, with no client-side timeout in `speech.js` to save it — so the silence-gap deadline came back as `BC_TTS_IDLE_MS` (default 20s): the gap between two bytes from upstream, never a cap on the whole request, and generic (it knows nothing about audio or paths). A slow client never trips it — backpressure re-arms it, because the silence is ours, not the engine's. The unauthenticated-exposure finding was approved as-is: the engine already listens on the same tailnet host.

## What Changed

- New `server/ttsproxy.js`: a path-preserving passthrough where `<method> /api/tts/<rest>` goes to `<engine>/<rest>` (engine = `tts.url` from `config.json`). Method, path, query, headers, status and bytes relayed untouched; only `host` is dropped. Both directions stream via `http/https.request` — never buffered — so audio plays while synthesis is still running. A client hangup destroys the upstream request so the engine actually stops synthesizing; a completed response does not (pooled socket). Upstream error before headers → 502 JSON, after headers → the response is destroyed, same truncation the browser saw talking to the engine direct.
- `server.js` mounts the route under `/api/tts` and `/api/config` now hands the browser `tts.url = '/api/tts'` (rest of the block whole), so `ui/js/voice.js` and `ui/js/voices.js` resolve a relative base against the page's own origin — no CORS, no tailnet required on the phone; the real engine address stays server-side. No `tts` block → no route → the ordinary 404.
- One deadline, `BC_TTS_IDLE_MS` (default 20s): the gap between two bytes *from upstream*, not a cap on the request. It re-arms while the client is still uploading or is behind on reading, so backpressure and slow links don't kill a healthy synthesis. `test/tts.test.js` rewritten — 12 tests covering passthrough (method/path/query/headers/body verified upstream), relayed 404/500, chunked streaming, client abort reaching the engine, the idle gap, backpressure, and no-engine 404; full suite 930/930. README config table and `BC_TTS_IDLE_MS` row updated (the old table claimed the browser calls the engine and that failures fall back to the browser voice — false since #75), and `dev/ui-server.js` notes that the playground has no proxy and still hands over the raw engine address.

## Risk Assessment

✅ Low: Two small, well-targeted changes — a guard so client backpressure re-arms the deadline instead of firing it, plus a wider test margin — and I verified both the slow-client and quiet-engine paths behave as ruled.

## Testing

Ran the rewritten test/tts.test.js (12/12) and the full suite (930/930, both green), then drove a live board in headless Chrome against a stand-in voxbench engine: the browser was handed `/api/tts` rather than the engine address, filled its voice picker from GET /api/tts/v1/voices, and spoke a real Portuguese lieutenant message through POST /api/tts/v1/audio/speech (200, chunked, x-sample-rate relayed, same-origin) with the speech transport on screen and zero requests to the engine address in the network log; hitting stop mid-speech made the engine stop synthesizing, an engine 404 came back as the engine's own 404, and a board with no tts block 404s the route. Screenshots, the browser network log, the engine-side log and a valid 48 kHz WAV pulled through the proxy are attached; I could not literally hear the audio because the box has no sound device.

- Evidence: Voice picker populated from the engine, through the board&#39;s own origin (local file: <code>/tmp/no-mistakes-evidence/01KZMFZMAT4NVN66YKE6WQ8CJP/01-voice-picker-from-engine.png</code>)
- Evidence: A Portuguese lieutenant message being spoken — speech transport up, no errors (local file: <code>/tmp/no-mistakes-evidence/01KZMFZMAT4NVN66YKE6WQ8CJP/02-message-spoken-through-board.png</code>)
<details>
<summary>Evidence: CLI transcript: config.json keeps the engine address, /api/config hands out /api/tts, voices + synthesis + engine 404 + no-tts 404</summary>

<code>### the workspace config on disk still holds the real engine address&#10;{&#34;tts&#34;: {&#34;url&#34;: &#34;http://127.0.0.1:18883&#34;, &#34;lang&#34;: &#34;pt&#34;, ...}}&#10;&#10;### what the browser is handed instead&#10;{&#34;voices&#34;:null,&#34;tts&#34;:{&#34;enabled&#34;:true,&#34;url&#34;:&#34;/api/tts&#34;,&#34;lang&#34;:&#34;pt&#34;,&#34;voice&#34;:null,&#34;params&#34;:{}}}&#10;&#10;### synthesis, streamed through — engine status and headers relayed untouched&#10;HTTP/1.1 200 OK&#10;content-type: audio/pcm&#10;x-sample-rate: 48000&#10;transfer-encoding: chunked&#10;-&gt; 1440000 bytes = 15.0s of 48 kHz mono PCM16&#10;&#10;### an engine 404 is the engine&#39;s 404 — the proxy invents nothing&#10;no such path [404]&#10;&#10;### a board with no tts block: no route at all, the ordinary 404&#10;{&#34;error&#34;:&#34;not found&#34;} [404]</code>

```text
### the workspace config on disk still holds the real engine address
$ cat .bridge-commander/config.json
{
  "tts": {
    "url": "http://127.0.0.1:18883",
    "lang": "pt",
    "voice": null,
    "params": {}
  },
  "port": 4863
}

### what the browser is handed instead
$ curl -s :4863/api/config
{"voices":null,"tts":{"enabled":true,"url":"/api/tts","lang":"pt","voice":null,"params":{}}}

### the catalogue, fetched from the board's own origin
$ curl -sD- :4863/api/tts/v1/voices
HTTP/1.1 200 OK
content-type: application/json
date: Mon, 10 Aug 2026 00:37:08 GMT
connection: keep-alive
keep-alive: timeout=5
transfer-encoding: chunked

{"voices":[{"id":"pt_br_lieutenant","name":"Bridget","langs":["pt-BR"]},{"id":"pt_br_capitao","name":"Capitao","langs":["pt-BR"]},{"id":"en_us_narrator","name":"Narrator","langs":["en-US"]}]}

### synthesis, streamed through — engine status and headers relayed untouched
$ curl -sD- -o speech.pcm -X POST :4863/api/tts/v1/audio/speech -d '{"input":"Capitão, a ponte está pronta.","voice":"pt_br_lieutenant"}'
HTTP/1.1 200 OK
content-type: audio/pcm
x-sample-rate: 48000
date: Mon, 10 Aug 2026 00:36:24 GMT
connection: keep-alive
keep-alive: timeout=5
transfer-encoding: chunked
  -> 1440000 bytes = 15.0s of 48 kHz mono PCM16 (see speech-through-proxy.wav)

### an engine 404 is the engine's 404 — the proxy invents nothing
$ curl -s -w ' [%{http_code}]' :4863/api/tts/no/such/path
no such path [404]

### a board with no tts block: no route at all, the ordinary 404
$ curl -s -w ' [%{http_code}]' :4864/api/tts/v1/voices    # workspace config has no tts
{"error":"not found"} [404]
$ curl -s :4864/api/config
{"voices":["Luciana"]}
```
</details>
<details>
<summary>Evidence: Browser network log — every TTS fetch is same-origin, zero hits on the engine address</summary>

<code>reqid=35815 GET http://127.0.0.1:4863/api/config [200]&#10;reqid=35817 GET http://127.0.0.1:4863/api/tts/v1/voices [200]&#10;reqid=35819 POST http://127.0.0.1:4863/api/tts/v1/audio/speech [200]&#10;reqid=35822 POST http://127.0.0.1:4863/api/tts/v1/audio/speech [200]&#10;&#10;# requests to the raw engine address (127.0.0.1:18883): count = 0&#10;&#10;# the speech request, in full:&#10;- host:127.0.0.1:4863 - origin:http://127.0.0.1:4863 - sec-fetch-site:same-origin&#10;{&#34;input&#34;:&#34;Capitão: a fala agora vem pela origem do próprio quadro — nenhum endereço de tailnet chega ao navegador.&#34;,&#34;voice&#34;:&#34;pt_br_lieutenant&#34;,&#34;stream&#34;:true}&#10;x-sample-rate:48000 transfer-encoding:chunked</code>

```text
# browser network log — every fetch the page made (chrome devtools)
Showing 1-8 of 8 (Page 1 of 1).
reqid=35815 GET http://127.0.0.1:4863/api/config [200]
reqid=35817 GET http://127.0.0.1:4863/api/tts/v1/voices [200]
reqid=35818 GET http://127.0.0.1:4863/api/board [200]
reqid=35819 POST http://127.0.0.1:4863/api/tts/v1/audio/speech [200]
reqid=35820 POST http://127.0.0.1:4863/api/read [200]
reqid=35821 GET http://127.0.0.1:4863/api/chat?target=lieutenant%3Abridget&before=2026-08-10T00%3A31%3A45.427Z&limit=50 [200]
reqid=35822 POST http://127.0.0.1:4863/api/tts/v1/audio/speech [200]
reqid=35823 POST http://127.0.0.1:4863/api/read [200]

# requests to the raw engine address (100.114.197.65:8883-style tailnet addr, here 127.0.0.1:18883):
  count = 0

# the speech request, in full — same-origin, headers relayed:
request:
## Request http://127.0.0.1:4863/api/tts/v1/audio/speech
Status: 200
### Request Headers
- user-agent:Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36
- content-type:application/json
- referer:http://127.0.0.1:4863/
- accept:*/*
- accept-encoding:gzip, deflate, br, zstd
- accept-language:en-US,en;q=0.9
- connection:keep-alive
- content-length:162
- host:127.0.0.1:4863
- origin:http://127.0.0.1:4863
- sec-fetch-dest:empty
- sec-fetch-mode:cors
- sec-fetch-site:same-origin
### Request Body
{"input":"Capitão: a fala agora vem pela origem do próprio quadro — nenhum endereço de tailnet chega ao navegador.","voice":"pt_br_lieutenant","stream":true}
### Response Headers
- connection:keep-alive
- content-type:audio/pcm
- date:Mon, 10 Aug 2026 00:35:48 GMT
- keep-alive:timeout=5
- transfer-encoding:chunked
- x-sample-rate:48000
### Response Body
<binary data>
```
</details>
<details>
<summary>Evidence: Stop mid-speech reaches the engine</summary>

<code>{&#34;t&#34;:&#34;...T00:36:10.603Z&#34;,&#34;method&#34;:&#34;POST&#34;,&#34;url&#34;:&#34;/v1/audio/speech&#34;,&#34;ua&#34;:&#34;Mozilla/5.0 ... Chrome/145&#34;,&#34;origin&#34;:&#34;http://127.0.0.1:4863&#34;,&#34;host&#34;:&#34;127.0.0.1:18883&#34;}&#10;{&#34;t&#34;:&#34;...T00:36:10.603Z&#34;,&#34;synth&#34;:{&#34;voice&#34;:&#34;pt_br_lieutenant&#34;,&#34;input&#34;:&#34;Aperte parar no meio desta frase...&#34;}}&#10;{&#34;t&#34;:&#34;...T00:36:14.344Z&#34;,&#34;hangup&#34;:&#34;client gone mid-synthesis, engine stopped&#34;}</code>

```text
# the captain hits ■ (stop) mid-speech — the engine must stop synthesizing too
# engine-side log, /api/tts POST relayed from the browser through the board:
{"t":"2026-08-10T00:36:10.603Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:36:10.603Z","synth":{"voice":"pt_br_lieutenant","input":"Aperte parar no meio desta frase e o motor deve parar de sintetizar junto com o navegador."}}
{"t":"2026-08-10T00:36:14.344Z","hangup":"client gone mid-synthesis, engine stopped"}
```
</details>
<details>
<summary>Evidence: Engine-side log — browser headers relayed verbatim, only host rewritten</summary>

```text
{"t":"2026-08-10T00:30:11.602Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:30:28.864Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:30:28.870Z","method":"POST","url":"/v1/audio/speech","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:30:28.870Z","synth":{"voice":"pt_br_lieutenant","input":"Capitao, a ponte esta pronta."}}
{"t":"2026-08-10T00:30:31.033Z","method":"GET","url":"/nope","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:30:35.965Z","method":"GET","url":"/v1/voices","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:31:17.260Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:31:17.260Z","synth":{"voice":"pt_br_lieutenant","input":"Hello, this is my voice."}}
{"t":"2026-08-10T00:31:45.430Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:31:45.430Z","synth":{"voice":"pt_br_lieutenant","input":"Capitão, o motor de voz agora é servido pela própria origem do quadro. Nada de endereço de tailnet no navegador."}}
{"t":"2026-08-10T00:32:22.934Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:32:28.536Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:32:28.537Z","synth":{"voice":"pt_br_lieutenant","input":"Mensagem longa para testar o corte: o navegador aborta o fetch e o motor precisa parar de sintetizar."}}
{"t":"2026-08-10T00:33:44.951Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:33:52.145Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:33:52.146Z","synth":{"voice":"pt_br_lieutenant","input":"Parar no meio da fala: o motor tem de parar de sintetizar junto."}}
{"t":"2026-08-10T00:34:54.353Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:35:01.097Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:35:01.097Z","synth":{"voice":"pt_br_lieutenant","input":"Cortar a fala no meio: o motor tem de parar de sintetizar junto."}}
{"t":"2026-08-10T00:35:05.030Z","hangup":"client gone mid-synthesis, engine stopped"}
{"t":"2026-08-10T00:35:30.065Z","method":"GET","url":"/v1/voices","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:35:48.436Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:35:48.437Z","synth":{"voice":"pt_br_lieutenant","input":"Capitão: a fala agora vem pela origem do próprio quadro — nenhum endereço de tailnet chega ao navegador."}}
{"t":"2026-08-10T00:36:10.603Z","method":"POST","url":"/v1/audio/speech","ua":"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/145.0.0.0 Safari/537.36","origin":"http://127.0.0.1:4863","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:36:10.603Z","synth":{"voice":"pt_br_lieutenant","input":"Aperte parar no meio desta frase e o motor deve parar de sintetizar junto com o navegador."}}
{"t":"2026-08-10T00:36:14.344Z","hangup":"client gone mid-synthesis, engine stopped"}
{"t":"2026-08-10T00:36:24.443Z","method":"POST","url":"/v1/audio/speech","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:36:24.443Z","synth":{"voice":"pt_br_lieutenant","input":"Capitão, a ponte está pronta."}}
{"t":"2026-08-10T00:37:08.713Z","method":"GET","url":"/v1/voices","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
{"t":"2026-08-10T00:37:08.721Z","method":"GET","url":"/no/such/path","ua":"curl/8.5.0","origin":"","host":"127.0.0.1:18883","from":"127.0.0.1"}
```
</details>
- Evidence: Audio pulled through the proxy, wrapped as WAV (48 kHz mono PCM16, 15.0s) (local file: <code>/tmp/no-mistakes-evidence/01KZMFZMAT4NVN66YKE6WQ8CJP/speech-through-proxy.wav</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `server/ttsproxy.js:29` - No &#39;error&#39; handler on the upstream response `r`. When the engine dies after sending headers, Node emits ECONNRESET on `r`, not on `up` — so `up.on(&#39;error&#39;)` never runs, `res` is never ended or destroyed, and the client hangs forever (verified with a standalone probe: fetch never settles, response socket stays open). speech.js has no client-side timeout, so voice.js&#39;s drain loop stays stuck with draining=true and the board never speaks again until reload; before this change the browser saw the reset immediately. Also contradicts the file&#39;s own comment and the card (&#34;after headers -&gt; destroy the response&#34;). Fix: add `r.on(&#39;error&#39;, () =&gt; res.destroy())` in the response callback, and cover the mid-stream engine death in test/tts.test.js.
- ⚠️ `server/ttsproxy.js:22` - The proxy has no timeouts (deliberate per the card), and the old server.js comment it replaced stated the opposite guarantee: &#34;External TTS proxy timeouts — a hanging engine must never hang the board.&#34; An engine that accepts the connection and then wedges now holds the browser request open indefinitely; with no timeout in speech.js either, the speech queue stalls permanently. Worth confirming you want the silence-gap deadline gone rather than reinstated on the server side.
- ℹ️ `server/server.js:3719` - The route relays any method and any path under /api/tts to the engine, and the board has no auth. An engine bound to loopback on the server host (the documented 127.0.0.1:8883 default) is now reachable by anyone who can reach the board — relevant when it binds to a tailnet address or 0.0.0.0. Intentional per the card (&#34;no auth&#34;), noted as an exposure change rather than a defect.
- ℹ️ `server/ttsproxy.js:34` - The extra `up.on(&#39;response&#39;, ...)` listener exists only to set `done`; the response callback on line 27 already has `r`. Setting `r.once(&#39;end&#39;, () =&gt; { done = true; })` there drops a listener and keeps the lifecycle logic in one place.

🔧 Fix: fix(tts): upstream response errors and an idle-gap hangup
3 issues (1 warning, 2 infos) still open:
- ⚠️ `server/ttsproxy.js:58` - The gap is re-armed by bytes *forwarded to the client*, not bytes arriving from upstream. When the client stops draining, pipe pauses `r`, &#39;data&#39; stops firing, and the timer kills a perfectly healthy engine mid-synthesis. Verified with a standalone probe (BC_TTS_IDLE_MS=500, client paused reading for 2s): the engine was hung up on after 15 MB and the client&#39;s stream terminated at 9 MB. Real-world trigger is the case this PR exists for — a phone off the tailnet on a link slower than the 96 KB/s the engine emits, or a frozen/backgrounded tab. Same arming also covers the request-body upload, so a slow POST upload past the gap fails too. Two-line remedy that keeps the stated rule (&#34;the gap between two bytes from upstream&#34;): `r.on(&#39;pause&#39;, disarm); r.on(&#39;resume&#39;, arm);` so backpressure suspends the deadline instead of firing it.
- ℹ️ `test/tts.test.js:205` - The &#39;keeps trickling&#39; test writes every 150ms against a 400ms gap — a 250ms margin. `node --test test/*.test.js` runs files in parallel processes, so one scheduler stall on a loaded box truncates the stream and fails the assertion. Widening the gap (e.g. BC_TTS_IDLE_MS=1000 with the same 150ms trickle, still ~1.5s) keeps the test fast and removes the flake.
- ℹ️ `server/ttsproxy.js:26` - The card/PR text still describes the proxy as &#34;Deliberately dumb: no cache, no retry, no auth, no default-filling, no path knowledge, no timeouts&#34;, while the code now has BC_TTS_IDLE_MS (20000 default). That is the ruling from the previous review round, not a regression — just worth updating the PR description so the acceptance criteria match what shipped.

🔧 Fix: fix(tts): client backpressure is not engine silence
1 info still open:
- ℹ️ `server/ttsproxy.js:59` - The `!req.readableEnded` clause is the ruled behaviour (a slow uploading client must not trip the deadline), with the accepted consequence that a client which sends headers and then stalls mid-body holds the upstream connection open past the 20s gap. It is bounded: Node&#39;s default `server.requestTimeout` (300000 ms on the Node 24 here) destroys the request, which fires `res` close and destroys `up`. Noting the tradeoff, not asking for a change.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/tts.test.js` — 12/12 (passthrough, streaming, client abort, idle gap, backpressure, no-engine 404)</code>
- <code>`node --test test/*.test.js harness/test/*.test.js` — full suite, 930/930</code>
- <code>Manual: booted a real board (`node server/server.js --workspace &lt;tmp&gt; --port 4863`) against a stand-in voxbench engine on 127.0.0.1:18883 with the engine address only in `.bridge-commander/config.json`</code>
- <code>Manual (browser, chrome-devtools-axi): opened the board, opened settings, voice picker populated with the engine&#39;s three voices via `GET /api/tts/v1/voices`, selected Bridget (pt-BR)</code>
- <code>Manual (browser): posted a Portuguese lieutenant message via `POST /api/message` and watched it auto-speak — `POST /api/tts/v1/audio/speech` 200, chunked, `x-sample-rate: 48000`, speech transport visible</code>
- <code>Manual (browser): `chrome-devtools-axi network` — 0 requests to the engine address 127.0.0.1:18883; speech request shows `sec-fetch-site: same-origin`</code>
- <code>Manual (browser): clicked ■ (stop) mid-synthesis — engine logged `hangup: client gone mid-synthesis, engine stopped` 3.7s into a 15s synthesis</code>
- <code>Manual (CLI): `curl -sD- :4863/api/tts/v1/voices`, `curl -sD- -X POST :4863/api/tts/v1/audio/speech`, `curl :4863/api/tts/no/such/path` (engine&#39;s own 404 relayed), and a second board with no tts block returning the ordinary `{&#34;error&#34;:&#34;not found&#34;}` 404</code>
- <code>Manual: wrapped the PCM pulled through the proxy into a WAV — `file` reports 16-bit mono 48000 Hz, 15.0s</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

