### PR TITLE
feat(ui): the room raises the Quest system keyboard, and gets dictation with it

### DIFF
--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -741,6 +741,17 @@ test('only the system keyboard focuses anything, and its field is in the viewpor
       `${f} builds a uikit Input, whose hidden element sits at left:-1000vw`);
   }
 
+  // The wrong theory itself, hunted by phrase. A stale copy of "focusing a node
+  // takes the browser out of the session" is exactly what this change exists to
+  // correct, and greping for `.focus(` above cannot see one rotting in a
+  // comment.
+  for (const f of fs.readdirSync(UI)) {
+    if (!f.endsWith('.js')) continue;
+    const src = fs.readFileSync(path.join(UI, f), 'utf8');
+    assert.ok(!/focus\w*[^.]{0,80}(out of the (session|room)|crash)/i.test(src),
+      `${f} still says focusing a DOM node takes the browser out of the session — it does not`);
+  }
+
   // The one field that is focused, and the property the crash turned on. It is
   // asserted against the STYLE the module ships, because that string is the
   // whole difference between the supported mechanism and the documented bug.
@@ -951,11 +962,70 @@ test('the system keyboard drives the composer, and never types a letter twice', 
 
   // The seam itself, which is the one decision this design cannot read off the
   // API: whether the first value of an editing session replaced what he had
-  // written or was typed after it.
+  // written or was typed after it. All five branches, because the seed survives
+  // an edit in EITHER direction — typing after it and backspacing into it —
+  // and the second is the whole reason the field is seeded at all.
   assert.equal(seamOf('olá', ' '), 'olá', 'an overwritten field threw away his sentence');
   assert.equal(seamOf('olá', 'olá tudo'), '', 'a surviving seed was pasted in front of itself');
+  assert.equal(seamOf('olá', 'ol'), '', 'a first backspace was read as an overwrite');
+  assert.equal(seamOf('olá', ''), null, 'an empty first value decided a seam it cannot know');
   assert.equal(seamOf('', 'a'), '', 'an empty composer grew a prefix');
 
+  setKeyboard(null);
+});
+
+test('the keyboard survives a first backspace, an empty field, and the keys moving', async () => {
+  const { Composer, routeKey, setKeyboard, keysHeld } = await load('keys.js');
+  const { SystemKeyboard } = await load('syskb.js');
+  const key = (k, over) => Object.assign({ key: k, preventDefault() {} }, over);
+
+  // ---- his first action is a backspace --------------------------------------
+  //
+  // The seed is there so he can delete back into what he already wrote. Reading
+  // that first shorter value as an overwrite pastes the whole sentence back in
+  // front of the edit, and it stays wrong for the rest of the showing.
+  const { doc } = fakeDom();
+  const kb = new SystemKeyboard(doc);
+  setKeyboard(kb);
+  kb.attach({ isSystemKeyboardSupported: true });
+  const el = doc.body.children[0];
+  const a = new Composer();
+  a.setValue('ola');
+  a.take();
+  el.typed('ol');
+  assert.equal(a.value, 'ol', 'a first backspace pasted the seed back in front of the edit');
+  el.typed('o');
+  assert.equal(a.value, 'o', 'the seam was re-decided after the first value');
+
+  // ---- and a field that goes empty ------------------------------------------
+  //
+  // An empty value is the one that says nothing: the overwrite model can empty
+  // the field on its own. The composer keeps what it had and the next value
+  // decides.
+  a.setValue('ola');
+  a.take();
+  el.typed('');
+  assert.equal(a.value, 'ola', 'an empty first value wiped text it knew nothing about');
+  el.typed('ol');
+  assert.equal(a.value, 'ol', 'the deferred seam decided wrong on the next value');
+
+  // ---- the keys move to another composer without asking for the keyboard ----
+  //
+  // `take({ raise: false })` is what opening a chat does. If the keyboard were
+  // left driving the composer that no longer holds the keys, `routeKey` would
+  // swallow every bluetooth character while the field wrote into the old one.
+  const b = new Composer();
+  a.take();
+  assert.equal(kb.driving(), true);
+  b.take({ raise: false });
+  assert.equal(keysHeld(), b);
+  assert.equal(kb.driving(), false, 'the keyboard is still editing the composer that lost the keys');
+  const before = a.value;
+  routeKey(key('z'));
+  assert.equal(b.value, 'z', 'bluetooth did not resume into the composer that took the keys');
+  assert.equal(a.value, before, 'the old composer was still being written into');
+
+  kb.detach();
   setKeyboard(null);
 });
 

