### PR TITLE
fix: deliver peer lieutenant messages to the recipient's queue

### DIFF
--- a/cli/bc-axi
+++ b/cli/bc-axi
@@ -1654,6 +1654,9 @@ async function cmdDrain() {
     } else if (it.kind === 'message') {
       head = 'captain message (your main chat)';
       hint = 'reply: bc-axi say ' + (it.target || 'lieutenant:' + it.lieutenant) + ' --text-file <f|->';
+    } else if (it.kind === 'peer-message') {
+      head = 'message from ' + (it.author || 'a fellow lieutenant') + ' (your main chat)';
+      hint = 'a colleague wrote in your chat — act on it; reply in THEIR chat: bc-axi say lieutenant:<their-id> --text-file <f|->';
     } else if (it.kind === 'line-passed') {
       head = 'YOU ARE ON THE LINE — passed by ' + (it.from || 'user');
       hint = 'greet him in ONE spoken line before anything else (bc-axi say lieutenant:' + it.lieutenant

--- a/server/server.js
+++ b/server/server.js
@@ -4693,12 +4693,23 @@ const server = http.createServer(async (req, res) => {
         // A free-form lieutenant message in its main chat is a level-1 notification.
         const ev = mkEvent({ text: text.slice(0, 200), actor: msg.author, level: body.level, kind: body.kind }, { level: 1 });
         board.events.push(ev);
+        // A PEER's message into another lieutenant's main chat must also be
+        // DELIVERED to that lieutenant: the chat append alone notifies nobody
+        // (same rule as the non-owner card-thread say above). Without this,
+        // lieutenant→lieutenant orders sit in the chat unread forever.
+        const fromPeer = !!(caller && lt && caller.id !== lt.id);
+        if (fromPeer) {
+          queuePush(lt.id, { kind: 'peer-message', target, author: msg.author,
+            text: text.slice(0, 4000), attachments });
+        }
         // …and it is the last voice the captain heard, so the line follows it:
         // an answer over the line keeps the line, and a lieutenant that speaks
         // up on its own becomes who he reaches when he answers with the screen
         // off. Card threads never move it — they are a board surface, read with
-        // eyes on a picker, not the channel with no picker.
-        if (lt) lineFollow(lt.id);
+        // eyes on a picker, not the channel with no picker. A peer's post is
+        // the PEER speaking, not the chat's owner — the line must not follow
+        // the silent recipient.
+        if (lt && !fromPeer) lineFollow(lt.id);
       }
       saveBoard(); broadcast(); // owed clears on ACK, not here — the reply alone leaves it derived from the queue
       return sendJson(res, 200, { ok: true });


### PR DESCRIPTION
## Problem

`bc-axi say lieutenant:<colleague>` reports "said", but the message only lands in the target's chat log. `POST /api/message` treats every main-chat say as "this lieutenant speaking to the captain" (level-1 event + line follow) and never enqueues anything for the chat's owner — no QueueItem, no wake. Lieutenant→lieutenant orders sit in the chat unread forever; on a live board this surfaced as one lieutenant asking another to QA a PR and the request silently going nowhere.

The card-thread branch of the same route already handles this correctly for non-owner authors (`worker-said`). The main-chat branch just misses the equivalent.

## Fix

- An identified caller posting into a **colleague's** main chat now enqueues a `peer-message` item (write-ahead queue, then the usual coalesced wake), mirroring the non-owner card-thread rule.
- `lineFollow` no longer follows the silent recipient in that case — the peer is the one speaking, not the chat's owner.
- `bc-axi drain` renders the new kind: `message from <author> (your main chat)` with a reply hint.

Self-says (a lieutenant posting in its own chat, i.e. answering the captain) are unchanged, as are card threads and captain-side `/api/feedback`.

## Tested

Applied on a live board (4 lieutenants): a peer say now lands as a queue item, the wake fires, and the recipient drains and acts on it; the recipient's reply arrived back the same way. Self-says still produce no self-queue item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)