### PR TITLE
fix(server): start workers on the tip the board actually fetched

### DIFF
--- a/dev/ui-server.js
+++ b/dev/ui-server.js
@@ -58,6 +58,7 @@ const BUILTIN_KINDS = {
   'worker-done': { emoji: '✅', level: 2 }, 'worker-died': { emoji: '💀', level: 2 },
   'hook-ran': { emoji: '🪝', level: 2 }, 'hook-failed': { emoji: '🧨', level: 1 },
   'worker-stopped': { emoji: '⏸️', level: 2 }, 'worker-stalled': { emoji: '🐢', level: 1 },
+  'stale-base': { emoji: '🧊', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 }, parked: { emoji: '🅿️', level: 2 },
   respawned: { emoji: '♻️', level: 1 }, 'needs-captain': { emoji: '🚨', level: 1 },
 };

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -203,6 +203,7 @@ session status, window adoption):
 | captain drags Your review → Backlog | rework-order QueueItem carrying the captain's thread comment; same `pendingOrder` marker |
 | captain creates / moves a card | `card-created` / `card-moved` QueueItem to the owner (awareness, not an order) |
 | `card.start` | worker spawned (worktree + window), card → Working, level-2 event, brief auto-attached as an artifact |
+| `card.start` on a base it could not refresh | `stale-base` level-1 event on the card, naming what failed — the start still proceeds on the last-known tip. A worktree that cannot be put ON the fetched tip is the other half: the start is REFUSED (502) naming the sha it got and the sha it wanted, since a worker on an unknown base is worse than no worker |
 | `chat.say` by captain | QueueItem (write-ahead, attachments riding along) + `harness.send` wake to the owning lieutenant |
 | `chat.say` starting with `/` | routed to `harness.runCommand`, reply lands in-thread — NO QueueItem, no wake, no owed. On a card target the command addresses the WORKER session (unlike say, which always talks to the owner). The board's own `/reset` respawns a lieutenant outright, and is marked for the duration of the call so supervision reads neither the gap as a crash nor races the restart with a respawn of its own |
 | `chat.say` on a card thread by anyone but the owning lieutenant (its worker, a peer, unidentified tooling) | `worker-said` QueueItem waking the owner — the thread alone notifies nobody |