--- a/test/bridge3d.test.js
+++ b/test/bridge3d.test.js
@@ -714,27 +714,53 @@ test('the ray is the vendored pointer library, not a hand-rolled rectangle', asy
 
 // ---- the headset stays in the session ---------------------------------------
 
-test('nothing in the room focuses a DOM node, and no field is a hidden input', async () => {
-  // This is the one that took the whole browser. Focusing a text input inside
-  // an immersive session asks the Quest browser for the system keyboard, which
-  // is a shell surface that has to composite over the immersive layer, and the
-  // session dies — with nothing thrown that a handler could catch. It killed a
-  // chat the instant it opened and the wall's search field on the first press.
+test('only the system keyboard focuses anything, and its field is in the viewport', async () => {
+  // The rule this used to hold — "nothing in the room ever focuses a DOM node"
+  // — was built on a wrong diagnosis, and the correction is the point of the
+  // test now. The Quest system keyboard IS supported inside an immersive
+  // session from Browser 26.1, focusing a field is how you raise it, and the
+  // session survives it. What took the browser out was the ELEMENT: uikit parks
+  // its hidden input at `left: -1000vw`, and an off-screen text field is the
+  // pitfall Meta's doc names by name — the page scrolls to it when typing
+  // starts.
   //
-  // The captain is the only one with a headset, so no test can reproduce it.
-  // What a test CAN do is hold the line: the crash needs a focused DOM element,
-  // and there is no longer any code in the room that could produce one.
+  // So the line held here moved. One file may focus, and the field it focuses
+  // has to be inside the viewport.
   for (const f of fs.readdirSync(UI)) {
     if (!f.endsWith('.js')) continue;
+    if (f === 'syskb.js') continue;
     const src = fs.readFileSync(path.join(UI, f), 'utf8');
-    assert.ok(!/\.focus\s*\(/.test(src), `${f} focuses something — that is the crash`);
+    assert.ok(!/\.focus\s*\(/.test(src),
+      `${f} focuses something — the system keyboard is syskb.js's job alone`);
     assert.ok(!/activeElement/.test(src),
       `${f} reads the document's active element instead of the room's own state`);
-    // uikit's Input focuses its own hidden element from its pointerdown
-    // handler, so one standing in the room is enough on its own.
+    // uikit's Input is still out, and now for a reason we can point at: it owns
+    // the off-screen element above, and it draws its own glyphs in a room where
+    // nothing is rendered by the browser.
     assert.ok(!/components\/input\.js/.test(src) && !/\bnew Input\(/.test(src),
-      `${f} builds a uikit Input, which focuses a hidden <input> when it is pressed`);
+      `${f} builds a uikit Input, whose hidden element sits at left:-1000vw`);
   }
+
+  // The one field that is focused, and the property the crash turned on. It is
+  // asserted against the STYLE the module ships, because that string is the
+  // whole difference between the supported mechanism and the documented bug.
+  const kb = fs.readFileSync(path.join(UI, 'syskb.js'), 'utf8');
+  const style = (/const STYLE = ([\s\S]*?);\n/.exec(kb) || [])[1] || '';
+  assert.match(style, /position:fixed/, 'the keyboard field can be scrolled to');
+  assert.match(style, /left:0;top:0/, 'the keyboard field is not at the viewport origin');
+  assert.ok(!/:\s*-/.test(style),
+    'the keyboard field is parked off-screen — that is the bug, not the fix');
+  // Focusable at all: `display:none` and `visibility:hidden` cannot take focus,
+  // so a field hidden either of those ways raises no keyboard.
+  assert.ok(!/display:none|visibility:hidden/.test(style),
+    'an unfocusable field raises no keyboard');
+  // uikit's element, quoted, so this test fails loudly if a vendor bump ever
+  // makes the ban unnecessary rather than leaving the reason to rot.
+  assert.match(
+    fs.readFileSync(path.join(ROOT, 'ui', 'vendor', 'uikit', 'text', 'input', 'hidden-input.js'), 'utf8'),
+    /'left',\s*'-1000vw'/,
+    "uikit no longer parks its input off-screen — the reason kit.js bans Input has changed",
+  );
 
   // And what replaced it: the room's own field, holding the keys as a module
   // reference rather than as a browser state, routed at the window.
@@ -785,6 +811,167 @@ test('nothing in the room focuses a DOM node, and no field is a hidden input', a
   wall.release();
   assert.equal(keysHeld(), null);
   assert.equal(routeKey(key('b')), false, 'the shortcuts are still dead after the panel closed');
+});
+
+// A browser, in as much detail as syskb.js can tell. `type()` is what the
+// system keyboard and a paired bluetooth keyboard both do to a focused field:
+// set the value and fire `input`. There are no key events to fake, because the
+// system keyboard does not send any — that is the whole shape of the thing.
+function fakeDom() {
+  const win = { scrollX: 0, scrollY: 0, scrollTo(x, y) { win.scrollX = x; win.scrollY = y; } };
+  const doc = {
+    defaultView: win,
+    activeElement: null,
+    body: { children: [], appendChild(el) { doc.body.children.push(el); } },
+    createElement() {
+      const handlers = {};
+      const fire = (t) => { for (const fn of handlers[t] || []) fn(); };
+      const el = {
+        style: { cssText: '' }, value: '', attrs: {},
+        setAttribute(k, v) { el.attrs[k] = v; },
+        addEventListener(t, fn) { (handlers[t] = handlers[t] || []).push(fn); },
+        focus() { doc.activeElement = el; },
+        blur() { if (doc.activeElement === el) doc.activeElement = null; fire('blur'); },
+        remove() { doc.body.children = doc.body.children.filter((c) => c !== el); },
+        // Named away from `type`: syskb.js sets `el.type = 'text'` on the real
+        // element, and a fake whose method shares that name loses it.
+        typed(v) { el.value = v; fire('input'); },
+      };
+      return el;
+    },
+  };
+  return { doc, win };
+}
+
+test('the system keyboard drives the composer, and never types a letter twice', async () => {
+  const { Composer, routeKey, setKeyboard, keysHeld } = await load('keys.js');
+  const { SystemKeyboard, seamOf } = await load('syskb.js');
+  const key = (k, over) => Object.assign({ key: k, preventDefault() {} }, over);
+
+  // ---- a browser that does not offer one -----------------------------------
+  //
+  // The guard is the part that must not be clever: no session, an old browser,
+  // or a session that does not advertise the keyboard, and the room is exactly
+  // what it was — bluetooth through the window, no element, no half-raised
+  // anything.
+  const off = fakeDom();
+  const quiet = new SystemKeyboard(off.doc);
+  setKeyboard(quiet);
+  const flat = new Composer();
+  flat.take();
+  assert.equal(off.doc.body.children.length, 0, 'a field was built with no session at all');
+  assert.equal(quiet.driving(), false);
+  routeKey(key('h')); routeKey(key('i'));
+  assert.equal(flat.value, 'hi', 'the bluetooth path stopped working without a system keyboard');
+  quiet.attach({ isSystemKeyboardSupported: false });
+  assert.equal(off.doc.body.children.length, 0, 'a browser that says no still got a field');
+  assert.equal(quiet.raise(flat), false, 'the keyboard was raised on a browser that has none');
+  flat.release();
+
+  // ---- and one that does ----------------------------------------------------
+  const { doc, win } = fakeDom();
+  const kb = new SystemKeyboard(doc);
+  setKeyboard(kb);
+  kb.attach({ isSystemKeyboardSupported: true });
+  assert.equal(doc.body.children.length, 1, 'the session started and no field was built');
+  const el = doc.body.children[0];
+  assert.match(el.style.cssText, /position:fixed/);
+  assert.ok(!/left:-/.test(el.style.cssText), 'the field is off-screen — the page will scroll to it');
+
+  const sent = [];
+  const chat = new Composer({ onSubmit: (v) => sent.push(v) });
+
+  // Opening a panel takes the keys WITHOUT raising the keyboard: he gets the
+  // caret and his bluetooth keyboard, and the shell surface only when he asks.
+  chat.take({ raise: false });
+  assert.equal(keysHeld(), chat);
+  assert.equal(kb.driving(), false, 'opening a panel raised the system keyboard by itself');
+  routeKey(key('o'));
+  assert.equal(chat.value, 'o', 'bluetooth stopped working before the keyboard was raised');
+
+  // Pressing the field is what raises it, and it opens onto what he has already
+  // written rather than onto a blank.
+  chat.take();
+  assert.equal(kb.driving(), true, 'pressing the field did not raise the keyboard');
+  assert.equal(el.value, 'o', 'the field was not seeded with the composer text');
+
+  // The documented behaviour: a new editing session, whose first key press
+  // overwrites the whole value. What arrives is a delta, and the composer keeps
+  // what it had.
+  el.typed('l');
+  assert.equal(chat.value, 'ol', 'the first keystroke wiped the text he had already written');
+  el.typed('lá');
+  assert.equal(chat.value, 'olá', 'the accented letter did not arrive intact');
+
+  // While that field is focused it is the only source of characters. A
+  // bluetooth keystroke reaches it AND the window; applying both would type
+  // everything twice. The shortcuts still stay dead, and Enter still sends —
+  // neither of those changes the field's value, so neither arrives twice.
+  assert.equal(routeKey(key('x')), true, 'a shortcut woke up while he was typing');
+  assert.equal(chat.value, 'olá', 'the keystroke was applied twice');
+  assert.equal(routeKey(key('Backspace')), true);
+  assert.equal(chat.value, 'olá', 'backspace deleted two characters, one per path');
+  routeKey(key('Enter'));
+  assert.deepEqual(sent, ['olá'], 'Enter did not send with the keyboard up');
+
+  // Sending clears the composer, and the field has to be told — otherwise it
+  // still holds the sent message and hands it back with the next letter.
+  chat.setValue('');
+  assert.equal(el.value, '', 'the field kept the message that was already sent');
+  el.typed('t');
+  assert.equal(chat.value, 't', 'the sent message came back attached to the next letter');
+
+  // Dismissing the keyboard — Done, the Meta button, a press outside it — blurs
+  // the field. He KEEPS the keys: bluetooth still types, the shortcuts stay
+  // dead, and pressing the field is how he asks for the keyboard back.
+  el.blur();
+  assert.equal(kb.driving(), false);
+  assert.equal(keysHeld(), chat, 'dismissing the keyboard let go of the keys');
+  routeKey(key('u'));
+  assert.equal(chat.value, 'tu', 'bluetooth stopped working after the keyboard was dismissed');
+  chat.take();
+  assert.equal(kb.driving(), true, 'pressing the field again did not bring the keyboard back');
+  assert.equal(el.value, 'tu', 'it came back onto a blank instead of onto what he had written');
+
+  // The page never scrolls. The field is in the viewport so there should be
+  // nothing to scroll to; if the browser finds something anyway, the flat board
+  // is put back where it was, because that is the page he leaves the session
+  // onto.
+  win.scrollY = 500;
+  el.typed('tudo');
+  assert.equal(win.scrollY, 0, 'the page was left scrolled somewhere he did not put it');
+
+  // Releasing lets go of everything, and the session ending takes the field out
+  // of the page — an input left behind is a focus trap on the flat board.
+  chat.release();
+  assert.equal(keysHeld(), null);
+  assert.equal(kb.driving(), false, 'the field is still focused with nobody holding the keys');
+  kb.detach();
+  assert.equal(doc.body.children.length, 0, 'the field outlived the session');
+
+  // The seam itself, which is the one decision this design cannot read off the
+  // API: whether the first value of an editing session replaced what he had
+  // written or was typed after it.
+  assert.equal(seamOf('olá', ' '), 'olá', 'an overwritten field threw away his sentence');
+  assert.equal(seamOf('olá', 'olá tudo'), '', 'a surviving seed was pasted in front of itself');
+  assert.equal(seamOf('', 'a'), '', 'an empty composer grew a prefix');
+
+  setKeyboard(null);
+});
+
+test('opening a chat takes the keys but does not raise the keyboard', () => {
+  // The distinction is worth a test of its own because it is the exact line the
+  // old crash was on: whatever the room does automatically the instant a panel
+  // opens is the worst possible place to be wrong about a shell surface.
+  assert.match(
+    fs.readFileSync(path.join(UI, 'chat.js'), 'utf8'),
+    /this\.field\.take\(\{ raise: false \}\)/,
+    'opening a chat fills the room with a keyboard he did not ask for',
+  );
+  // And the session owns the field's whole life.
+  const main = fs.readFileSync(path.join(UI, 'main.js'), 'utf8');
+  assert.match(main, /syskb\.attach\(session\)/, 'the keyboard is never told a session started');
+  assert.match(main, /syskb\.detach\(\)/, 'the keyboard field outlives the session');
 });
 
 // ---- the old room is gone --------------------------------------------------

--- a/ui/bridge3d.html
+++ b/ui/bridge3d.html
@@ -24,7 +24,8 @@
     the lieutenants are the arc above — <b>point at one and pull the trigger to open its chat</b> ·
     the mat on the floor ahead opens <b>the board</b>, and a press on a card brings it forward<br>
     in the headset — <b>trigger</b>: press · <b>squeeze</b> a window's title bar: pick it up and put it
-    where you want · type on a paired keyboard, <b>enter</b> sends<br>
+    where you want · press a composer to dictate on the <b>system keyboard</b>, whose <b>done</b>
+    doesn't send — the send box does; a paired keyboard's <b>enter</b> still sends<br>
     at a desk — drag to look · click to press · <b>b</b>: the board · <b>c</b>: a chat · <b>x</b>: close the front window
   </div>
 </div>

--- a/ui/js/bridge3d/board.js
+++ b/ui/js/bridge3d/board.js
@@ -249,9 +249,13 @@ export class BoardWall {
     }
 
     // The field: still here, still free text, and it ANDs with the faces rather
-    // than replacing them. A Composer rather than uikit's Input — pressing an
-    // Input focuses its hidden DOM element, and that is what took the headset
-    // browser out of the session the moment he pressed this. See keys.js.
+    // than replacing them. A Composer rather than uikit's Input, for the two
+    // reasons in kit.js — and pressing it raises the system keyboard, so the
+    // wall can be filtered by voice as well as by a face. Every character it
+    // gets goes through `onChange` below, which is the same door a bluetooth
+    // keystroke comes through, so a dictated word filters exactly like a typed
+    // one. MNC-4 — "search all cards crashed the headset browser" — was the
+    // off-screen element, not this press. See syskb.js.
     this.field = new Field({
       box: {
         width: '100%', height: cm(barM), flexShrink: 0,

--- a/ui/js/bridge3d/chat.js
+++ b/ui/js/bridge3d/chat.js
@@ -10,15 +10,18 @@
 // bottom, and a composer in the foot.
 //
 // **Input, honestly.** The composer is a `Field` — a surface the room draws and
-// types into itself, with no DOM focus anywhere near it, because focusing a
-// hidden <input> inside an immersive session summons the Quest system keyboard
-// and takes the browser out of the session with it. See keys.js. A paired
-// Bluetooth keyboard delivers keydown to the document regardless, main.js hears
-// it at the window, and it goes to whichever composer holds the keys — opening
-// a chat is an intention to talk, so this one takes them. Enter sends. There is
-// no on-screen keyboard: typing on a floating keyboard in VR is miserable, and
-// a half-built one would be worse than saying plainly that a keyboard is
-// required. When dictation lands it plugs in here, at `send()`.
+// paints itself; nothing here is ever rendered by the browser. Two things can
+// put characters in it. A paired Bluetooth keyboard delivers keydown to the
+// document regardless of focus, main.js hears it at the window, and it goes to
+// whichever composer holds the keys — opening a chat is an intention to talk,
+// so this one takes them, and Enter sends. And PRESSING the field raises the
+// Quest system keyboard, which is where dictation comes from: he speaks, the
+// words arrive through the field's `value`, and `send` puts them on the board.
+// See keys.js and syskb.js.
+//
+// The system keyboard has no Enter that reaches us — Done dismisses it and
+// nothing is delivered — so the `send` box beside the field is not decoration.
+// It is the only way to send a dictated message.
 //
 // Sending is `POST /api/feedback` — the captain side of chat.say. Write-ahead:
 // the server queues the delivery before it wakes anybody, so a message never
@@ -92,7 +95,15 @@ export class ChatPanel extends Panel {
     // chats open never has two of them listening, because taking the keys takes
     // them off whoever had them. Closing gives them back to the room, which is
     // what makes `b`/`c`/`x` work again.
-    if (on) this.field.take(); else this.field.release();
+    //
+    // `raise: false` is the one thing opening does NOT do. Taking the keys is
+    // cheap — a caret, a ring, and his bluetooth keyboard live — but raising the
+    // system keyboard puts a shell surface in front of the conversation he has
+    // just opened and has not asked to write in yet. Pressing the composer is
+    // what asks. It is also, not by accident, the one path that used to take the
+    // headset out of the session: whatever the room does automatically the
+    // instant a panel opens is the worst place to be wrong.
+    if (on) this.field.take({ raise: false }); else this.field.release();
   }
 
   // Paint the tail of a thread. `messages` is the board's own shape:
@@ -171,7 +182,13 @@ export class ChatPanel extends Panel {
       this.sending = false;
       // Pressing `send` with a ray put the keys wherever they were; typing
       // straight on is the next thing he does either way.
-      this.field.take();
+      //
+      // `raise: false`, and it is not the same call as pressing the field. If
+      // the system keyboard is up it STAYS up — nothing blurred it, and
+      // `setValue('')` above already emptied the field under it — so he can
+      // keep dictating. Raising here would instead mean that sending with
+      // Enter on a bluetooth keyboard summons a keyboard he is not using.
+      this.field.take({ raise: false });
     }
   }
 }

--- a/ui/js/bridge3d/field.js
+++ b/ui/js/bridge3d/field.js
@@ -1,15 +1,20 @@
 // field.js — a text field the room draws itself.
 //
-// uikit's `Input` cannot be used for one here, and the reason is the bug this
-// file exists for: an Input owns a hidden DOM <input> and focuses it from its
-// own pointerdown handler, so merely PRESSING one inside an immersive session
-// is enough to summon the Quest system keyboard and take the browser out of the
-// room. See `keys.js` for the whole of it.
+// A field is a Container with a Text in it. The value, and whether the keys are
+// here, come from `Composer`; this adds the box, the caret and the ring around
+// it — and all three paint from the same state the keys are routed by, so what
+// he sees is what will receive the next letter.
 //
-// So a field is a Container with a Text in it. The value, and whether the keys
-// are here, come from `Composer`; this adds the box, the caret and the ring
-// around it — and all three paint from the same state the keys are routed by,
-// so what he sees is what will receive the next letter.
+// It is drawn here rather than by uikit's `Input` for two reasons, and the
+// first one used to be stated wrongly: focusing a DOM input inside a session is
+// FINE and the room does it on purpose to raise the system keyboard (syskb.js).
+// What is not fine is where uikit puts its element — `left: -1000vw`, the
+// off-screen field Meta's doc says the page will scroll to. The other reason
+// needs no correction: nothing in this room is rendered by the browser, and an
+// `Input` brings its own glyphs, its own caret and its own selection.
+//
+// So the DOM field is a source of characters with no appearance, and this is
+// the appearance. `paint()` is called for a keystroke from either of them.
 
 import { Container, Text, COL, cm, inert, safe } from './kit.js';
 import { Composer } from './keys.js';

--- a/ui/js/bridge3d/keys.js
+++ b/ui/js/bridge3d/keys.js
@@ -1,30 +1,53 @@
 // keys.js — which composer in the room is taking keystrokes, and what a key
 // does when it gets there.
 //
-// **Nothing in this room ever focuses a DOM node.** Focusing a text input
-// inside an immersive session asks the Quest browser for the system keyboard,
-// and that is a shell surface which has to composite over the immersive layer.
-// It does not throw and nothing can catch it: the browser leaves the session
-// and the room is gone. Text only, headset only, instant — every symptom the
-// captain reported, both from opening a chat and from pressing the wall's
-// search field.
+// **The Quest system keyboard works inside an immersive session, and the note
+// that used to be here saying otherwise was wrong.** It is supported from Quest
+// Browser 26.1, advertised per-session as `XRSession.isSystemKeyboardSupported`,
+// and the session SURVIVES it: visibility goes to `visible-blurred` while it is
+// up and back to `visible` when it is dismissed. Focusing a text field is how
+// you raise it. That is worth having for one reason above every other — the
+// system keyboard dictates, and nothing the room could draw itself does.
 //
-// The DOM focus was never what made typing work anyway. A paired keyboard
-// delivers `keydown` to the document regardless of what is focused, and
-// `main.js` already listens at the window. So the room owns the notion itself,
-// the way it owns every other bit of interaction state: a module variable
-// holding a Composer, never a DOM node, and nothing here asks the document
-// which of its elements is active.
+// What really took the browser out of the session is in `syskb.js`, and it was
+// the ELEMENT rather than the focus: uikit parks its hidden input at
+// `left: -1000vw`, and an off-screen field is the one pitfall Meta's own doc
+// names — the page scrolls to it the moment typing starts. Different bug, same
+// symptom, still a bug. So uikit's `Input` stays out of `kit.js`, and the field
+// the room does focus is one transparent pixel inside the viewport.
+//
+// Two things can hand a character to a composer, and they must never both hand
+// over the same one:
+//
+//   · a paired BLUETOOTH keyboard, whose `keydown` reaches the window whatever
+//     is focused — `main.js` listens there and calls `routeKey`;
+//   · the SYSTEM keyboard, which exposes no key events at all. Its only channel
+//     is the DOM field's `value`, so `syskb.js` reads that and calls
+//     `setValue`. While that field is focused, `routeKey` keeps its hands off
+//     the characters and minds the shortcuts.
 //
 // This file imports nothing. That is deliberate — the room's modules pull in
-// three.js and uikit and so cannot be loaded from a test, and the rule that
-// `b`/`c`/`x` are dead while he is typing is exactly the rule worth testing.
-// The surface a composer DRAWS is `field.js`.
+// three.js and uikit and so cannot be loaded from a test, and the rules here
+// (that `b`/`c`/`x` are dead while he is typing, and that a keystroke is never
+// applied twice) are exactly the rules worth testing. The keyboard arrives
+// through `setKeyboard` rather than an import for the same reason: a test hands
+// in a fake and asserts what the room asked it to do.
+//
+// The surface a composer DRAWS is `field.js`. Nothing in this room is ever
+// rendered by the browser — the DOM field is a source of characters and has no
+// appearance at all.
 
 // Exactly one composer takes keys, or none.
 let holder = null;
 
+// The system keyboard, when the room has one. Null on a desk, null on a browser
+// that does not advertise it, and then everything below behaves exactly as it
+// did before any of this: bluetooth, or nothing.
+let keyboard = null;
+
 export function keysHeld() { return holder; }
+export function setKeyboard(kb) { keyboard = kb || null; return keyboard; }
+export function keyboardIn() { return keyboard; }
 
 // The window's keydown comes through here FIRST. `true` means a composer took
 // the key and no shortcut may see it — held is held, so `b`/`c`/`x` are dead
@@ -34,9 +57,15 @@ export function routeKey(e) {
   if (!c) return false;
   // A browser shortcut is his, not ours, but it is still not a room shortcut.
   if (e.ctrlKey || e.metaKey || e.altKey) return true;
-  if (e.key === 'Enter') { if (!e.shiftKey) { e.preventDefault(); c.submit(); } }
-  else if (e.key === 'Backspace') { e.preventDefault(); c.setValue(c.value.slice(0, -1)); }
-  else if (e.key === 'Escape') { e.preventDefault(); c.release(); }
+  if (e.key === 'Enter') { if (!e.shiftKey) { e.preventDefault(); c.submit(); } return true; }
+  if (e.key === 'Escape') { e.preventDefault(); c.release(); return true; }
+  // With the system keyboard's field focused, that field IS the text: its
+  // `input` event has already carried this keystroke into the composer, so
+  // applying it here as well would type every letter twice and delete two
+  // characters per backspace. Enter and Escape above are safe either way —
+  // neither changes the field's value, so neither arrives twice.
+  if (keyboard && keyboard.driving()) return true;
+  if (e.key === 'Backspace') { e.preventDefault(); c.setValue(c.value.slice(0, -1)); }
   // One code point is a character he typed. 'ArrowLeft' and 'F5' are not.
   else if ([...e.key].length === 1) { e.preventDefault(); c.setValue(c.value + e.key); }
   return true;
@@ -54,12 +83,23 @@ export class Composer {
 
   // Take the keys. Whoever had them loses them — one keyboard, one composer,
   // so a room with three chats open never has two of them listening.
-  take() {
-    if (holder === this) return this;
-    const was = holder;
-    holder = this;
-    if (was) was.paint();
-    this.paint();
+  //
+  // `raise` is whether this also asks for the system keyboard. Pressing a field
+  // does; a panel OPENING does not, and that distinction is the whole of it —
+  // opening a chat is an intention to talk, not an instruction to fill the room
+  // with a keyboard he did not ask for. He gets the caret, the ring and his
+  // bluetooth keyboard immediately, and the system keyboard when he presses.
+  take({ raise = true } = {}) {
+    if (holder !== this) {
+      const was = holder;
+      holder = this;
+      if (was) was.paint();
+      this.paint();
+    }
+    // Deliberately outside that branch: pressing a field that ALREADY holds the
+    // keys re-raises the keyboard, and after a dismissal that is the only way
+    // back to it.
+    if (raise && keyboard) keyboard.raise(this);
     return this;
   }
 
@@ -68,6 +108,7 @@ export class Composer {
   release() {
     if (holder !== this) return this;
     holder = null;
+    if (keyboard) keyboard.dismiss(this);
     this.paint();
     return this;
   }
@@ -79,6 +120,12 @@ export class Composer {
     if (next === this.value) return this;
     this.value = next;
     this.paint();
+    // The keyboard's field has to be told when the ROOM changed the text under
+    // it — `send()` clearing the composer is the case that bites, because the
+    // field would otherwise still hold the sent message and hand it back with
+    // the next letter attached. `sync` is a no-op for a value that came FROM
+    // the field, which is what keeps this from looping.
+    if (keyboard) keyboard.sync(this);
     if (this.onChange) this.onChange(next);
     return this;
   }

--- a/ui/js/bridge3d/keys.js
+++ b/ui/js/bridge3d/keys.js
@@ -47,7 +47,6 @@ let keyboard = null;
 
 export function keysHeld() { return holder; }
 export function setKeyboard(kb) { keyboard = kb || null; return keyboard; }
-export function keyboardIn() { return keyboard; }
 
 // The window's keydown comes through here FIRST. `true` means a composer took
 // the key and no shortcut may see it — held is held, so `b`/`c`/`x` are dead
@@ -93,6 +92,11 @@ export class Composer {
     if (holder !== this) {
       const was = holder;
       holder = this;
+      // The system keyboard belongs to whoever holds the keys. When they move
+      // without asking for it, the old holder is dismissed rather than left
+      // being typed into by a field it no longer owns — and blurring makes
+      // `driving()` false, so bluetooth resumes into the new holder at once.
+      if (was && !raise && keyboard) keyboard.dismiss(was);
       if (was) was.paint();
       this.paint();
     }

--- a/ui/js/bridge3d/kit.js
+++ b/ui/js/bridge3d/kit.js
@@ -11,12 +11,20 @@
 // not vendor, and in the finished kits it pulls an icon set of 1,595 modules.
 // Per-component is the intended workflow — see `building.md`.
 
-// **uikit's `Input` is deliberately not here.** It owns a hidden DOM <input>
-// and focuses it from its own pointerdown handler, and focusing a DOM input
-// inside an immersive session summons the Quest system keyboard and takes the
-// browser out of the session — so a field the ray can press is a crash. Text
-// fields in this room are `Field` (field.js): a Container, a Text, and a caret
-// the room paints. Not importing it here is what keeps one out.
+// **uikit's `Input` is deliberately not here**, and the reason has been
+// corrected: it is not that focusing a DOM input is fatal. It is not — the Quest
+// system keyboard is supported inside a session from Browser 26.1 and the room
+// raises it on purpose now (syskb.js). It is WHERE uikit puts the element. Its
+// hidden input is parked at `left: -1000vw`
+// (`ui/vendor/uikit/text/input/hidden-input.js`), and an off-screen text field
+// is the one pitfall Meta's own doc names: the page scrolls to it the moment
+// typing starts, so the flat board is somewhere else when he leaves the
+// session. The room's own field is one transparent pixel INSIDE the viewport.
+//
+// The second reason stands on its own: an `Input` draws its own text with its
+// own caret and selection, and nothing in this room is rendered by the browser.
+// Text fields here are `Field` (field.js) — a Container, a Text, and a caret the
+// room paints. Not importing it here is what keeps one out.
 import { Container } from '../../vendor/uikit/components/container.js';
 import { Text } from '../../vendor/uikit/components/text.js';
 import { Image } from '../../vendor/uikit/components/image.js';

--- a/ui/js/bridge3d/main.js
+++ b/ui/js/bridge3d/main.js
@@ -30,7 +30,8 @@ import { Rays, setVoice } from './hover.js';
 import { Windows } from './windows.js';
 import { ChatPanel } from './chat.js';
 import { BoardWall, CardPanel } from './board.js';
-import { routeKey } from './keys.js';
+import { routeKey, setKeyboard } from './keys.js';
+import { SystemKeyboard } from './syskb.js';
 import { Grabs } from './grab.js';
 import { Sound } from './sound.js';
 import { installSky, installToneMapping } from './sky.js';
@@ -120,6 +121,13 @@ const grabs = new Grabs(scene);
 // created here and started in enter() rather than on load.
 const sound = new Sound();
 setVoice(sound);
+
+// The system keyboard. It has nothing to do until a session starts and tells it
+// whether this browser advertises one — before then, and on any browser that
+// does not, every call into it is a no-op and text arrives the way it always
+// has, from a paired bluetooth keyboard through the window's keydown.
+const syskb = new SystemKeyboard();
+setKeyboard(syskb);
 
 // Click a lieutenant, get its chat. This is the shortest path between "I can
 // see my crew" and "I am talking to them", and it is the whole reason the
@@ -232,7 +240,15 @@ async function enter() {
   await renderer.xr.setSession(session);
   gate.hidden = true;
   rays.setPresenting(true);
-  session.addEventListener('end', () => { gate.hidden = false; rays.setPresenting(false); });
+  // The keyboard's DOM field exists only for the length of the session. Meta's
+  // doc asks for exactly that, and it is right to: an input left behind on the
+  // flat board is a focus trap on a page he is about to be looking at again.
+  syskb.attach(session);
+  session.addEventListener('end', () => {
+    gate.hidden = false;
+    rays.setPresenting(false);
+    syskb.detach();
+  });
 }
 
 // ---- squeeze to pick a window up -------------------------------------------

--- a/ui/js/bridge3d/main.js
+++ b/ui/js/bridge3d/main.js
@@ -286,11 +286,11 @@ window.addEventListener('pointermove', (e) => {
 });
 // Keystrokes belong to whatever composer holds the keys — a chat panel takes
 // them when it opens, and Enter inside it sends. `routeKey` is the room's own
-// notion of that, and it never asks the document which element is active:
-// nothing here focuses a DOM node, because focusing one inside an immersive
-// session is what crashes the headset browser out of the room. It returns true
-// when a composer took the key, which is what keeps the shortcuts below off
-// while he is typing.
+// notion of that, and it runs first, which is what keeps the shortcuts below
+// off while he is typing. The room DOES focus a DOM node, deliberately: the one
+// in-viewport field in `syskb.js`, which is how the system keyboard is raised.
+// While that field is focused `routeKey` leaves the characters to its `input`
+// event. Why, and what the old crash really was, is in `keys.js` and `syskb.js`.
 window.addEventListener('keydown', (e) => {
   if (routeKey(e)) return;
   if (e.key === 'b') openBoard();

--- a/ui/js/bridge3d/syskb.js
+++ b/ui/js/bridge3d/syskb.js
@@ -30,8 +30,9 @@
 // keyboard is shown it starts a new editing session in which the first key
 // press overwrites whatever the field held. So nothing here counts keys. The
 // composer's text at the moment the keyboard went up is remembered, the field's
-// `input` event carries the rest, and `seam()` in keys.js decides — once per
-// showing — whether what arrived replaced the seed or was typed after it.
+// `input` event carries the rest, and `seamOf()` at the foot of this file
+// decides — once per showing — whether what arrived replaced the seed or was
+// typed after it.
 
 // One transparent pixel, fixed to the corner of the viewport. Fixed rather than
 // absolute so it cannot extend the page and give the browser somewhere to
@@ -183,8 +184,8 @@ export class SystemKeyboard {
 }
 
 // What survives of the composer's earlier text once the system keyboard has had
-// its first say. Exported for the test; the reasoning is in keys.js beside the
-// routing rules, because both are about who owns a character.
+// its first say. Exported for the test. It is the other half of the question
+// `routeKey` in keys.js answers — both are about who owns a character.
 //
 // The seed survives an EDIT in either direction: he can type after it, and he
 // can backspace into it — the second is the whole reason the field is seeded at

--- a/ui/js/bridge3d/syskb.js
+++ b/ui/js/bridge3d/syskb.js
@@ -157,7 +157,13 @@ export class SystemKeyboard {
     const c = this.composer;
     if (!c) return;
     const v = this.el.value;
-    if (this.seam === null) this.seam = seamOf(this.base, v);
+    if (this.seam === null) {
+      const seam = seamOf(this.base, v);
+      // An empty first value says nothing about whether the seed survived, so
+      // the decision waits for the next one and the composer keeps its text.
+      if (seam === null) { this._unscroll(); return; }
+      this.seam = seam;
+    }
     this.applying = true;
     try { c.setValue(this.seam + v); } finally { this.applying = false; }
     this._unscroll();
@@ -179,6 +185,21 @@ export class SystemKeyboard {
 // What survives of the composer's earlier text once the system keyboard has had
 // its first say. Exported for the test; the reasoning is in keys.js beside the
 // routing rules, because both are about who owns a character.
+//
+// The seed survives an EDIT in either direction: he can type after it, and he
+// can backspace into it — the second is the whole reason the field is seeded at
+// all, so reading it as an overwrite would defeat the point. `null` means the
+// value decides nothing and the next one is asked instead.
+//
+// One ambiguity has no answer from the value alone: if the field really did
+// overwrite and his first character happens to begin the seed — base "olá", he
+// types "o" — the backspace rule reads it as a surviving seed and the earlier
+// text stays. It costs one character, and no API we have distinguishes the two.
 export function seamOf(base, first) {
-  return base && String(first).startsWith(base) ? '' : base;
+  if (!base) return '';
+  const v = String(first);
+  if (v === '') return null;
+  if (v.startsWith(base)) return '';
+  if (base.startsWith(v)) return '';
+  return base;
 }

--- a/ui/js/bridge3d/syskb.js
+++ b/ui/js/bridge3d/syskb.js
@@ -1,0 +1,184 @@
+// syskb.js — the Quest system keyboard, raised from inside the session.
+//
+// **The room's old note said focusing a DOM input kills the session. It is
+// wrong, and the correction matters more than the bug did**: the system
+// keyboard is supported inside an immersive session from Quest Browser 26.1,
+// advertised per-session as `XRSession.isSystemKeyboardSupported`, and the
+// session survives it — visibility goes to `visible-blurred` while it is up and
+// back to `visible` when it is dismissed. Meta documents the whole thing:
+// https://developers.meta.com/horizon/documentation/web/webxr-keyboard/
+//
+// That is worth having for one reason above all the others: **the system
+// keyboard dictates.** Nothing we could draw ourselves does.
+//
+// ---- what the old crash actually was ---------------------------------------
+//
+// Not `focus()`. The element. uikit's hidden input is parked at
+// `left: -1000vw` (`ui/vendor/uikit/text/input/hidden-input.js`), and that is
+// the one pitfall the doc calls out by name: "when appended to an off-screen
+// location, like outside the underlying viewport, the web page scrolls to the
+// text field when the user types." A flat page yanked a thousand viewport
+// widths sideways under a live immersive layer is a different bug with the same
+// symptom, and it is still a bug. So this element sits IN the viewport — one
+// transparent pixel in the corner — and uikit's `Input` stays banned, now for a
+// reason we can point at rather than a theory.
+//
+// ---- and how it behaves ------------------------------------------------------
+//
+// **There is no keystroke stream.** The doc is explicit: no key-press events
+// are exposed, the field's `value` is the only channel, and every time the
+// keyboard is shown it starts a new editing session in which the first key
+// press overwrites whatever the field held. So nothing here counts keys. The
+// composer's text at the moment the keyboard went up is remembered, the field's
+// `input` event carries the rest, and `seam()` in keys.js decides — once per
+// showing — whether what arrived replaced the seed or was typed after it.
+
+// One transparent pixel, fixed to the corner of the viewport. Fixed rather than
+// absolute so it cannot extend the page and give the browser somewhere to
+// scroll to; `opacity: 0` rather than `display:none` or `visibility:hidden`
+// because both of those make an element unfocusable and focus is the whole
+// mechanism. It is never pointed at — the ray presses the uikit field, and that
+// is what calls in here.
+const STYLE = 'position:fixed;left:0;top:0;width:1px;height:1px;padding:0;border:0;'
+  + 'margin:0;opacity:0;background:transparent;color:transparent;pointer-events:none;';
+
+export class SystemKeyboard {
+  constructor(doc = typeof document === 'undefined' ? null : document) {
+    this.doc = doc;
+    this.session = null;
+    this.el = null;
+    this.composer = null;
+    this.base = '';          // the composer's text when the keyboard went up
+    this.seam = null;        // what to keep of it — decided on the first input
+    this.applying = false;   // inside our own setValue, so `sync` stays out
+    this.scroll = [0, 0];
+  }
+
+  // Called when a session starts. The element is created here and removed on
+  // `detach`, which is what the doc asks for: an input left in the page after
+  // the session ends is a focus trap on the flat board.
+  attach(session) {
+    this.detach();
+    this.session = session || null;
+    if (!this.supported()) return this;
+    const el = this.doc.createElement('input');
+    el.type = 'text';
+    el.setAttribute('aria-hidden', 'true');
+    el.setAttribute('tabindex', '-1');
+    // A system keyboard that helpfully capitalises and corrects is a system
+    // keyboard rewriting his Portuguese on the way in.
+    el.autocomplete = 'off';
+    el.autocapitalize = 'off';
+    el.spellcheck = false;
+    el.setAttribute('autocorrect', 'off');
+    el.style.cssText = STYLE;
+    el.addEventListener('input', () => this._input());
+    // Dismissing the keyboard — Done, the Meta button, a press outside it —
+    // blurs the field. The composer KEEPS the keys: a paired bluetooth keyboard
+    // still types into it, and pressing the field is how he asks for the system
+    // keyboard back. Releasing here would make `b`/`c`/`x` live again while he
+    // is plainly still in the middle of a sentence.
+    el.addEventListener('blur', () => { this.composer = null; });
+    this.doc.body.appendChild(el);
+    this.el = el;
+    return this;
+  }
+
+  detach() {
+    if (this.el) { this.el.remove(); this.el = null; }
+    this.session = null;
+    this.composer = null;
+    return this;
+  }
+
+  // False on a desk, on an older browser, and on any session that does not
+  // advertise it — and then every path here is a no-op and the room behaves
+  // exactly as it did: the bluetooth keyboard, and nothing else.
+  supported() {
+    return !!(this.doc && this.session && this.session.isSystemKeyboardSupported);
+  }
+
+  // Is the DOM field the thing carrying his typing right now? While it is, the
+  // window's `keydown` must not ALSO apply the character — the field's `input`
+  // event has already carried it, and applying both types everything twice.
+  driving() {
+    return !!(this.el && this.doc.activeElement === this.el);
+  }
+
+  // Press a composer -> the keyboard comes up. Pressing one that already holds
+  // the keys re-raises it, because dismissing with Done is not letting go and
+  // pressing the field is the only way back.
+  raise(composer) {
+    if (!this.supported() || !composer) return false;
+    this.composer = composer;
+    this.base = composer.value || '';
+    this.seam = null;
+    // Seeded, so the keyboard opens onto what he has already written rather
+    // than onto a blank. Whether the seed survives his first key press is the
+    // browser's business and `seamOf` finds out rather than assuming.
+    this.el.value = this.base;
+    this.scroll = [this.win().scrollX || 0, this.win().scrollY || 0];
+    this.el.focus();
+    this._unscroll();
+    return true;
+  }
+
+  // Dismissal is watched at the FIELD and not at the session. The doc lists two
+  // signals for it — the field blurs, and `visibilityState` goes back from
+  // `visible-blurred` to `visible` — and they say the same thing. Blur is the
+  // one that also fires when the room moves the keys to another composer, so
+  // one listener covers both and there is no second notion of "up" to keep in
+  // step with the first.
+  dismiss(composer) {
+    if (composer && this.composer && composer !== this.composer) return false;
+    this.composer = null;
+    if (this.el && this.driving()) this.el.blur();
+    return true;
+  }
+
+  // The room changed the text under the keyboard — `send()` clearing the
+  // composer is the case that matters. Without this the field still holds the
+  // sent message and the next letter arrives with it attached.
+  //
+  // `applying` is what keeps it from eating its own tail: every character the
+  // field delivers arrives as a `setValue`, and treating that as the ROOM
+  // changing the text would re-seed the seam on every keystroke and paste the
+  // sentence in front of itself one letter at a time — "olá" typed as "ollá".
+  sync(composer) {
+    if (this.applying) return false;
+    if (!this.el || composer !== this.composer) return false;
+    this.base = composer.value || '';
+    this.seam = null;
+    this.el.value = this.base;
+    return true;
+  }
+
+  _input() {
+    const c = this.composer;
+    if (!c) return;
+    const v = this.el.value;
+    if (this.seam === null) this.seam = seamOf(this.base, v);
+    this.applying = true;
+    try { c.setValue(this.seam + v); } finally { this.applying = false; }
+    this._unscroll();
+  }
+
+  win() { return (this.doc && this.doc.defaultView) || { scrollX: 0, scrollY: 0, scrollTo() {} }; }
+
+  // Belt and braces against the documented pitfall. The element is in the
+  // viewport so there should be nothing to scroll to; if the browser finds
+  // something anyway, the flat page is put back where it was — the captain
+  // leaves the session onto that page and it has to look like he left it.
+  _unscroll() {
+    const w = this.win();
+    if ((w.scrollX || 0) === this.scroll[0] && (w.scrollY || 0) === this.scroll[1]) return;
+    if (w.scrollTo) w.scrollTo(this.scroll[0], this.scroll[1]);
+  }
+}
+
+// What survives of the composer's earlier text once the system keyboard has had
+// its first say. Exported for the test; the reasoning is in keys.js beside the
+// routing rules, because both are about who owns a character.
+export function seamOf(base, first) {
+  return base && String(first).startsWith(base) ? '' : base;
+}


### PR DESCRIPTION
## Intent

Raise the Quest system keyboard from inside the immersive session so the captain can dictate into the room's composers, and correct the room's wrong note saying that is impossible.

The old note in ui/js/bridge3d/keys.js said focusing any DOM node inside an immersive session kills the session. That was a wrong diagnosis of a real crash (MNC-4). The system keyboard IS supported from Quest Browser 26.1, advertised per-session as XRSession.isSystemKeyboardSupported; focusing a field raises it and the session survives (visibility goes visible-blurred and back). Meta's doc: https://developers.meta.com/horizon/documentation/web/webxr-keyboard/ . The captain asked for this specifically because the system keyboard brings dictation, which nothing the room could draw itself does; he explicitly rejected a hand-built keyboard component.

Root cause of the real crash, found and confirmed at the source: not focus(), the ELEMENT. uikit parks its hidden input at left:-1000vw (ui/vendor/uikit/text/input/hidden-input.js:7), which is the off-screen-field pitfall Meta's doc names — the page scrolls to it when typing starts. uikit's Input therefore stays banned in kit.js, now for a citable reason, and a test quotes the vendored line so the ban fails loudly if a vendor bump ever removes it.

New ui/js/bridge3d/syskb.js owns a single <input> styled position:fixed;left:0;top:0;1x1;opacity:0 — hidden but IN the viewport — created on session start and removed on session end. It imports nothing, so it is testable without a GPU (the same rule keys.js already followed); main.js injects it via setKeyboard(), which is why keys.js takes the keyboard through a setter instead of an import.

Decisions and tradeoffs made while doing the work:
- There are no key events from the system keyboard; the field's value is the only channel, and each showing starts an editing session whose first keypress overwrites the field. So nothing counts keys: the composer's text is remembered at raise, the input event carries the rest, and seamOf() decides ONCE per showing whether what arrived replaced the seed or followed it. Chose seed-plus-reconcile over not seeding at all, because not seeding means he cannot backspace into text he already wrote.
- Three separate guards were needed for a letter to arrive exactly once: routeKey ignores characters while the field is focused (a bluetooth keystroke reaches both the field and the window); sync() pushes room-side value changes into the field (else a sent message comes back attached to the next letter); and an 'applying' flag stops sync firing on values that came FROM the field — without it 'ola' with an accent typed as 'olla'. That last one was a real bug caught by the new test, not by reading.
- Opening a chat now takes the keys with take({raise:false}) — caret and bluetooth immediately, system keyboard only when he presses the composer. Deliberate: auto-raising a shell surface the instant a panel opens is exactly where the old crash lived, and opening a chat is not a request for a keyboard. send() does the same, so Enter on a bluetooth keyboard never summons a keyboard he is not using.
- Dismissal is watched at the field's blur rather than at session visibilitychange: both signal the same thing, and blur also fires when the keys move to another composer, so one listener and no second notion of 'up' to keep in step.
- Dismissing the keyboard deliberately does NOT release the keys — bluetooth keeps typing and the b/c/x shortcuts stay dead; pressing the field re-raises, which is why take() calls raise even when it already holds the keys.
- A belt-and-braces _unscroll() restores window scroll if the browser scrolls anyway; the acceptance requires the flat board to look untouched after leaving the session.
- Fully guarded: no session, an old browser, or isSystemKeyboardSupported false, and every path is a no-op identical to today's bluetooth-only behaviour.

Deliberately out of scope, on the lieutenant's explicit instruction: no README.md changes (the captain just cut the root README to 7 lines on GitHub and a change from this branch would reintroduce what he deleted), and the Portuguese MSDF font work was written and then reverted in full because card MNC-83 is concurrently generating ui/vendor/msdfonts/inter-latin1.js and two sheets at two paths would clobber each other. safe() therefore still strips accented letters, so a dictated 'acao' with a cedilla paints as 'aao' in-room until MNC-83 lands; the value that reaches the board is correct either way. Do not flag either of those as an omission.

Verification so far: 932/932 tests pass (node --test test/*.test.js harness/test/*.test.js), including new behavioural tests that drive a fake DOM through the whole raise/type/dictate/dismiss/re-raise cycle plus the unsupported-browser guard. node dev/room-shots.js runs a real emulated immersive session clean — 8 shots, the ray lands on all six kinds of thing, the wall node count stays flat. The headset acceptance itself needs the captain: he owns the only Quest.

## What Changed

- New `ui/js/bridge3d/syskb.js` owns a single hidden-but-in-viewport `<input>` (`position:fixed;left:0;top:0;1x1;opacity:0`), created on session start and removed on session end, guarded behind `XRSession.isSystemKeyboardSupported`. Pressing a room composer focuses it, which raises the Quest system keyboard — dictation included; on an old browser or an unsupported session every path is a no-op and typing stays bluetooth-only.
- Because the system keyboard emits no key events, text arrives only as the field's value: the composer's text is seeded at raise and `seamOf()` decides once per showing whether the new value replaced or followed the seed. Three guards keep each letter arriving exactly once — `routeKey` ignores characters while the field is focused, `sync()` pushes room-side value changes into the field, and an `applying` flag stops `sync()` echoing values that came from the field. Dismissal is watched at the field's `blur`, and `_unscroll()` restores window scroll if the browser scrolls anyway.
- `keys.js` takes the keyboard through `setKeyboard()` (injected by `main.js`) instead of importing it, so it stays GPU-free and testable; opening a chat and sending both use `take({raise:false})` so a panel opening never summons the keyboard. The old comment blaming `focus()` for the MNC-4 crash is corrected — the real cause was uikit's hidden input at `left:-1000vw`, which stays banned in `kit.js` with a test quoting the vendored line so a vendor bump can't silently lift the ban. The headset gate legend now mentions the composer/dictation path.

## Risk Assessment

✅ Low: All four round-1 findings are fixed exactly as specified and covered by new tests, and the whole feature is still a no-op on any browser that does not advertise isSystemKeyboardSupported, so the existing bluetooth path cannot regress.

## Testing

Ran the full suite (933/933 pass) and the existing room capture run (clean, 8 shots, ray reaches everything), then drove the actual user flow in an emulated immersive session with a headless Chrome driver — pressing the chat composer with the ray raises the system keyboard's field, dictated text arrives in the composer and sends into the thread, dismissal leaves the session and the keys intact, the wall search field filters from dictation, the flat page never scrolls, and the field is gone once the session ends. Screenshots and a walkthrough GIF captured for each step.

- Evidence: Dictated sentence in the chat composer, inside the immersive session (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/shots/4-dictated.png</code>)
- Evidence: Sent — the dictated line is in Monica&#39;s thread, composer cleared (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/shots/6-sent.png</code>)
- Evidence: Wall search field dictated &#34;dashboard&#34; — 1 of 10 cards left (the surface MNC-4 crashed on) (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/shots/7b-wall-dictated-filter.png</code>)
- Evidence: Session ended — flat board back, unscrolled, no input left behind (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/shots/8-back-on-the-flat-board.png</code>)
- Evidence: Full walkthrough GIF: open chat → ray on composer → keyboard raised → dictate → dismiss → send → wall filter → leave (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/syskb-walkthrough.gif</code>)
- Evidence: Chat open — keys taken, keyboard deliberately NOT raised (local file: <code>/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/shots/1-chat-open.png</code>)
<details>
<summary>Evidence: Step-by-step DOM/session state from the evidence run</summary>

<code>· session started, keyboard field attached {&#34;inputs&#34;:1,&#34;style&#34;:&#34;position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; ... opacity: 0; ...&#34;,&#34;focused&#34;:false,&#34;scroll&#34;:[0,0],&#34;presenting&#34;:true}&#10;· chat open — keys taken, keyboard NOT raised {&#34;focused&#34;:false,&#34;room&#34;:{&#34;painted&#34;:&#34;|&#34;,&#34;value&#34;:&#34;&#34;,&#34;holds&#34;:true}}&#10;· ray on the composer {&#34;pitch&#34;:-26,&#34;lit&#34;:[{&#34;name&#34;:&#34;chat-field&#34;,&#34;state&#34;:&#34;hovered-near&#34;,&#34;distance&#34;:0.94}]}&#10;· pressed it — the system keyboard is raised {&#34;focused&#34;:true,&#34;presenting&#34;:true,&#34;scroll&#34;:[0,0]}&#10;· dictated into the composer {&#34;fieldValue&#34;:&#34;bom dia capitao, ditado funciona&#34;,&#34;room&#34;:{&#34;painted&#34;:&#34;bom dia capitao, ditado funciona|&#34;,&#34;holds&#34;:true}}&#10;· a stray keydown while the field drives {&#34;doubled&#34;:false,&#34;panels&#34;:1}&#10;· keyboard dismissed — session alive, keys still held {&#34;focused&#34;:false,&#34;presenting&#34;:true,&#34;room&#34;:{&#34;holds&#34;:true}}&#10;· bluetooth still types after dismissal {&#34;value&#34;:&#34;bom dia capitao, ditado funciona!&#34;}&#10;· sent — composer and the keyboard field both cleared {&#34;sentText&#34;:&#34;bom dia capitao, ditado funciona!&#34;,&#34;value&#34;:&#34;&#34;,&#34;room&#34;:{&#34;value&#34;:&#34;&#34;}}&#10;· dictated into the wall search field {&#34;dictated&#34;:&#34;dashboard&#34;,&#34;focused&#34;:true,&#34;presenting&#34;:true,&#34;shownBefore&#34;:10,&#34;shownAfter&#34;:1,&#34;nodesBefore&#34;:274,&#34;nodesAfter&#34;:274}&#10;· session ended — no field left on the flat board {&#34;inputs&#34;:0,&#34;scroll&#34;:[0,0],&#34;presenting&#34;:false}</code>

```text
{
  "url": "http://127.0.0.1:35835/ui/bridge3d.html?capture=1&xr=emulate",
  "chrome": "/usr/bin/google-chrome",
  "steps": [
    {
      "name": "before the session: fields in the page",
      "inputs": 0,
      "style": null,
      "value": null,
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": false,
      "visibility": null
    },
    {
      "name": "session started, keyboard field attached",
      "inputs": 1,
      "style": "position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; padding: 0px; border: 0px; margin: 0px; opacity: 0; background: transparent; color: transparent; pointer-events: none;",
      "value": "",
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": true,
      "visibility": "visible"
    },
    {
      "name": "chat open — keys taken, keyboard NOT raised",
      "inputs": 1,
      "style": "position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; padding: 0px; border: 0px; margin: 0px; opacity: 0; background: transparent; color: transparent; pointer-events: none;",
      "value": "",
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": true,
      "visibility": "visible",
      "room": {
        "painted": "|",
        "value": "",
        "holds": true
      }
    },
    {
      "name": "ray on the composer",
      "pitch": -26,
      "lit": [
        {
          "name": "chat-field",
          "state": "hovered-near",
          "distance": 0.94
        }
      ]
    },
    {
      "name": "pressed it — the system keyboard is raised",
      "inputs": 1,
      "style": "position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; padding: 0px; border: 0px; margin: 0px; opacity: 0; background: transparent; color: transparent; pointer-events: none;",
      "value": "",
      "focused": true,
      "scroll": [
        0,
        0
      ],
      "presenting": true,
      "visibility": "visible"
    },
    {
      "name": "dictated into the composer",
      "fieldValue": "bom dia capitao, ditado funciona",
      "room": {
        "painted": "bom dia capitao, ditado funciona|",
        "value": "bom dia capitao, ditado funciona",
        "holds": true
      }
    },
    {
      "name": "and the flat page never moved",
      "scroll": [
        0,
        0
      ]
    },
    {
      "name": "a stray keydown while the field drives",
      "before": "bom dia capitao, ditado funciona",
      "after": "bom dia capitao, ditado funciona",
      "doubled": false,
      "panels": 1
    },
    {
      "name": "keyboard dismissed — session alive, keys still held",
      "inputs": 1,
      "style": "position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; padding: 0px; border: 0px; margin: 0px; opacity: 0; background: transparent; color: transparent; pointer-events: none;",
      "value": "bom dia capitao, ditado funciona",
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": true,
      "visibility": "visible",
      "room": {
        "painted": "bom dia capitao, ditado funciona|",
        "value": "bom dia capitao, ditado funciona",
        "holds": true
      }
    },
    {
      "name": "bluetooth still types after dismissal",
      "painted": "bom dia capitao, ditado funciona!|",
      "value": "bom dia capitao, ditado funciona!",
      "holds": true
    },
    {
      "name": "sent — composer and the keyboard field both cleared",
      "sentText": "bom dia capitao, ditado funciona!",
      "inputs": 1,
      "style": "position: fixed; left: 0px; top: 0px; width: 1px; height: 1px; padding: 0px; border: 0px; margin: 0px; opacity: 0; background: transparent; color: transparent; pointer-events: none;",
      "value": "",
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": true,
      "visibility": "visible",
      "room": {
        "painted": "|",
        "value": "",
        "holds": true
      }
    },
    {
      "name": "dictated into the wall search field",
      "dictated": "dashboard",
      "aim": {
        "yaw": -41.422733578406,
        "pitch": -40.64
      },
      "focused": true,
      "presenting": true,
      "shownBefore": 10,
      "shownAfter": 1,
      "cards": 10,
      "nodesBefore": 274,
      "nodesAfter": 274,
      "scroll": [
        0,
        0
      ]
    },
    {
      "name": "session ended — no field left on the flat board",
      "inputs": 0,
      "style": null,
      "value": null,
      "focused": false,
      "scroll": [
        0,
        0
      ],
      "presenting": false,
      "visibility": null
    }
  ],
  "dictation": [
    {
      "fieldValue": "bom",
      "room": {
        "painted": "bom|",
        "value": "bom",
        "holds": true
      }
    },
    {
      "fieldValue": "bom dia",
      "room": {
        "painted": "bom dia|",
        "value": "bom dia",
        "holds": true
      }
    },
    {
      "fieldValue": "bom dia capitao",
      "room": {
        "painted": "bom dia capitao|",
        "value": "bom dia capitao",
        "holds": true
      }
    },
    {
      "fieldValue": "bom dia capitao, ditado funciona",
      "room": {
        "painted": "bom dia capitao, ditado funciona|",
        "value": "bom dia capitao, ditado funciona",
        "holds": true
      }
    }
  ],
  "wall": {
    "dictated": "dashboard",
    "aim": {
      "yaw": -41.422733578406,
      "pitch": -40.64
    },
    "focused": true,
    "presenting": true,
    "shownBefore": 10,
    "shownAfter": 1,
    "cards": 10,
    "nodesBefore": 274,
    "nodesAfter": 274,
    "scroll": [
      0,
      0
    ]
  },
  "errors": []
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `ui/js/bridge3d/syskb.js:183` - seamOf() only recognises a surviving seed when the new value STARTS WITH the old one, so a first action of backspace is misread as an overwrite and the whole seed is pasted back in front of the edit. Composer holds &#39;ola&#39;, he presses the field (el.value = &#39;ola&#39;), and his first key is backspace: el.value = &#39;ol&#39;, &#39;ol&#39;.startsWith(&#39;ola&#39;) is false, seam locks to &#39;ola&#39;, and the composer becomes &#39;olaol&#39; — and stays wrong for the rest of the showing (&#39;a&#39; next gives &#39;olaola&#39;). Under the overwrite model the same line makes a first backspace a silent no-op (v=&#39;&#39; -&gt; composer stays &#39;ola&#39;), so either way he cannot backspace into text he already wrote until he has typed at least one character — which is the case the intent gives as the whole reason for seeding. The new test only exercises overwrite-then-type, so nothing catches it. Treating a first value that is a prefix of base as continued editing fixes the backspace case but loses the overwrite case when the first typed letter happens to begin the seed, so the tradeoff is yours to pick.
- ⚠️ `ui/js/bridge3d/main.js:290` - The corrected diagnosis did not reach main.js. The keydown comment still reads &#34;nothing here focuses a DOM node, because focusing one inside an immersive session is what crashes the headset browser out of the room&#34; — the exact wrong note the intent requires correcting (&#34;correct the room&#39;s wrong note saying that is impossible&#34;), sitting in the same file that builds the SystemKeyboard at line 125 and calls syskb.attach(session) at line 243. keys.js, kit.js, field.js, chat.js and board.js were all rewritten; this one was missed, and the file-scan test only greps for `.focus(` so it cannot catch a stale comment.
- ℹ️ `ui/js/bridge3d/keys.js:93` - take({raise:false}) changes `holder` without telling the keyboard, so kb.composer can outlive the composer that actually holds the keys. If a second composer takes the keys while the field is still focused (chat.js:106 on panel open, chat.js:191 after send), driving() stays true — routeKey then swallows every bluetooth character (keys.js:67) while _input keeps writing into the OLD composer. Currently unreachable on a headset because XR input is not delivered during visible-blurred, so nothing in the room can be pressed while the keyboard is up; it is a latent trap for the next caller of take({raise:false}). Cheapest guard: when the holder changes and raise is false, call keyboard.dismiss(was).
- ℹ️ `ui/js/bridge3d/keys.js:50` - keyboardIn() is exported and never imported anywhere — not by the room, not by the new tests. Dead surface on a module whose import list is deliberately empty.

🔧 Fix: fix seam edits, stale focus note, keyboard holder handover
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test test/*.test.js harness/test/*.test.js` — 933/933 pass, including the new syskb behavioural tests and the vendored `left:-1000vw` quote that keeps uikit&#39;s Input banned</code>
- <code>`node dev/room-shots.js --out /tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/room-shots` — 8 shots, no blank frames, ray lands on all 6 kinds of thing, wall pool flat at 274 nodes</code>
- <code>Manual end-to-end drive in a headless-Chrome emulated immersive session (`/tmp/no-mistakes-evidence/01KZMMB5VMDWCS3WH0TCV3FHQ0/syskb-shots.js`): session start builds one in-viewport 1x1 opacity:0 input; opening a chat takes the keys without focusing it; ray press on `chat-field` focuses it and the session stays presenting; dictation via value+`input` paints in the composer; a stray window `keydown` neither doubles a letter nor fires the `x` shortcut; blur keeps the session and the keys; send posts the dictated line into the thread and clears both composer and field; dictating `dashboard` into `wall-field` narrows the wall to 1 of 10 with the node count unchanged; `window.scrollX/Y` stays [0,0] throughout; ending the session removes the input from the flat board</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `ui/bridge3d.html:27` - The gate legend&#39;s headset line still reads &#34;type on a paired keyboard, enter sends&#34; — the only text-entry story it knows. This change makes pressing a composer raise the Quest system keyboard (dictation included), and the system keyboard has no Enter that reaches the room, so dictated text is sent with the send box. This is the authoritative user-facing instruction for how to type in the headset and it is now incomplete. Left unedited because it is UI copy in an HTML body, not a documentation file or doc comment; suggested replacement: &#34;... press the composer for the system keyboard and dictation · a paired keyboard types too, enter sends&#34;.

🔧 Fix: fix headset legend for system keyboard
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
