### PR TITLE
DOCTRINE: retire the writing-great-skills example (MNC-120)

### DIFF
--- a/DOCTRINE.md
+++ b/DOCTRINE.md
@@ -137,7 +137,8 @@ when the field was still called `brief`, which nothing backfills — have none: 
 `card patch --playbook <id>` when you get to them.
 
 A playbook orders only what a worker can run: the Skill tool refuses a `disable-model-invocation`
-skill to an agent — `writing-great-skills` is one — so that step is yours, at handoff.
+skill to an agent — `retro` is one — so that step is yours, at handoff. A skill without that flag
+(`writing-for-agents`, say) a worker loads for itself, so a playbook may order it.
 
 ## Starting work
 


### PR DESCRIPTION
Matt Pocock renamed the skill to `writing-for-agents`, and the rename changed the fact the doctrine was leaning on: the new frontmatter has no `disable-model-invocation`, so a worker *can* load it — the opposite of what the sentence claimed.

Swapped in `retro`, which still carries the flag, and kept `writing-for-agents` as the counter-example so the rule reads in both directions. `grep -rn writing-great-skills` over the repo now returns nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)