--- a/server/server.js
+++ b/server/server.js
@@ -2707,6 +2707,7 @@ async function doStartCard(card, body) {
   // log's: the worker is about to run on it either way.
   for (const w of (wt.warnings || [])) {
     card.events.push(mkEvent({ text: 'worktree base: ' + w, actor: 'server' }, { kind: 'stale-base' }));
+    card.updated = now(); // a start that fails after this still flushes the event
   }
   delete wt.warnings; // said on the card; the persisted record is the checkout itself
 

--- a/server/server.js
+++ b/server/server.js
@@ -454,6 +454,10 @@ const BUILTIN_KINDS = {
   'schedule-failed': { emoji: '🔔', level: 1 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
   'worker-stalled': { emoji: '🐢', level: 1 },
+  // A start that could not put the worker on the tip it just fetched. It still
+  // started — that is exactly why this is level 1: the work is running, on a
+  // base nobody chose.
+  'stale-base': { emoji: '🧊', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },
   parked: { emoji: '🅿️', level: 2 },
   respawned: { emoji: '♻️', level: 1 },
@@ -2699,6 +2703,12 @@ async function doStartCard(card, body) {
   let wt;
   try { wt = await createWorktree(project.path, card.id, WORKSPACE); }
   catch (e) { return { error: 'worktree provisioning failed: ' + String((e && e.message) || e), code: 502 }; }
+  // A base that could not be refreshed is the card's business, not the server
+  // log's: the worker is about to run on it either way.
+  for (const w of (wt.warnings || [])) {
+    card.events.push(mkEvent({ text: 'worktree base: ' + w, actor: 'server' }, { kind: 'stale-base' }));
+  }
+  delete wt.warnings; // said on the card; the persisted record is the checkout itself
 
   const session = ownerSession(card);
   const window = names.workerWindow(card.id);

--- a/server/worktrees.js
+++ b/server/worktrees.js
@@ -12,7 +12,10 @@
 // fm-spawn.sh, with --lease replacing the interactive-subshell dance), else
 // plain `git worktree add -d` under <workspace>/.bridge-commander/worktrees/.
 // BC_WORKTREE_TOOL=git|treehouse forces the choice (tests pin `git` for
-// hermetic cleanup).
+// hermetic cleanup). A pooled worktree is backed by whatever clone treehouse
+// built its pool from — NOT the project clone this board registered — so the
+// base is carried into it by sha and checked afterwards (freshBase/applyBase/
+// assertOnBase below).
 //
 // All subprocess work is async (the server's event loop must never block on
 // a multi-GB worktree add), and provision/release are serialized per project
@@ -76,7 +79,7 @@ async function assertIsolated(wt, projectPath) {
   if (wGit === pGit) throw new Error('worktree shares the clone\'s git dir (not isolated): ' + wt);
 }
 
-// freshBase(proj) -> commit-ish for a new worktree, or null.
+// freshBase(proj) -> { ref, fullRef, sha, warnings }
 //
 // `git worktree add` with no commit-ish uses the clone's HEAD, and nothing
 // keeps a long-lived clone's HEAD current — so every worker was starting from
@@ -85,36 +88,94 @@ async function assertIsolated(wt, projectPath) {
 // before the agent read the brief. Fetch, then cut from origin's default
 // branch.
 //
+// The SHA is the load-bearing half. A ref name means whatever the ref store
+// reading it happens to hold, and a pooled worktree reads a different clone
+// than the one fetched here (see createWorktree) — so the tip is carried by
+// value, and every path that applies the base is checked against it.
+//
 // A fetch that fails must not block the board: fall back to the local
 // origin/HEAD ref (stale, but still a real base), then to the clone's HEAD
-// (the old behaviour). Both fallbacks say so on stderr — a silent fallback is
-// how this bug hid in the first place.
+// (the old behaviour). Both fallbacks return a warning — a silent fallback is
+// how this bug hid in the first place, and stderr is where nobody read it.
 async function freshBase(proj) {
-  let fetched = true;
+  const warnings = [];
+  const none = { ref: null, fullRef: null, sha: null, warnings };
   try {
     await git(proj, 'fetch', '--quiet', 'origin');
   } catch (e) {
-    fetched = false;
-    process.stderr.write('worktrees: fetch failed in ' + proj + ' — base may be stale: ' + String(e.message || e) + '\n');
+    warnings.push('fetch failed in ' + proj + ' — the base may be stale: ' + String(e.message || e));
   }
+  let fullRef;
   try {
-    const ref = await git(proj, 'rev-parse', '--abbrev-ref', 'origin/HEAD');
-    if (!fetched) process.stderr.write('worktrees: cutting from the last-fetched ' + ref + '\n');
-    return ref;
+    fullRef = await git(proj, 'rev-parse', '--symbolic-full-name', 'origin/HEAD');
   } catch (e) {
-    process.stderr.write('worktrees: no origin/HEAD in ' + proj + ' — cutting from the clone HEAD: ' + String(e.message || e) + '\n');
-    return null;
+    warnings.push('no origin/HEAD in ' + proj + ' — cutting from the clone HEAD: ' + String(e.message || e));
+    return none;
+  }
+  const ref = fullRef.replace(/^refs\/remotes\//, '');
+  let sha;
+  try {
+    sha = await git(proj, 'rev-parse', fullRef);
+  } catch (e) {
+    warnings.push('cannot resolve ' + ref + ' in ' + proj + ' — cutting from the clone HEAD: ' + String(e.message || e));
+    return none;
+  }
+  return { ref, fullRef, sha, warnings };
+}
+
+// applyBase(wt, proj, base) -> warnings
+//
+// The pooled worktree's ref store is NOT the clone freshBase() fetched.
+// treehouse keeps one pool per repository per machine, and which clone backs
+// it is decided by whoever asked for it first — here, a checkout in another
+// workspace entirely. So `checkout --detach origin/master` inside the lease
+// reads that other clone's `origin/master`, whatever it last happened to know,
+// and the fetch we just paid for lands somewhere nobody reads. When the two
+// clones agree the start looks fine, which is why the stale base was
+// intermittent rather than obvious.
+//
+// Fetching the fetched clone's own ref, BY PATH, into the lease puts the exact
+// tip in the ref store the checkout will read. No treehouse internals: it is
+// git, run inside the leased path.
+async function applyBase(wt, proj, base) {
+  const warnings = [];
+  try {
+    await git(wt, 'fetch', '--quiet', '--no-tags', proj, base.fullRef);
+    await git(wt, 'checkout', '--detach', 'FETCH_HEAD');
+    return warnings;
+  } catch (e) {
+    warnings.push('could not carry ' + base.ref + ' from ' + proj + ' into the leased worktree ('
+      + String(e.message || e) + ') — falling back to that worktree\'s own ' + base.ref);
+  }
+  await git(wt, 'checkout', '--detach', base.ref);
+  return warnings;
+}
+
+// assertOnBase — the checkout landed on the tip that was actually fetched.
+// Without this the base is a hope: two ref stores, two `origin/master`s, and
+// nothing downstream can tell which one the worker got.
+async function assertOnBase(wt, base) {
+  if (!base.sha) return;
+  const head = await git(wt, 'rev-parse', 'HEAD');
+  if (head !== base.sha) {
+    throw new Error('worktree is on ' + head + ' but the fetched ' + base.ref + ' is ' + base.sha
+      + ' — refusing to start a worker on a stale base');
   }
 }
 
-// createWorktree(projectPath, cardId, workspace) -> { path, tool, base? }
-// Always returns an asserted-isolated worktree or throws.
+// createWorktree(projectPath, cardId, workspace)
+//   -> { path, tool, base, baseSha, warnings }
+// Always returns an asserted-isolated worktree standing on the tip that was
+// just fetched, or throws. `warnings` is what the caller must make audible on
+// the card: a start that fell back to a stale base is still a start, and
+// nobody reads the server's stderr.
 function createWorktree(projectPath, cardId, workspace) {
   const proj = fs.realpathSync(projectPath);
   return withProjectLock(proj, async () => {
     let wt = null;
     let tool = 'git';
     const base = await freshBase(proj);
+    const warnings = base.warnings;
     if (await treehouseAvailable()) {
       try {
         const out = await run('treehouse', ['get', '--lease', '--lease-holder', 'bc-w-' + cardId], { cwd: proj });
@@ -123,8 +184,16 @@ function createWorktree(projectPath, cardId, workspace) {
         if (cand && fs.existsSync(cand)) { wt = cand; tool = 'treehouse'; }
       } catch (e) { wt = null; /* fall back to git worktree */ }
       // A pooled worktree comes back on whatever the pool left it on, so the
-      // base has to be applied after the fact rather than at creation.
-      if (wt && base) await git(wt, 'checkout', '--detach', base);
+      // base has to be applied after the fact rather than at creation — into
+      // ITS ref store, which is not the clone we fetched.
+      if (wt && base.ref) {
+        try {
+          warnings.push(...await applyBase(wt, proj, base));
+        } catch (e) {
+          await run('treehouse', ['return', wt], { cwd: proj }).catch(() => {}); // no lease left behind
+          throw e;
+        }
+      }
     }
     if (!wt) {
       tool = 'git';
@@ -132,10 +201,20 @@ function createWorktree(projectPath, cardId, workspace) {
       fs.mkdirSync(dir, { recursive: true });
       wt = path.join(dir, String(cardId).replace(/[^A-Za-z0-9_.-]/g, '-'));
       if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);
-      await git(proj, 'worktree', 'add', '-d', wt, ...(base ? [base] : []));
+      await git(proj, 'worktree', 'add', '-d', wt, ...(base.ref ? [base.ref] : []));
     }
     await assertIsolated(wt, proj);
-    return { path: fs.realpathSync(wt), tool, base: base || null };
+    try {
+      await assertOnBase(wt, base);
+    } catch (e) {
+      // Nothing half-provisioned survives a refusal: a leaked lease starves the
+      // pool, and a leaked git worktree owns the deterministic path this card
+      // would be handed on its next start.
+      if (tool === 'treehouse') await run('treehouse', ['return', wt], { cwd: proj }).catch(() => {});
+      else await git(proj, 'worktree', 'remove', '--force', wt).catch(() => {});
+      throw e;
+    }
+    return { path: fs.realpathSync(wt), tool, base: base.ref || null, baseSha: base.sha || null, warnings };
   });
 }
 

--- a/server/worktrees.js
+++ b/server/worktrees.js
@@ -137,11 +137,24 @@ async function freshBase(proj) {
 // Fetching the fetched clone's own ref, BY PATH, into the lease puts the exact
 // tip in the ref store the checkout will read. No treehouse internals: it is
 // git, run inside the leased path.
+//
+// The fetch carries a DESTINATION refspec because a tip reachable only through
+// FETCH_HEAD is held by no ref at all, and releaseWorktree reads exactly that:
+// its dangling probe (`rev-list HEAD --not --branches --tags --remotes`) would
+// return HEAD itself and refuse to release a worker that committed nothing —
+// leaking the lease forever. The destination is a bc-owned
+// refs/remotes/bc-base/* namespace, never refs/remotes/origin/*: the pool clone
+// belongs to another workspace and moving ITS remote-tracking refs is not ours
+// to do, while `--remotes` still matches ours.
+function baseDest(base) {
+  return 'refs/remotes/bc-base/' + base.ref.replace(/^[^/]+\//, '');
+}
 async function applyBase(wt, proj, base) {
   const warnings = [];
+  const dest = baseDest(base);
   try {
-    await git(wt, 'fetch', '--quiet', '--no-tags', proj, base.fullRef);
-    await git(wt, 'checkout', '--detach', 'FETCH_HEAD');
+    await git(wt, 'fetch', '--quiet', '--no-tags', proj, '+' + base.fullRef + ':' + dest);
+    await git(wt, 'checkout', '--detach', dest);
     return warnings;
   } catch (e) {
     warnings.push('could not carry ' + base.ref + ' from ' + proj + ' into the leased worktree ('
@@ -203,8 +216,8 @@ function createWorktree(projectPath, cardId, workspace) {
       if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);
       await git(proj, 'worktree', 'add', '-d', wt, ...(base.ref ? [base.ref] : []));
     }
-    await assertIsolated(wt, proj);
     try {
+      await assertIsolated(wt, proj);
       await assertOnBase(wt, base);
     } catch (e) {
       // Nothing half-provisioned survives a refusal: a leaked lease starves the
@@ -212,6 +225,10 @@ function createWorktree(projectPath, cardId, workspace) {
       // would be handed on its next start.
       if (tool === 'treehouse') await run('treehouse', ['return', wt], { cwd: proj }).catch(() => {});
       else await git(proj, 'worktree', 'remove', '--force', wt).catch(() => {});
+      // The refusal is the only thing the caller sees, so it carries WHY the
+      // base was stale too — the warnings are returned, not logged, and this
+      // path never reaches the success return that hands them to the card.
+      if (warnings.length) e.message += ' (' + warnings.join('; ') + ')';
       throw e;
     }
     return { path: fs.realpathSync(wt), tool, base: base.ref || null, baseSha: base.sha || null, warnings };

--- a/server/worktrees.js
+++ b/server/worktrees.js
@@ -123,7 +123,7 @@ async function freshBase(proj) {
   return { ref, fullRef, sha, warnings };
 }
 
-// applyBase(wt, proj, base) -> warnings
+// applyBase(wt, proj, base, cardId, warnings) — records into `warnings`
 //
 // The pooled worktree's ref store is NOT the clone freshBase() fetched.
 // treehouse keeps one pool per repository per machine, and which clone backs
@@ -146,22 +146,28 @@ async function freshBase(proj) {
 // refs/remotes/bc-base/* namespace, never refs/remotes/origin/*: the pool clone
 // belongs to another workspace and moving ITS remote-tracking refs is not ours
 // to do, while `--remotes` still matches ours.
-function baseDest(base) {
-  return 'refs/remotes/bc-base/' + base.ref.replace(/^[^/]+\//, '');
+//
+// The destination is named for the CARD, not the branch, because refs/remotes/*
+// is shared by every worktree cut from the clone while the pool is shared by
+// every workspace on the repo — a per-branch name is one ref two boards race to
+// force-update, and the loser's checkout reads the winner's tip and 502s on an
+// assertion meant to catch real staleness. One ref per card has no contenders;
+// the force-update keeps it from accumulating stale tips across starts.
+function baseDest(cardId) {
+  const slug = String(cardId).replace(/[^A-Za-z0-9_-]/g, '-');
+  return 'refs/remotes/bc-base/' + (slug || 'card');
 }
-async function applyBase(wt, proj, base) {
-  const warnings = [];
-  const dest = baseDest(base);
+async function applyBase(wt, proj, base, cardId, warnings) {
+  const dest = baseDest(cardId);
   try {
     await git(wt, 'fetch', '--quiet', '--no-tags', proj, '+' + base.fullRef + ':' + dest);
     await git(wt, 'checkout', '--detach', dest);
-    return warnings;
+    return;
   } catch (e) {
     warnings.push('could not carry ' + base.ref + ' from ' + proj + ' into the leased worktree ('
       + String(e.message || e) + ') — falling back to that worktree\'s own ' + base.ref);
   }
   await git(wt, 'checkout', '--detach', base.ref);
-  return warnings;
 }
 
 // assertOnBase — the checkout landed on the tip that was actually fetched.
@@ -174,6 +180,14 @@ async function assertOnBase(wt, base) {
     throw new Error('worktree is on ' + head + ' but the fetched ' + base.ref + ' is ' + base.sha
       + ' — refusing to start a worker on a stale base');
   }
+}
+
+// A refusal is the only thing the caller ever sees of a failed start: the
+// warnings are RETURNED, not logged, so every throw out of createWorktree has
+// to carry them or the reason the base went stale dies with the request.
+function carrying(e, warnings) {
+  if (warnings.length) e.message += ' (' + warnings.join('; ') + ')';
+  return e;
 }
 
 // createWorktree(projectPath, cardId, workspace)
@@ -201,10 +215,10 @@ function createWorktree(projectPath, cardId, workspace) {
       // ITS ref store, which is not the clone we fetched.
       if (wt && base.ref) {
         try {
-          warnings.push(...await applyBase(wt, proj, base));
+          await applyBase(wt, proj, base, cardId, warnings);
         } catch (e) {
           await run('treehouse', ['return', wt], { cwd: proj }).catch(() => {}); // no lease left behind
-          throw e;
+          throw carrying(e, warnings);
         }
       }
     }
@@ -213,8 +227,10 @@ function createWorktree(projectPath, cardId, workspace) {
       const dir = path.join(workspace, '.bridge-commander', 'worktrees');
       fs.mkdirSync(dir, { recursive: true });
       wt = path.join(dir, String(cardId).replace(/[^A-Za-z0-9_.-]/g, '-'));
-      if (fs.existsSync(wt)) throw new Error('worktree path already exists: ' + wt);
-      await git(proj, 'worktree', 'add', '-d', wt, ...(base.ref ? [base.ref] : []));
+      if (fs.existsSync(wt)) throw carrying(new Error('worktree path already exists: ' + wt), warnings);
+      try {
+        await git(proj, 'worktree', 'add', '-d', wt, ...(base.ref ? [base.ref] : []));
+      } catch (e) { throw carrying(e, warnings); }
     }
     try {
       await assertIsolated(wt, proj);
@@ -225,11 +241,7 @@ function createWorktree(projectPath, cardId, workspace) {
       // would be handed on its next start.
       if (tool === 'treehouse') await run('treehouse', ['return', wt], { cwd: proj }).catch(() => {});
       else await git(proj, 'worktree', 'remove', '--force', wt).catch(() => {});
-      // The refusal is the only thing the caller sees, so it carries WHY the
-      // base was stale too — the warnings are returned, not logged, and this
-      // path never reaches the success return that hands them to the card.
-      if (warnings.length) e.message += ' (' + warnings.join('; ') + ')';
-      throw e;
+      throw carrying(e, warnings);
     }
     return { path: fs.realpathSync(wt), tool, base: base.ref || null, baseSha: base.sha || null, warnings };
   });

--- a/test/kinds.test.js
+++ b/test/kinds.test.js
@@ -29,6 +29,7 @@ const BUILTINS = {
   'schedule-failed': { emoji: '🔔', level: 1 },
   'worker-stopped': { emoji: '⏸️', level: 2 },
   'worker-stalled': { emoji: '🐢', level: 1 },
+  'stale-base': { emoji: '🧊', level: 1 },
   'worker-paused': { emoji: '💤', level: 2 },
   parked: { emoji: '🅿️', level: 2 },
   respawned: { emoji: '♻️', level: 1 },

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -443,6 +443,20 @@ test('a pooled worktree lands on the tip the board fetched, not on the pool clon
       assert.ok(fs.existsSync(path.join(w.worktree.path, 'NEW.md')));
       // nothing to say: the base was refreshed
       assert.deepStrictEqual((await cardEvents(s, 'pooled')).filter((e) => e.kind === 'stale-base'), []);
+      // The carried tip is held by a REAL ref in the lease's own ref store, not
+      // by FETCH_HEAD alone: releaseWorktree reads `--branches --tags --remotes`
+      // to decide whether HEAD carries work nothing else holds, and a worker
+      // that committed nothing must never look like one that did.
+      assert.strictEqual(
+        git(w.worktree.path, 'rev-list', '--max-count=1', 'HEAD', '--not', '--branches', '--tags', '--remotes'),
+        '', 'the base is reachable from a ref, so the release is not refused');
+      const { releaseWorktree } = require('../server/worktrees.js');
+      const realPath = process.env.PATH;
+      process.env.PATH = bin + path.delimiter + realPath; // the fake pool, as the server sees it
+      let rel;
+      try { rel = await releaseWorktree(w.worktree, path.join(s.dir, 'projects', 'proj')); }
+      finally { process.env.PATH = realPath; }
+      assert.strictEqual(rel.released, true, JSON.stringify(rel));
     } finally { await s.stop(); }
   } finally { fs.rmSync(root, { recursive: true, force: true }); }
 });

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -450,6 +450,12 @@ test('a pooled worktree lands on the tip the board fetched, not on the pool clon
       assert.strictEqual(
         git(w.worktree.path, 'rev-list', '--max-count=1', 'HEAD', '--not', '--branches', '--tags', '--remotes'),
         '', 'the base is reachable from a ref, so the release is not refused');
+      // and that ref is named for the CARD: refs/remotes/* is shared by every
+      // worktree of the pool clone, so a per-branch name is one ref that two
+      // boards on the same repo race to force-update under each other.
+      assert.strictEqual(git(w.worktree.path, 'rev-parse', 'refs/remotes/bc-base/pooled'), tip);
+      assert.throws(() => git(w.worktree.path, 'rev-parse', '--verify', 'refs/remotes/bc-base/main'),
+        'the destination is scoped to the card, never to the branch');
       const { releaseWorktree } = require('../server/worktrees.js');
       const realPath = process.env.PATH;
       process.env.PATH = bin + path.delimiter + realPath; // the fake pool, as the server sees it

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -365,6 +365,127 @@ test('a worktree is cut from origin\'s tip, not from wherever the clone happens 
   } finally { await teardown(); }
 });
 
+// The fetch was real and landed in the clone the board registered; the
+// checkout read a DIFFERENT clone's `origin/<branch>`. treehouse keeps one pool
+// per repository per machine, so which clone backs it is decided by whoever
+// asked for it first — often a checkout in another workspace entirely. When the
+// two agreed the start looked fine, which is why this was intermittent.
+//
+// The fake pool below is exactly that shape: worktrees cut from a SECOND clone
+// that is behind and never fetches.
+function writeFakeTreehouse(root, poolClone) {
+  const bin = path.join(root, 'fakebin');
+  fs.mkdirSync(bin, { recursive: true });
+  const pool = path.join(root, 'pool');
+  fs.mkdirSync(pool, { recursive: true });
+  const sh = [
+    '#!/bin/sh',
+    'set -e',
+    'POOL=' + JSON.stringify(pool),
+    'CLONE=' + JSON.stringify(poolClone),
+    'case "$1" in',
+    '  --version) echo "fake-treehouse 0.0.0" ;;',
+    '  get)',
+    '    slot="$POOL/1"',
+    '    if [ ! -d "$slot" ]; then',
+    // the pool leaves a worktree on ITS clone's stale tip — never the board's
+    '      git -C "$CLONE" worktree add -q -d "$slot" origin/main >&2',
+    '    fi',
+    '    echo "$slot" ;;',
+    '  return) : ;;',
+    '  *) exit 1 ;;',
+    'esac',
+    '',
+  ].join('\n');
+  fs.writeFileSync(path.join(bin, 'treehouse'), sh, { mode: 0o755 });
+  return bin;
+}
+
+test('a pooled worktree lands on the tip the board fetched, not on the pool clone\'s stale one', async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'bc-pool-'));
+  try {
+    const repo = makeRepo(root);
+    // the pool's clone is taken NOW and never fetches again — a June checkout
+    // in somebody else's workspace, which is what backs the real pool here
+    const poolClone = path.join(root, 'poolclone');
+    execFileSync('git', ['clone', '-q', repo, poolClone], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const stale = git(poolClone, 'rev-parse', 'origin/main');
+
+    const bin = writeFakeTreehouse(root, poolClone);
+    const s = await startServerWithLieutenant({
+      env: {
+        BC_FAKE_STATE: path.join(root, 'fake'), BC_WORKTREE_TOOL: 'treehouse',
+        PATH: bin + path.delimiter + process.env.PATH,
+        BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
+      },
+    });
+    try {
+      assert.strictEqual((await s.api('POST', '/api/projects', { source: repo, name: 'proj' })).status, 200);
+      // origin moves on after both clones exist — the pool clone never learns
+      fs.writeFileSync(path.join(repo, 'NEW.md'), 'pushed between starts\n');
+      git(repo, 'add', '.');
+      git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'moved on');
+      const tip = git(repo, 'rev-parse', 'HEAD');
+      assert.notStrictEqual(tip, stale, 'the pool clone really is behind');
+
+      await s.api('POST', '/api/cards', withOwner({
+        title: 'Pooled', id: 'pooled', attributes: { repo: 'proj' },
+      }));
+      const r = await s.api('POST', '/api/cards/pooled/start', { harness: 'fake' });
+      assert.strictEqual(r.status, 200, JSON.stringify(r.body));
+      const w = r.body.worker;
+      assert.strictEqual(w.worktree.tool, 'treehouse');
+      // the pooled worktree hangs off the OTHER clone — the bug's precondition
+      assert.match(git(w.worktree.path, 'rev-parse', '--git-common-dir'), rx(fs.realpathSync(poolClone)));
+      assert.strictEqual(git(w.worktree.path, 'rev-parse', 'HEAD'), tip,
+        'the worker stands on the sha the board fetched, not the pool clone\'s origin/main');
+      assert.strictEqual(w.worktree.baseSha, tip);
+      assert.ok(fs.existsSync(path.join(w.worktree.path, 'NEW.md')));
+      // nothing to say: the base was refreshed
+      assert.deepStrictEqual((await cardEvents(s, 'pooled')).filter((e) => e.kind === 'stale-base'), []);
+    } finally { await s.stop(); }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+});
+
+test('a second start after a push to origin gets the new commit — the actual sha, plain git', async () => {
+  const { s, repo, teardown } = await boot();
+  try {
+    const commit = (msg, file) => {
+      fs.writeFileSync(path.join(repo, file), msg + '\n');
+      git(repo, 'add', '.');
+      git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', msg);
+      return git(repo, 'rev-parse', 'HEAD');
+    };
+    const first = commit('before', 'ONE.md');
+    await s.api('POST', '/api/cards', withOwner({ title: 'One', id: 'one', attributes: { repo: 'proj' } }));
+    const r1 = await s.api('POST', '/api/cards/one/start', { harness: 'fake' });
+    assert.strictEqual(git(r1.body.worker.worktree.path, 'rev-parse', 'HEAD'), first);
+
+    const second = commit('after', 'TWO.md');
+    await s.api('POST', '/api/cards', withOwner({ title: 'Two', id: 'two', attributes: { repo: 'proj' } }));
+    const r2 = await s.api('POST', '/api/cards/two/start', { harness: 'fake' });
+    assert.strictEqual(git(r2.body.worker.worktree.path, 'rev-parse', 'HEAD'), second,
+      'the second worker starts on the commit pushed between the two starts');
+    assert.strictEqual(r2.body.worker.worktree.baseSha, second);
+  } finally { await teardown(); }
+});
+
+test('a fetch that fails says so on the card, at level 1 — not on a stderr nobody reads', async () => {
+  const { s, teardown } = await boot();
+  try {
+    const clone = path.join(s.dir, 'projects', 'proj');
+    git(clone, 'remote', 'set-url', 'origin', path.join(s.dir, 'gone-forever.git'));
+    await s.api('POST', '/api/cards', withOwner({ title: 'Stale', id: 'stale', attributes: { repo: 'proj' } }));
+    const r = await s.api('POST', '/api/cards/stale/start', { harness: 'fake' });
+    assert.strictEqual(r.status, 200, 'a failed fetch never blocks the board');
+    const ev = (await cardEvents(s, 'stale')).find((e) => e.kind === 'stale-base');
+    assert.ok(ev, 'the timeline carries the stale base');
+    assert.strictEqual(ev.level, 1);
+    assert.match(ev.text, /fetch failed/);
+    assert.match(ev.text, rx(clone));
+  } finally { await teardown(); }
+});
+
 test('card start --resume reincarnates a dead recorded worker in the same worktree', async () => {
   const { s, teardown } = await boot();
   try {


### PR DESCRIPTION
## Intent

MNC-111: card start fetched one clone and cut the worktree from another. server/worktrees.js freshBase() ran `git fetch origin` in the registered project clone and returned the ref NAME origin/HEAD resolves to there; the treehouse branch then applied that name inside the leased pooled worktree, whose ref store is a DIFFERENT clone (treehouse keeps one pool per repository per machine). The fetch landed in clone A, the checkout read clone B — intermittent stale bases. Fix: freshBase() now returns {ref, fullRef, sha, warnings}; the pooled branch calls applyBase(), which fetches the fetched clone's own full ref BY PATH into the lease (git -C <wt> fetch --no-tags <proj> refs/remotes/origin/<b>) and checks out FETCH_HEAD, falling back to the worktree's own origin ref with a recorded warning. assertOnBase() then compares worktree HEAD against the fetched sha on BOTH paths and throws (start 502s, naming both shas) when they differ, best-effort returning the lease / removing the half-added git worktree so nothing is left behind. Warnings that were stderr-only are now returned to server.js, which pushes them as level-1 'stale-base' card events on the card being started (new BUILTIN_KIND, emoji ice cube) — start still proceeds on a stale-but-real base, since blocking the board is worse. Tradeoffs/decisions: (a) carried the tip by SHA rather than by ref name because a ref name means whatever ref store reads it; (b) fetched by local PATH rather than trusting the pool clone's own origin remote, which may point anywhere, and rather than git fetch <sha> which needs uploadpack.allowAnySHA1InWant; (c) assertion runs on the plain-git path too — it already satisfied it, so no behaviour change there, per the card; (d) no treehouse internals touched, no treehouse upgrade, no .github changes, pool not rebuilt (out of scope per the card). Tests added to test/workers.test.js: a fake treehouse on PATH whose pool worktrees are cut from a second, deliberately-stale clone — proves the worker lands on the board's fetched sha (this test fails against the old checkout-by-name code); two consecutive starts with a commit pushed to origin in between, proving the second worker's actual HEAD sha on the plain-git path; and a broken origin URL proving the failed fetch lands a level-1 stale-base event on the card instead of a stderr line. test/kinds.test.js BUILTINS and docs/api/overview.md side-effects table updated.

## What Changed

- `server/worktrees.js`: `freshBase()` now returns `{ref, fullRef, sha, warnings}` instead of a bare ref name, and a new `applyBase()` carries that tip into a pooled worktree by fetching the project clone's full ref **by local path** (`git -C <wt> fetch --no-tags <proj> +<fullRef>:refs/remotes/bc-base/<card>`) and checking out that per-card destination ref — previously the fetch landed in the registered project clone while the checkout read the pool clone's own `origin/<b>`, a different ref store, so workers intermittently started on a stale base. Fallback to the worktree's own origin ref records a warning instead of proceeding silently.
- `server/worktrees.js`: a new `assertOnBase()` compares worktree HEAD against the fetched sha on both the pooled and plain-git paths and throws (start 502s naming both shas); refusals now best-effort return the treehouse lease or force-remove the half-added git worktree, and every throw out of `createWorktree()` appends the accumulated warnings to its message. The per-card `bc-base` destination ref keeps the fetched commits reachable so `releaseWorktree()`'s dangling probe doesn't refuse to release a worker that committed nothing.
- `server/server.js`: warnings returned from `createWorktree()` are pushed onto the card as level-1 `stale-base` events (new `BUILTIN_KIND`, 🧊) with `card.updated` bumped, rather than written to stderr — the start still proceeds on a stale-but-real base. Registered in `test/kinds.test.js`, `dev/ui-server.js`, and the `docs/api/overview.md` side-effects table.

Tests added in `test/workers.test.js` cover a fake `treehouse` on PATH whose pool is cut from a deliberately-stale second clone (fails against the old checkout-by-name code), two consecutive starts across a new origin commit on the plain-git path, and a broken origin URL landing a `stale-base` event on the card. Full suite passes (1039/0); review left three open informational notes, including that `refs/remotes/bc-base/<card>` is never deleted on release.

## Risk Assessment

✅ Low: Both prior rounds' findings are resolved and covered by assertions in the pooled-path test; what remains is one non-functional hygiene item (unpruned bc-base refs) in an otherwise well-bounded change.

## Testing

Ran the workers suite and the full CI suite (1039 pass / 0 fail), proved the new pooled test fails against the pre-change worktrees.js, then drove a live board with a fake treehouse pool backed by a stale second clone to show end-to-end that a pooled worker lands on the sha the board fetched, that an unrefreshable base becomes a level-1 🧊 stale-base card event (captured as a board-UI screenshot and in a bc-axi CLI transcript) without blocking the start, and that a worktree that cannot be put on the fetched tip refuses the start with a 502 naming both shas while returning the lease.

- Evidence: Board UI: the 🧊 stale-base event in the card timeline (local file: <code>/tmp/no-mistakes-evidence/01M0ZKBDT040213GPKPTRHZ64R/stale-base-card-timeline.png</code>)
<details>
<summary>Evidence: End-to-end transcript: three live card starts against a stale-backed pool</summary>

<code>origin/main tip : b97f4b8cdd58ea7843b2e993501dea5a74d87470&#10;pool clone still on : f98d4c572c8bd2790c447d0fc851c6e55f1db425&#10;&#10;=== 1. pooled start ===&#10;POST /api/cards/mnc111-pooled/start -&gt; 200&#10;{&#34;path&#34;:&#34;/tmp/mnc111-ieYgpT/pool/1798738&#34;,&#34;tool&#34;:&#34;treehouse&#34;,&#34;base&#34;:&#34;origin/main&#34;,&#34;baseSha&#34;:&#34;b97f4b8cdd58ea7843b2e993501dea5a74d87470&#34;}&#10;worktree HEAD : b97f4b8cdd58ea7843b2e993501dea5a74d87470&#10;backed by clone : /tmp/mnc111-ieYgpT/poolclone&#10;^ NOT the board clone : /tmp/bc-test-uctBav/projects/proj&#10;that clone&#39;s own origin/main: f98d4c572c8bd2790c447d0fc851c6e55f1db425 &lt;- what the old code checked out&#10;base ref held in the lease : refs/remotes/bc-base/mnc111-pooled = b97f4b8c...&#10;file pushed after the pool clone was taken is present: true&#10;VERDICT: HEAD === origin tip -&gt; true&#10;&#10;=== 2. unrefreshable base ===&#10;POST /api/cards/mnc111-stale/start -&gt; 200 (the board is never blocked)&#10;card event: {&#34;kind&#34;:&#34;stale-base&#34;,&#34;level&#34;:1,&#34;text&#34;:&#34;worktree base: fetch failed in /tmp/bc-test-uctBav/projects/proj — the base may be stale: ...&#34;}&#10;&#10;=== 3. cannot be put on the fetched tip ===&#10;POST /api/cards/mnc111-refused/start -&gt; 502&#10;error: worktree is on f98d4c57... but the fetched origin/main is b97f4b8c... — refusing to start a worker on a stale base (could not carry origin/main ... — falling back to that worktree&#39;s own origin/main)&#10;card column after the refusal: backlog (no worker: true)&#10;leases the server handed back (`treehouse return &lt;path&gt;`): [&#34;/tmp/mnc111-ieYgpT/pool/1798791&#34;]</code>

```text
board up at http://127.0.0.1:39085  (workspace /tmp/bc-test-uctBav)
POST /api/projects {source: srcrepo, name: proj} -> 200

origin/main tip      : b97f4b8cdd58ea7843b2e993501dea5a74d87470
pool clone still on  : f98d4c572c8bd2790c447d0fc851c6e55f1db425   (git -C poolclone rev-parse origin/main)

================ 1. pooled start: the worker lands on the tip the BOARD fetched ============
POST /api/cards/mnc111-pooled/start -> 200
{
  "path": "/tmp/mnc111-ieYgpT/pool/1798738",
  "tool": "treehouse",
  "base": "origin/main",
  "baseSha": "b97f4b8cdd58ea7843b2e993501dea5a74d87470"
}
worktree HEAD              : b97f4b8cdd58ea7843b2e993501dea5a74d87470
backed by clone            : /tmp/mnc111-ieYgpT/poolclone
  ^ NOT the board clone    : /tmp/bc-test-uctBav/projects/proj
that clone's own origin/main: f98d4c572c8bd2790c447d0fc851c6e55f1db425  <- what the old code checked out
base ref held in the lease : refs/remotes/bc-base/mnc111-pooled = b97f4b8cdd58ea7843b2e993501dea5a74d87470
file pushed after the pool clone was taken is present: true
stale-base events on the card: []
VERDICT: HEAD === origin tip -> true

================ 2. a base that could not be refreshed is said ON THE CARD ================
POST /api/cards/mnc111-stale/start -> 200  (the board is never blocked)
card event: {
  "kind": "stale-base",
  "level": 1,
  "text": "worktree base: fetch failed in /tmp/bc-test-uctBav/projects/proj — the base may be stale: Command failed: git -C /tmp/bc-test-uctBav/projects/proj fetch --quiet origin\nfatal: '/tmp/bc-test-uctBav/gone-forever.git' does not appear to be a git repository\nfatal: Could not read from remote repository.\n\nPlease make sure you have the correct access rights\nand the repository exists.\n"
}

================ 3. a worktree that cannot be put on the fetched tip REFUSES the start ====
POST /api/cards/mnc111-refused/start -> 502
error: "worktree provisioning failed: worktree is on f98d4c572c8bd2790c447d0fc851c6e55f1db425 but the fetched origin/main is b97f4b8cdd58ea7843b2e993501dea5a74d87470 — refusing to start a worker on a stale base (could not carry origin/main from /tmp/bc-test-uctBav/projects/proj into the leased worktree (Command failed: git -C /tmp/mnc111-ieYgpT/pool/1798791 fetch --quiet --no-tags /tmp/bc-test-uctBav/projects/proj +refs/remotes/origin/main:refs/remotes/bc-base/mnc111-refused\nfatal: couldn't find remote ref refs/remotes/origin/main\n) — falling back to that worktree's own origin/main)"
card column after the refusal: backlog (no worker: true)
leases the server handed back (`treehouse return <path>`): ["/tmp/mnc111-ieYgpT/pool/1798791"]  <- nothing half-provisioned survives the refusal

board left running for the screenshot: http://127.0.0.1:39085
```
</details>
<details>
<summary>Evidence: bc-axi CLI: the 502 refusal and the level-1 stale-base line on the card</summary>

<code>$ bc-axi card start ADA-1 --harness fake&#10;starting a worker for ADA-1 (worktree + real session — can take a minute)...&#10;HTTP 502: {&#34;error&#34;:&#34;worktree provisioning failed: worktree is on f98d4c572c8bd2790c447d0fc851c6e55f1db425 but the fetched origin/main is b97f4b8cdd58ea7843b2e993501dea5a74d87470 — refusing to start a worker on a stale base (...)&#34;}&#10;exit=1&#10;&#10;$ bc-axi card show ADA-1&#10;# Refused: cannot be put on the fetched tip (id=ADA-1, ..., column=backlog)&#10;status: worker=absent owed=false unread=false&#10;&#10;$ bc-axi card show mnc111-stale&#10;--- events ---&#10;08-26 18:11 L2 created created in 📋 Backlog (agent)&#10;08-26 18:11 L1 stale-base worktree base: fetch failed in /tmp/bc-test-uctBav/projects/proj — the base may be stale: ...</code>

```text
# The by-path carry into the lease is blocked, so the pooled checkout can only fall back
# to the pool clone own (stale) origin/main — exactly the case the assertion is for.
$ git -C projects/proj config uploadpack.hideRefs refs/remotes/origin

$ bc-axi card create --title "Refused: cannot be put on the fetched tip" --owner ada --playbook default --attr repo=proj
created ADA-1 in backlog

$ bc-axi card start ADA-1 --harness fake
starting a worker for ADA-1 (worktree + real session — can take a minute)...
HTTP 502: {"error":"worktree provisioning failed: worktree is on f98d4c572c8bd2790c447d0fc851c6e55f1db425 but the fetched origin/main is b97f4b8cdd58ea7843b2e993501dea5a74d87470 — refusing to start a worker on a stale base (could not carry origin/main from /tmp/bc-test-uctBav/projects/proj into the leased worktree (Command failed: git -C /tmp/mnc111-ieYgpT/pool/1803790 fetch --quiet --no-tags /tmp/bc-test-uctBav/projects/proj +refs/remotes/origin/main:refs/remotes/bc-base/ADA-1\nfatal: couldn't find remote ref refs/remotes/origin/main\n) — falling back to that worktree's own origin/main)"}
exit=1

$ bc-axi card show ADA-1
# Refused: cannot be put on the fetched tip  (id=ADA-1, type=implementation, owner=ada, column=backlog)
status: worker=absent owed=false unread=false
repo: proj

--- events ---
08-26 18:13  L2 created  created in 📋 Backlog  (agent)
# Origin unreachable at start  (id=mnc111-stale, type=implementation, owner=ada, column=working)
status: worker=working(bc-bc-test-uctb-a0e679-lt-ada:w-mnc111-stale) owed=false unread=false
repo: proj
session: bc-bc-test-uctb-a0e679-lt-ada:w-mnc111-stale
worktree: /tmp/mnc111-ieYgpT/pool/1798768
branch: bc/mnc111-stale
artifacts: [{"uri":"file:///tmp/bc-test-uctBav/.bridge-commander/harness/bc-bc-test-uctb-a0e679-lt-ada:w-mnc111-stale.prompt","label":"brief","type":"markdown"}]

--- events ---
08-26 18:11  L2 created  created in 📋 Backlog  (agent)
08-26 18:11  L1 stale-base  worktree base: fetch failed in /tmp/bc-test-uctBav/projects/proj — the base may be stale: Command failed: git -C /tmp/bc-test-uctBav/projects/proj fetch --quiet origin
fatal: '/tmp/bc-test-uctBav/gone-forever.git' does not appear to be a git repository
```
</details>
<details>
<summary>Evidence: The new pooled test against the pre-change worktrees.js (fails)</summary>

<code>✖ a pooled worktree lands on the tip the board fetched, not on the pool clone&#39;s stale one&#10;AssertionError: the worker stands on the sha the board fetched, not the pool clone&#39;s origin/main&#10;+ actual &#39;4c4c77b92e5c8d83059cfdb5f25097229e0de136&#39;&#10;- expected &#39;3d293d36d0ed3383b4608e5096c0078a879997ac&#39;&#10;ℹ pass 0 ℹ fail 1</code>

```text
# The new pooled test, run against the PRE-CHANGE server/worktrees.js (30cc01f).
# The old code checks the pooled worktree out by REF NAME, so the lease lands on the
# pool clone stale origin/main instead of the sha the board just fetched.
$ git show 30cc01f:server/worktrees.js > server/worktrees.js
$ node --test --test-name-pattern="pooled worktree lands" test/workers.test.js

✖ a pooled worktree lands on the tip the board fetched, not on the pool clone's stale one (178.61288ms)
ℹ tests 1
ℹ suites 0
ℹ pass 0
ℹ fail 1
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 3212.540568

✖ failing tests:

test at test/workers.test.js:404:1
✖ a pooled worktree lands on the tip the board fetched, not on the pool clone's stale one (178.61288ms)
  AssertionError [ERR_ASSERTION]: the worker stands on the sha the board fetched, not the pool clone's origin/main
  + actual - expected
  
  + '4c4c77b92e5c8d83059cfdb5f25097229e0de136'
  - '3d293d36d0ed3383b4608e5096c0078a879997ac'
  
      at TestContext.<anonymous> (/home/ai/.no-mistakes/worktrees/deeca192624b/01M0ZKBDT040213GPKPTRHZ64R/test/workers.test.js:440:14)
      at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
      at async Test.run (node:internal/test_runner/test:1332:7)
      at async startSubtestAfterBootstrap (node:internal/test_runner/harness:385:3) {
    generatedMessage: false,
    code: 'ERR_ASSERTION',
    actual: '4c4c77b92e5c8d83059cfdb5f25097229e0de136',
    expected: '3d293d36d0ed3383b4608e5096c0078a879997ac',
    operator: 'strictEqual',
    diff: 'simple'
  }
```
</details>
<details>
<summary>Evidence: Re-runnable evidence script (boots a real board + fake stale-backed treehouse pool)</summary>

```text
'use strict';
// MNC-111 end-to-end evidence: a card start puts the worker on the tip the
// BOARD fetched, even when the pooled worktree is backed by a different clone;
// a base that could not be refreshed is said on the card; a worktree that
// cannot be put on the fetched tip refuses the start.
const fs = require('node:fs');
const os = require('node:os');
const path = require('node:path');
const { execFileSync } = require('node:child_process');
const REPO = '/home/ai/.no-mistakes/worktrees/deeca192624b/01M0ZKBDT040213GPKPTRHZ64R';
const { startServerWithLieutenant, withOwner } = require(path.join(REPO, 'test/helper.js'));

const git = (dir, ...a) => execFileSync('git', ['-C', dir, ...a], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }).trim();
const short = (s) => String(s || '').slice(0, 12);
const say = (...a) => console.log(...a);

function makeRepo(root) {
  const repo = path.join(root, 'srcrepo');
  fs.mkdirSync(repo, { recursive: true });
  execFileSync('git', ['init', '-q', '-b', 'main', repo], { stdio: ['ignore', 'pipe', 'pipe'] });
  fs.writeFileSync(path.join(repo, 'README.md'), 'hello\n');
  git(repo, 'add', '.');
  git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', 'init');
  return repo;
}
function commit(repo, msg, file) {
  fs.writeFileSync(path.join(repo, file), msg + '\n');
  git(repo, 'add', '.');
  git(repo, '-c', 'user.email=t@t', '-c', 'user.name=t', 'commit', '-q', '-m', msg);
  return git(repo, 'rev-parse', 'HEAD');
}
// A fake `treehouse` on PATH whose pool worktrees are cut from a SECOND,
// deliberately stale clone — the real bug's shape.
function fakeTreehouse(root, poolClone) {
  const bin = path.join(root, 'fakebin');
  fs.mkdirSync(bin, { recursive: true });
  const pool = path.join(root, 'pool');
  fs.mkdirSync(pool, { recursive: true });
  fs.writeFileSync(path.join(bin, 'treehouse'), [
    '#!/bin/sh', 'set -e',
    'POOL=' + JSON.stringify(pool), 'CLONE=' + JSON.stringify(poolClone),
    'case "$1" in',
    '  --version) echo "fake-treehouse 0.0.0" ;;',
    '  get)',
    '    slot="$POOL/$$"',
    '    git -C "$CLONE" worktree add -q -d "$slot" origin/main >&2',
    '    echo "$slot" ;;',
    '  return) echo "$2" >> "$POOL/returned.log" ;;',
    '  *) exit 1 ;;',
    'esac', '',
  ].join('\n'), { mode: 0o755 });
  return bin;
}

(async () => {
  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mnc111-'));
  const repo = makeRepo(root);
  const poolClone = path.join(root, 'poolclone');
  execFileSync('git', ['clone', '-q', repo, poolClone], { stdio: ['ignore', 'pipe', 'pipe'] });
  const staleTip = git(poolClone, 'rev-parse', 'origin/main');
  const bin = fakeTreehouse(root, poolClone);

  const s = await startServerWithLieutenant({
    env: {
      BC_FAKE_STATE: path.join(root, 'fake'), BC_WORKTREE_TOOL: 'treehouse',
      PATH: bin + path.delimiter + process.env.PATH,
      BC_SUPERVISE_INTERVAL_MS: '0', BC_PRWATCH_INTERVAL_MS: '0',
    },
  });
  say('board up at ' + s.base + '  (workspace ' + s.dir + ')');
  const pr = await s.api('POST', '/api/projects', { source: repo, name: 'proj' });
  say('POST /api/projects {source: srcrepo, name: proj} -> ' + pr.status);
  const clone = path.join(s.dir, 'projects', 'proj');

  // origin moves on AFTER both clones exist; the pool clone never learns.
  const tip = commit(repo, 'pushed after the pool clone was taken', 'NEW.md');
  say('\norigin/main tip      : ' + tip);
  say('pool clone still on  : ' + staleTip + '   (git -C poolclone rev-parse origin/main)');

  const start = async (id, title) => {
    await s.api('POST', '/api/cards', withOwner({ title, id, attributes: { repo: 'proj' } }));
    return s.api('POST', '/api/cards/' + id + '/start', { harness: 'fake' });
  };
  const events = async (id) => ((await s.api('GET', '/api/cards/' + id)).body.events || []);

  say('\n================ 1. pooled start: the worker lands on the tip the BOARD fetched ============');
  let r = await start('mnc111-pooled', 'Pooled start on a stale-backed pool');
  say('POST /api/cards/mnc111-pooled/start -> ' + r.status);
  const wt = r.body.worker.worktree;
  say(JSON.stringify(wt, null, 2));
  say('worktree HEAD              : ' + git(wt.path, 'rev-parse', 'HEAD'));
  say('backed by clone            : ' + git(wt.path, 'rev-parse', '--git-common-dir').replace(/\/(\.git|worktrees).*$/, ''));
  say('  ^ NOT the board clone    : ' + clone);
  say('that clone\'s own origin/main: ' + git(poolClone, 'rev-parse', 'origin/main') + '  <- what the old code checked out');
  say('base ref held in the lease : refs/remotes/bc-base/mnc111-pooled = ' + git(wt.path, 'rev-parse', 'refs/remotes/bc-base/mnc111-pooled'));
  say('file pushed after the pool clone was taken is present: ' + fs.existsSync(path.join(wt.path, 'NEW.md')));
  say('stale-base events on the card: ' + JSON.stringify((await events('mnc111-pooled')).filter((e) => e.kind === 'stale-base')));
  say('VERDICT: HEAD === origin tip -> ' + (git(wt.path, 'rev-parse', 'HEAD') === tip));

  say('\n================ 2. a base that could not be refreshed is said ON THE CARD ================');
  const goodUrl = git(clone, 'remote', 'get-url', 'origin');
  git(clone, 'remote', 'set-url', 'origin', path.join(s.dir, 'gone-forever.git'));
  r = await start('mnc111-stale', 'Origin unreachable at start');
  say('POST /api/cards/mnc111-stale/start -> ' + r.status + '  (the board is never blocked)');
  const ev = (await events('mnc111-stale')).find((e) => e.kind === 'stale-base');
  say('card event: ' + JSON.stringify({ kind: ev.kind, level: ev.level, text: ev.text }, null, 2));
  git(clone, 'remote', 'set-url', 'origin', goodUrl);

  say('\n================ 3. a worktree that cannot be put on the fetched tip REFUSES the start ====');
  // The by-path fetch into the lease is blocked (the source hides the ref), so
  // applyBase falls back to the pool clone's own stale origin/main.
  git(clone, 'config', 'uploadpack.hideRefs', 'refs/remotes/origin');
  r = await start('mnc111-refused', 'Worktree cannot be put on the fetched tip');
  say('POST /api/cards/mnc111-refused/start -> ' + r.status);
  say('error: ' + JSON.stringify(r.body.error, null, 2));
  const board = await s.api('GET', '/api/board');
  const card = (board.body.cards || []).find((c) => c.id === 'mnc111-refused');
  say('card column after the refusal: ' + card.column + ' (no worker: ' + !card.worker + ')');
  const returned = fs.existsSync(path.join(root, 'pool', 'returned.log')) ? fs.readFileSync(path.join(root, 'pool', 'returned.log'), 'utf8').trim().split('\n') : [];
  say('leases the server handed back (`treehouse return <path>`): ' + JSON.stringify(returned) + '  <- nothing half-provisioned survives the refusal');
  git(clone, 'config', '--unset', 'uploadpack.hideRefs');

  fs.writeFileSync(path.join(__dirname, 'board-url.txt'), s.base + '\n');
  say('\nboard left running for the screenshot: ' + s.base);
  await new Promise((res) => setTimeout(res, 600000));
  await s.stop();
})().catch((e) => { console.error(e); process.exit(1); });
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- 🚨 `server/worktrees.js:143` - applyBase() fetches the tip with no destination refspec, so in the pool clone&#39;s ref store the fetched commits are reachable only through FETCH_HEAD — no branch, tag, or remote ref holds them. releaseWorktree()&#39;s dangling probe (server/worktrees.js:246, `rev-list --max-count=1 HEAD --not --branches --tags --remotes`) therefore returns HEAD itself and refuses the release with &#39;HEAD carries commits no branch or tag holds&#39;. I reproduced this exactly (stale pool clone + fetch-by-path + checkout FETCH_HEAD → dangling == HEAD). Failure scenario: an investigation card (or any `branch: false` playbook, or a worker that dies before cutting its branch) starts on the treehouse path, HEAD stays at the fetched base, handoff/restart then never releases — the treehouse lease leaks and `card start` on a rework returns 409 &#39;previous worker worktree not releasable&#39; forever. This only bites when the pool clone is behind, i.e. precisely the case this change exists to fix; the plain-git path is unaffected because the project clone&#39;s origin/&lt;b&gt; still holds the sha. Smallest fix: in releaseWorktree, treat `dangling === rec.baseSha` as clean (baseSha is now recorded on the worktree record), since that means nothing was committed on top of the base. Alternative: give the fetch a destination refspec (e.g. `+refs/remotes/origin/&lt;b&gt;:refs/remotes/origin/&lt;b&gt;`) so the tip is held by a remote ref in the pool clone.
- ⚠️ `server/worktrees.js:208` - When assertOnBase() throws, every accumulated warning is discarded — the array is only returned on the success path, and freshBase/applyBase no longer write to stderr. Failure scenario: the fetch fails, applyBase falls back to the lease&#39;s own origin ref, that ref is behind, assertOnBase throws, and the 502 the captain sees names two shas but never says the fetch failed or why — the exact diagnostic that used to reach stderr and is the reason the warnings were introduced. Append `base.warnings` (plus applyBase&#39;s) to the thrown error&#39;s message, or write them to stderr before rethrowing.
- ℹ️ `server/worktrees.js:206` - assertOnBase() now cleans up on refusal (returns the lease / force-removes the git worktree), but the assertIsolated() call one line above still throws with the lease held and the worktree on disk. Failure scenario: a pool hands back a path that fails the isolation check — the lease is never returned and starves the pool, the same leak the new cleanup block exists to prevent. Move assertIsolated inside the same try/cleanup block.
- ℹ️ `server/server.js:2709` - The stale-base events are pushed without bumping `card.updated`, and on the paths where doStartCard later fails (spawn failure → 502, card archived mid-start → 409) the request handler skips saveBoard()/broadcast() entirely. Failure scenario: a start whose fetch fell back and whose spawn then failed leaves the stale-base event only in memory with an unchanged `updated`, so connected UIs never see it and it lands on disk silently at the next unrelated write. Set `card.updated = now()` alongside the push.

🔧 Fix: hold pooled base by a real ref; fix release refusal
2 issues (1 warning, 1 info) still open:
- ⚠️ `server/worktrees.js:158` - `refs/remotes/bc-base/&lt;branch&gt;` is a single ref in the SHARED pool clone, but the checkout now reads it instead of FETCH_HEAD — which I confirmed is per-worktree (a fetch in worktree A leaves worktree B&#39;s FETCH_HEAD unset). Failure scenario: two workspaces on the same repo share the pool (the premise of this whole fix); board A fetches tip X into bc-base/main, board B&#39;s concurrent start force-updates the same ref to tip Y in the window before A&#39;s `checkout --detach dest`, and A lands on Y — assertOnBase then throws and the captain gets a spurious 502 with the lease returned. withProjectLock only closes this window inside one server process, not across workspaces. Fix without giving up reachability: keep the `+&lt;fullRef&gt;:refs/remotes/bc-base/&lt;branch&gt;` refspec (that is what holds the commits for releaseWorktree&#39;s probe) but check out `FETCH_HEAD`, which is per-worktree and is the sha this fetch actually got — the round-1 instructions explicitly allowed either. Alternatively scope the destination per card (`refs/remotes/bc-base/&lt;cardId&gt;/&lt;branch&gt;`).
- ℹ️ `server/worktrees.js:208` - The new `e.message += &#39; (&#39; + warnings.join(&#39;; &#39;) + &#39;)&#39;` only runs in the assertIsolated/assertOnBase catch. When applyBase itself throws — the carry failed AND the fallback `checkout --detach base.ref` also failed — createWorktree rethrows at line 208 without appending, so the warning naming why the carry failed (and any freshBase fetch warning) is dropped. Failure scenario: fetch fails and the lease has no origin ref either; the 502 reports only the fallback checkout&#39;s git error, not that the fetch failed first. Append the same warnings there too.

🔧 Fix: scope pooled base ref per card; carry warnings on every throw
1 info still open:
- ℹ️ `server/worktrees.js:156` - `refs/remotes/bc-base/&lt;card&gt;` is created in the pool clone and never deleted, so the shared clone accumulates one permanent ref per card ever started on that machine, each pinning its base commit against gc. Failure scenario: a long-lived pool clone belonging to another workspace slowly collects hundreds of bc-base refs that nothing ever cleans up — the same &#39;not ours to litter&#39; concern that motivated avoiding refs/remotes/origin/*. Cheap fix: in releaseWorktree, after the dangling probe passes and before returning the lease, `git update-ref -d refs/remotes/bc-base/&lt;slug&gt;` (the slug can be derived from rec, or recorded on the worktree record alongside baseSha). Order matters — the probe must run first, since that ref is what makes HEAD reachable.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node --test --test-concurrency=1 test/workers.test.js` (36/36 pass, incl. the three new MNC-111 tests)</code>
- <code>`node --test --test-concurrency=1 test/*.test.js harness/test/*.test.js` — full CI suite, 1039 pass / 0 fail</code>
- <code>Regression proof: `git show 30cc01f:server/worktrees.js &gt; server/worktrees.js` then `node --test --test-name-pattern=&#34;pooled worktree lands&#34; test/workers.test.js` → fails on the pool clone&#39;s stale sha; file restored, worktree clean</code>
- <code>Manual end-to-end: booted `server/server.js` on a temp workspace with a fake `treehouse` on PATH whose pool worktrees are cut from a second stale clone; `POST /api/cards/&lt;id&gt;/start` for a pooled start, a broken-origin start, and a start whose by-path base carry is blocked (`git config uploadpack.hideRefs refs/remotes/origin`)</code>
- <code>Verified in the leased worktree: `git rev-parse HEAD` == origin tip, `git rev-parse --git-common-dir` == the OTHER clone, `git rev-parse refs/remotes/bc-base/&lt;card&gt;`</code>
- <code>Agent-facing CLI: `bc-axi card create`, `bc-axi card start ADA-1 --harness fake` (HTTP 502 naming both shas), `bc-axi card show` (L1 stale-base line)</code>
- `Visual: opened the board UI in Chrome, expanded the card detail and screenshotted the 🧊 stale-base event in the card timeline`

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed ✅</summary>

- ℹ️ `dev/ui-server.js:52` - dev/ui-server.js hand-copies server.js BUILTIN_KINDS (comment: &#34;copied, not imported&#34;) and has drifted: it is missing schedule, ci-failed, schedule-failed, line — and now stale-base. It is a code file, so a docs pass must not edit it, and the drift predates this change. Follow-up worth doing separately: generate the dev harness map from the server&#39;s (or have test/kinds.test.js assert the dev copy matches) so the fifth divergence is the last one.

🔧 Fix: add stale-base kind to dev playground kinds map
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
